### PR TITLE
fix: perf issue, do not load proto on each search() call

### DIFF
--- a/milvus/Data.ts
+++ b/milvus/Data.ts
@@ -1,4 +1,4 @@
-import protobuf from 'protobufjs';
+import protobuf, { Root } from 'protobufjs';
 import { promisify } from '../utils';
 import { Client } from './Client';
 import { Collection } from './Collection';
@@ -49,10 +49,14 @@ export class Data extends Client {
   vectorTypes: number[];
   collectionManager: Collection;
 
+  private readonly _protoRoot: Root;
+
   constructor(client: any, collectionManager: Collection) {
     super(client);
     this.vectorTypes = [DataType.BinaryVector, DataType.FloatVector];
     this.collectionManager = collectionManager;
+
+    this._protoRoot = protobuf.loadSync(protoPath)
   }
 
   /**
@@ -302,7 +306,6 @@ export class Data extends Client {
    * ```
    */
   async search(data: SearchReq): Promise<SearchResults> {
-    const root = await protobuf.load(protoPath);
     this.checkCollectionName(data);
     if (
       !data.search_params ||
@@ -348,7 +351,7 @@ export class Data extends Client {
     }
 
     // when data type is bytes , we need use protobufjs to transform data to buffer bytes.
-    const PlaceholderGroup = root.lookupType(
+    const PlaceholderGroup = this._protoRoot.lookupType(
       'milvus.proto.common.PlaceholderGroup'
     );
     // tag $0 is hard code in milvus, when dsltype is expr


### PR DESCRIPTION
### Issue
I wanted to use this client for a project, but the problem is it's **extremely slow** because it loads proto on each `search()` call which takes around 40ms just to load proto.

Here's a benchmark, it's a simple nodejs server that uses milvus client to search:
```js
const http = require('http');
const { query } = require('./db-client');

const server = http.createServer();

function vector(dim) {
  const arr = new Array(dim);
  for (let i = 0; i < dim; i++) {
    arr[i] = Math.random();
  }
  return arr;
}

const vectors = {};

for (let dims = 128; dims <= 2048; dims += 128) {
  vectors[dims] = vector(dims);
}

server.on('request', (request, res) => {
  const dims = +request.url.slice(1);
  
  query('milvus', `random_${dims}`, vectors[dims]).then((d) => {
     return res.end('Ok.');
  }).catch((e) => {
    console.log(e);
    res.writeHead(500);
    return res.end('Bad.')
  });
});

server.listen(8000);

```

![image](https://user-images.githubusercontent.com/9841409/208300732-62fe4a93-84f4-4a9a-bdc9-9fe48baad7e2.png)

### Dataset
id as varchar 24, and float vector with 128 dimensions, 500K vectors.

### Env:
CPU AMD Ryzen 3900X
32GB ram DDR4
SSD 512GB WD black PCIe 4.0 m2

### Results
I think it's speaks for itself :)
![image](https://user-images.githubusercontent.com/9841409/208300721-e96780fb-a5a1-4bbf-85d9-5054d056d914.png)

