### PR TITLE
Support create client by a config object

### DIFF
--- a/milvus/BaseClient.ts
+++ b/milvus/BaseClient.ts
@@ -18,26 +18,6 @@ export class BaseClient {
   grpcClient: Client;
 
   /**
-   * Connect to a Milvus gRPC client using one config object
-   *
-   * @param config The configuration object.
-   */
-  constructor(config: MilvusClientConfig);
-  /**
-   * Connect to a Milvus gRPC client.
-   *
-   * @param address The Milvus address as a string.
-   * @param ssl Whether to use SSL or not. Default is false.
-   * @param username The username for authentication. Required if password is provided.
-   * @param password The password for authentication. Required if username is provided.
-   */
-  constructor(
-    address: string,
-    ssl?: boolean,
-    username?: string,
-    password?: string
-  );
-  /**
    * Connect to a Milvus gRPC client.
    *
    * @param configOrAddress The configuration object or the Milvus address as a string.

--- a/milvus/index.ts
+++ b/milvus/index.ts
@@ -10,5 +10,6 @@ export * from './types/Partition';
 export * from './types/Response';
 export * from './types/User';
 export * from './types/Resource';
+export * from './types/Client';
 // client
 export * from './MilvusClient';

--- a/milvus/types.ts
+++ b/milvus/types.ts
@@ -13,3 +13,5 @@ export * from './types/Response';
 export * from './types/User';
 
 export * from './types/Resource';
+
+export * from './types/Client';

--- a/milvus/types/Client.ts
+++ b/milvus/types/Client.ts
@@ -1,0 +1,6 @@
+export interface MilvusClientConfig {
+  address: string;
+  ssl?: boolean;
+  username?: string;
+  password?: string;
+}

--- a/test/Alias.spec.ts
+++ b/test/Alias.spec.ts
@@ -2,7 +2,7 @@ import { MilvusClient, ERROR_REASONS, ErrorCode } from '../milvus';
 import { IP } from '../const';
 import { genCollectionParams, GENERATE_NAME } from '../utils/test';
 
-let milvusClient = new MilvusClient(IP);
+let milvusClient = new MilvusClient({ address: IP });
 const COLLECTION_NAME = GENERATE_NAME();
 const COLLECTION_ALIAS = GENERATE_NAME('alias');
 

--- a/test/BinarySearch.spec.ts
+++ b/test/BinarySearch.spec.ts
@@ -7,7 +7,7 @@ import {
   generateInsertData,
 } from '../utils/test';
 
-let milvusClient = new MilvusClient(IP);
+let milvusClient = new MilvusClient({ address: IP });
 const COLLECTION_NAME = GENERATE_NAME();
 
 describe(`Bianary search API`, () => {

--- a/test/Collection.spec.ts
+++ b/test/Collection.spec.ts
@@ -14,7 +14,7 @@ import {
 } from '../utils/test';
 import { timeoutTest } from './common/timeout';
 
-const milvusClient = new MilvusClient(IP);
+const milvusClient = new MilvusClient({ address: IP });
 const COLLECTION_NAME = GENERATE_NAME();
 const NUMBER_DIM_COLLECTION_NAME = GENERATE_NAME();
 const NEW_COLLECTION_NAME = GENERATE_NAME();

--- a/test/Data.spec.ts
+++ b/test/Data.spec.ts
@@ -14,7 +14,7 @@ import {
 } from '../utils/test';
 import { timeoutTest } from './common/timeout';
 
-let milvusClient = new MilvusClient(IP);
+const milvusClient = new MilvusClient({ address: IP });
 const COLLECTION_NAME = GENERATE_NAME();
 const fields = [
   {

--- a/test/Import.spec.ts
+++ b/test/Import.spec.ts
@@ -7,7 +7,7 @@ import {
   GENERATE_NAME,
 } from '../utils/test';
 
-let milvusClient = new MilvusClient(IP);
+const milvusClient = new MilvusClient({ address: IP });
 const COLLECTION_NAME = GENERATE_NAME();
 
 describe(`Import API`, () => {

--- a/test/Index.spec.ts
+++ b/test/Index.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '../utils/test';
 import { timeoutTest } from './common/timeout';
 
-let milvusClient = new MilvusClient(IP);
+const milvusClient = new MilvusClient({ address: IP });
 // names
 const COLLECTION_NAME = GENERATE_NAME();
 const COLLECTION_NAME_WITHOUT_INDEX_NAME = GENERATE_NAME();

--- a/test/Insert.spec.ts
+++ b/test/Insert.spec.ts
@@ -13,7 +13,7 @@ import {
   GENERATE_NAME,
 } from '../utils/test';
 
-let milvusClient = new MilvusClient(IP);
+const milvusClient = new MilvusClient({ address: IP });
 const COLLECTION_NAME = GENERATE_NAME();
 const BINARY_COLLECTION_NAME = GENERATE_NAME();
 const COLLECTION_NAME_AUTO_ID = GENERATE_NAME();

--- a/test/MilvusClient.spec.ts
+++ b/test/MilvusClient.spec.ts
@@ -10,12 +10,12 @@ describe(`Milvus client`, () => {
   });
 
   test(`should create a grpc client without SSL credentials when ssl is false`, () => {
-    const client = new MilvusClient(
-      'localhost:19530',
-      false,
-      'username',
-      'password'
-    );
+    const client = new MilvusClient({
+      address: 'localhost:19530',
+      ssl: false,
+      username: 'username',
+      password: 'password',
+    });
     expect(client.grpcClient).toBeDefined();
   });
 

--- a/test/Partition.spec.ts
+++ b/test/Partition.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '../utils/test';
 import { timeoutTest } from './common/timeout';
 
-const milvusClient = new MilvusClient(IP);
+const milvusClient = new MilvusClient({ address: IP });
 const COLLECTION_NAME = GENERATE_NAME();
 const PARTITION_NAME = GENERATE_NAME('partition');
 

--- a/test/Replica.spec.ts
+++ b/test/Replica.spec.ts
@@ -6,7 +6,7 @@ import {
   GENERATE_NAME,
 } from '../utils/test';
 
-let milvusClient = new MilvusClient(IP);
+const milvusClient = new MilvusClient({ address: IP });
 const COLLECTION_NAME = GENERATE_NAME();
 
 describe(`Replica API`, () => {

--- a/test/Resource.spec.ts
+++ b/test/Resource.spec.ts
@@ -6,7 +6,7 @@ import {
   GENERATE_NAME,
 } from '../utils/test';
 
-let milvusClient = new MilvusClient(IP);
+const milvusClient = new MilvusClient({ address: IP });
 
 const DEFAULT_RESOURCE_GROUP = '__default_resource_group';
 const COLLECTION_NAME = GENERATE_NAME('col');

--- a/test/User.spec.ts
+++ b/test/User.spec.ts
@@ -12,7 +12,7 @@ import { timeoutTest } from './common/timeout';
 
 import { genCollectionParams, GENERATE_NAME } from '../utils/test';
 
-let milvusClient = new MilvusClient(IP);
+const milvusClient = new MilvusClient({ address: IP });
 let authClient: MilvusClient;
 const USERNAME = 'nameczz';
 const PASSWORD = '123456';
@@ -66,7 +66,12 @@ describe(`User Api`, () => {
   });
 
   it(`Auth client list user expect success`, async () => {
-    authClient = new MilvusClient(IP, false, USERNAME, PASSWORD);
+    authClient = new MilvusClient({
+      address: IP,
+      ssl: false,
+      username: USERNAME,
+      password: PASSWORD,
+    });
     const res = await authClient.listUsers();
     expect(res.usernames).toEqual([USERNAME, 'root']);
   });
@@ -102,7 +107,12 @@ describe(`User Api`, () => {
   });
 
   it(`It should create role successfully`, async () => {
-    authClient = new MilvusClient(IP, false, USERNAME, NEW_PASSWORD);
+    authClient = new MilvusClient({
+      address: IP,
+      ssl: false,
+      username: USERNAME,
+      password: NEW_PASSWORD,
+    });
     const res = await authClient.createRole({
       roleName: ROLENAME,
     });


### PR DESCRIPTION
We should support this, it's easier to extend. 
```javascript
const client = new MilvusClient({
      address: 'localhost:19530',
      ssl: false,
      username: 'username',
      password: 'password',
    });
```