### PR TITLE
no more type_params and support dim/max_length as number 

### DIFF
--- a/milvus/Collection.ts
+++ b/milvus/Collection.ts
@@ -38,6 +38,7 @@ import {
   StatisticsResponse,
   ReplicasResponse,
 } from '.';
+import { assignTypeParams } from '../utils';
 
 /**
  * @see [collection operation examples](https://github.com/milvus-io/milvus-sdk-node/blob/main/example/Collection.ts)
@@ -112,7 +113,10 @@ export class Collection extends BaseClient {
       description: description || '',
       fields: [],
     };
+
     data.fields.forEach(field => {
+      field = assignTypeParams(field);
+
       const value = {
         ...field,
         typeParams: parseToKeyValue(field.type_params),
@@ -125,7 +129,7 @@ export class Collection extends BaseClient {
     });
 
     const collectionParams = CollectionSchema.create(payload);
-    const schemaBtyes = CollectionSchema.encode(collectionParams).finish();
+    const schemaBytes = CollectionSchema.encode(collectionParams).finish();
     const level = Object.keys(ConsistencyLevelEnum).includes(consistency_level)
       ? ConsistencyLevelEnum[consistency_level]
       : ConsistencyLevelEnum['Bounded'];
@@ -134,7 +138,7 @@ export class Collection extends BaseClient {
       'CreateCollection',
       {
         ...data,
-        schema: schemaBtyes,
+        schema: schemaBytes,
         consistency_level: level,
       },
       data.timeout

--- a/milvus/types/Collection.ts
+++ b/milvus/types/Collection.ts
@@ -52,11 +52,11 @@ export interface FieldType {
   data_type?: DataType;
   is_primary_key?: boolean;
   type_params?: {
-    [key in TypeParamKey]?: TypeParam;
+    [key: string]: TypeParam;
   };
+  autoID?: boolean;
   dim?: TypeParam;
   max_length?: TypeParam;
-  autoID?: boolean;
 }
 
 export enum ShowCollectionsType {

--- a/milvus/types/Collection.ts
+++ b/milvus/types/Collection.ts
@@ -43,15 +43,19 @@ export interface ReplicaInfo {
   node_ids: number[];
 }
 
+export type TypeParam = string | number;
+export type TypeParamKey = 'dim' | 'max_length';
+
 export interface FieldType {
   name: string;
-  description: string;
+  description?: string;
   data_type?: DataType;
   is_primary_key?: boolean;
   type_params?: {
-    dim?: string;
-    max_length?: string;
+    [key in TypeParamKey]?: TypeParam;
   };
+  dim?: TypeParam;
+  max_length?: TypeParam;
   autoID?: boolean;
 }
 

--- a/test/Collection.spec.ts
+++ b/test/Collection.spec.ts
@@ -15,6 +15,7 @@ import { timeoutTest } from './common/timeout';
 
 const milvusClient = new MilvusClient(IP);
 const COLLECTION_NAME = GENERATE_NAME();
+const NUMBER_DIM_COLLECTION_NAME = GENERATE_NAME();
 const NEW_COLLECTION_NAME = GENERATE_NAME();
 const TEST_CONSISTENCY_LEVEL_COLLECTION_NAME = GENERATE_NAME();
 const LOAD_COLLECTION_NAME = GENERATE_NAME();
@@ -25,6 +26,14 @@ describe(`Collection API`, () => {
   it(`Create Collection Successful`, async () => {
     const res = await milvusClient.createCollection({
       ...genCollectionParams(COLLECTION_NAME, '128'),
+      consistency_level: 'Eventually',
+    });
+    expect(res.error_code).toEqual(ErrorCode.SUCCESS);
+  });
+
+  it(`Create Collection with number dim Successful`, async () => {
+    const res = await milvusClient.createCollection({
+      ...genCollectionParams(NUMBER_DIM_COLLECTION_NAME, 128),
       consistency_level: 'Eventually',
     });
     expect(res.error_code).toEqual(ErrorCode.SUCCESS);
@@ -484,11 +493,15 @@ describe(`Collection API`, () => {
     const res5 = await milvusClient.dropCollection({
       collection_name: 'any',
     });
+    const res6 = await milvusClient.dropCollection({
+      collection_name: NUMBER_DIM_COLLECTION_NAME,
+    });
 
     expect(res.error_code).toEqual(ErrorCode.SUCCESS);
     expect(res2.error_code).toEqual(ErrorCode.SUCCESS);
     expect(res3.error_code).toEqual(ErrorCode.SUCCESS);
     expect(res4.error_code).toEqual(ErrorCode.SUCCESS);
     expect(res5.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(res6.error_code).toEqual(ErrorCode.SUCCESS);
   });
 });

--- a/test/Utils.spec.ts
+++ b/test/Utils.spec.ts
@@ -12,6 +12,7 @@ import {
   getGRPCService,
   getAuthInterceptor,
   checkTimeParam,
+  assignTypeParams,
 } from '../utils';
 import { ERROR_REASONS } from '../milvus';
 import { InterceptingCall } from '@grpc/grpc-js';
@@ -234,5 +235,56 @@ describe(`Utils`, () => {
       'authorization',
       'dGVzdHVzZXI6dGVzdHBhc3N3b3Jk'
     );
+  });
+  it('should assign properties with keys `dim` or `max_length` to the `type_params` object and delete them from the `field` object', () => {
+    const field = {
+      name: 'vector',
+      type: 'BinaryVector',
+      dim: 128,
+      max_length: 100,
+    };
+    const expectedOutput = {
+      name: 'vector',
+      type: 'BinaryVector',
+      type_params: {
+        dim: '128',
+        max_length: '100',
+      },
+    };
+    expect(assignTypeParams(field)).toEqual(expectedOutput);
+  });
+
+  it('should not modify the `field` object if it does not have properties with keys `dim` or `max_length`', () => {
+    const field = {
+      name: 'id',
+      type: 'Int64',
+    };
+    const expectedOutput = {
+      name: 'id',
+      type: 'Int64',
+    };
+    expect(assignTypeParams(field)).toEqual(expectedOutput);
+  });
+
+  it('should convert properties with keys `dim` or `max_length` to strings if they already exist in the `type_params` object', () => {
+    const field = {
+      name: 'text',
+      type: 'String',
+      type_params: {
+        dim: 100,
+        max_length: 50,
+      },
+      dim: 200,
+      max_length: 75,
+    };
+    const expectedOutput = {
+      name: 'text',
+      type: 'String',
+      type_params: {
+        dim: '200',
+        max_length: '75',
+      },
+    };
+    expect(assignTypeParams(field)).toEqual(expectedOutput);
   });
 });

--- a/utils/Format.ts
+++ b/utils/Format.ts
@@ -33,9 +33,9 @@ export const parseToKeyValue = (data?: {
 }): KeyValuePair[] => {
   return data
     ? Object.keys(data).reduce(
-      (pre: any[], cur: string) => [...pre, { key: cur, value: data[cur] }],
-      []
-    )
+        (pre: any[], cur: string) => [...pre, { key: cur, value: data[cur] }],
+        []
+      )
     : [];
 };
 
@@ -193,21 +193,24 @@ export const formatAddress = (address: string) => {
  * @param field The `FieldType` object to modify.
  * @returns The modified `FieldType` object.
  */
-export const assignTypeParams = (field: FieldType) => {
-  const typeParamKeys: TypeParamKey[] = ['dim', 'max_length'];
+export const assignTypeParams = (
+  field: FieldType,
+  typeParamKeys: TypeParamKey[]
+) => {
+  let newField = JSON.parse(JSON.stringify(field));
   typeParamKeys.forEach(key => {
-    if (field.hasOwnProperty(key)) {
+    if (newField.hasOwnProperty(key)) {
       // if the property exists in the field object, assign it to the type_params object
-      field.type_params = field.type_params || {};
-      field.type_params[key] = String(field[key]);
+      newField.type_params = newField.type_params || {};
+      newField.type_params[key] = String(newField[key]);
       // delete the property from the field object
-      delete field[key];
+      delete newField[key];
     }
 
-    if (field.type_params && field.type_params[key]) {
+    if (newField.type_params && newField.type_params[key]) {
       // if the property already exists in the type_params object, convert it to a string
-      field.type_params[key] = String(field.type_params[key]);
+      newField.type_params[key] = String(newField.type_params[key]);
     }
   });
-  return field;
+  return newField;
 };

--- a/utils/Format.ts
+++ b/utils/Format.ts
@@ -195,7 +195,7 @@ export const formatAddress = (address: string) => {
  */
 export const assignTypeParams = (
   field: FieldType,
-  typeParamKeys: TypeParamKey[] = ['dim', 'max_length']
+  typeParamKeys: string[] = ['dim', 'max_length']
 ) => {
   let newField = JSON.parse(JSON.stringify(field));
   typeParamKeys.forEach(key => {

--- a/utils/Format.ts
+++ b/utils/Format.ts
@@ -195,7 +195,7 @@ export const formatAddress = (address: string) => {
  */
 export const assignTypeParams = (
   field: FieldType,
-  typeParamKeys: TypeParamKey[]
+  typeParamKeys: TypeParamKey[] = ['dim', 'max_length']
 ) => {
   let newField = JSON.parse(JSON.stringify(field));
   typeParamKeys.forEach(key => {

--- a/utils/test.ts
+++ b/utils/test.ts
@@ -4,7 +4,7 @@ export const VECTOR_FIELD_NAME = 'vector_field';
 export const INDEX_NAME = 'index_name';
 export const genCollectionParams = (
   collectionName: string,
-  dim: string,
+  dim: string | number,
   vectorType:
     | DataType.FloatVector
     | DataType.BinaryVector = DataType.FloatVector,


### PR DESCRIPTION
User should be able to create a collection like
```
new milvusClient(MILUVS_ADDRESS).createCollection({
  collection_name: "my_collection",
  fields: [
    {
      name: "vector_01",
      description: "vector field",
      data_type: DataType.FloatVector,
      dim: 8
    },
    {
      name: "age",
      data_type: DataType.VarChar,
      autoID: true,
      is_primary_key: true,
      description: "",
      max_length: 256
    },
  ],
});
```

no more `type_params` and support number type for 'dim' and 'max_length' 