### PR TITLE
feat: generate expr by pk type when delete entities by ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ api
 coverage
 .DS_Store
 yarn-error.log
+.idea

--- a/milvus/grpc/Collection.ts
+++ b/milvus/grpc/Collection.ts
@@ -43,7 +43,7 @@ import {
   formatCollectionSchema,
   formatDescribedCol,
   validatePartitionNumbers,
-  METADATA,
+  METADATA, DataTypeMap, DataType,
 } from '../';
 
 /**
@@ -172,7 +172,7 @@ export class Collection extends Database {
  *  | :-- | :-- | :-- |
  *  | collection_name | String | Collection name |
  *  | timeout? | number | An optional duration of time in millisecond to allow for the RPC. If it is set to undefined, the client keeps waiting until the server responds or error occurs. Default is undefined |
- * 
+ *
  * @returns
  *  | Property | Description |
  *  | :-- | :-- |
@@ -984,5 +984,49 @@ export class Collection extends Database {
     }
 
     return pkField;
+  }
+
+  /**
+   * Get the primary key field type
+   *
+   * @param data
+   *  | Property | Type | Description |
+   *  | :-- | :-- | :-- |
+   *  | collection_name | string | the name of the collection |
+   *  | timeout? | number | An optional duration of time in milliseconds to allow for the RPC. If it is set to undefined, the client keeps waiting until the server responds or an error occurs. Default is undefined |
+   *
+   * @returns
+   *  | Property | Description |
+   *  | :-- | :-- |
+   *  | pkFieldType | the primary key field type |
+   *
+   * @throws {Error} if `collection_name` property is not present in `data`
+   *
+   * #### Example
+   *
+   * ```
+   *  new milvusClient(MILUVS_ADDRESS).getPkFieldType({
+   *    collection_name: 'my_collection',
+   *  });
+   * ```
+   */
+  async getPkFieldType(data: DescribeCollectionReq): Promise<keyof typeof DataType> {
+    // get collection info
+    const collectionInfo = await this.describeCollection(data);
+
+    // pk field type
+    let pkFieldType: keyof typeof DataType = 'None';
+    // extract key information
+    for (let i = 0; i < collectionInfo.schema.fields.length; i++) {
+      const f = collectionInfo.schema.fields[i];
+
+      // get pk field type info
+      if (f.is_primary_key) {
+        pkFieldType = f.data_type;
+        break;
+      }
+    }
+
+    return pkFieldType;
   }
 }

--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -103,7 +103,7 @@ export class Data extends Collection {
    *      scalar_field: 1
    *    }]
    *  });
-   * ``` 
+   * ```
    */
   private async _insert(
     data: InsertReq,
@@ -332,10 +332,11 @@ export class Data extends Collection {
     }
 
     const pkField = await this.getPkFieldName(data);
+    const pkFieldType = await this.getPkFieldType(data);
 
-    // generate expr by different type of ids
+    // generate expr by different type of pk
     const expr =
-      typeof data.ids[0] === 'string'
+      DataTypeMap[pkFieldType] === DataType.VarChar
         ? `${pkField} in ["${data.ids.join('","')}"]`
         : `${pkField} in [${data.ids.join(',')}]`;
     const req = { ...data, expr };
@@ -809,9 +810,16 @@ export class Data extends Collection {
       throw new Error(ERROR_REASONS.IDS_REQUIRED);
     }
 
-    // build query req
-    const req = { ...data, expr: `${pkField} in [${data.ids.join(',')}]` };
+    const pkFieldType = await this.getPkFieldType(data);
 
+    // generate expr by different type of pk
+    const expr =
+      DataTypeMap[pkFieldType] === DataType.VarChar
+        ? `${pkField} in ["${data.ids.join('","')}"]`
+        : `${pkField} in [${data.ids.join(',')}]`;
+
+    // build query req
+    const req = { ...data, expr };
     return this.query(req);
   }
 


### PR DESCRIPTION
The id on query and search result always is string type, even if the pk field type is int64.
So, we should generate the expr by the type of pk field when delete data by ids.
<img width="481" alt="image" src="https://github.com/milvus-io/milvus-sdk-node/assets/13033733/54fd7f97-ac10-4f17-9fb9-e5086ebefa18">

example:
`index.ts`
``` ts
import { MilvusClient, InsertReq, DataType } from '@zilliz/milvus2-sdk-node';

const COLLECTION_NAME = 'data_query_example';

(async () => {
  // build client
  const milvusClient = new MilvusClient({
    address: 'localhost:19530',
    username: 'username',
    password: 'Aa12345!!',
  });

  console.log('Node client is initialized.');
  // create collection
  const create = await milvusClient.createCollection({
    collection_name: COLLECTION_NAME,
    fields: [
      {
        name: 'id',
        description: 'ID field',
        data_type: DataType.Int64,
        is_primary_key: true,
      },
      {
        name: 'vector',
        description: 'Vector field',
        data_type: DataType.FloatVector,
        dim: 8,
      },
      { name: 'height', description: 'int64 field', data_type: DataType.Int64 },
      {
        name: 'name',
        description: 'VarChar field',
        data_type: DataType.VarChar,
        max_length: 128,
      },
    ],
  });
  console.log('Create collection is finished.', create);

  // build example data
  const vectorsData = [
    {
      id: 1,
      vector: [
        0.11878310581111173, 0.9694947902934701, 0.16443679307243175,
        0.5484226189097237, 0.9839246709011924, 0.5178387104937776,
        0.8716926129208069, 0.5616972243831446,
      ],
      height: 20405,
      name: 'zlnmh',
    },
    {
      id: 2,
      vector: [
        0.9992090731236536, 0.8248790611809487, 0.8660083940881405,
        0.09946359318481224, 0.6790698063908669, 0.5013786801063624,
        0.795311915725105, 0.9183033261617566,
      ],
      height: 93773,
      name: '5lr9y',
    },
    {
      id: 3,
      vector: [
        0.8761291569818763, 0.07127366044153227, 0.775648976160332,
        0.5619757601304878, 0.6076543120476996, 0.8373907516027586,
        0.8556140171597648, 0.4043893119391049,
      ],
      height: 85122,
      name: 'nes0j',
    }
  ];
  const params: InsertReq = {
    collection_name: COLLECTION_NAME,
    fields_data: vectorsData,
  };
  // insert data into collection
  await milvusClient.insert(params);
  console.log('Data is inserted.');

  // create index
  const createIndex = await milvusClient.createIndex({
    collection_name: COLLECTION_NAME,
    field_name: 'vector',
    metric_type: 'L2',
  });

  console.log('Index is created', createIndex);

  // need load collection before search
  const load = await milvusClient.loadCollectionSync({
    collection_name: COLLECTION_NAME,
  });
  console.log('Collection is loaded.', load);

  // do the query
  console.time('Query time');
  const query = await milvusClient.query({
    collection_name: COLLECTION_NAME,
    filter: 'height > 31400',
    output_fields: ['id', 'height'],
    limit: 100,
  });
  console.timeEnd('Query time');
  console.log('query result', query);

  // get ids for query result
  // and type of id, the id always is string type
  const ids = query.data.map((item: any) => {
    console.log(item, "id type:", typeof item.id);
    return item.id;
  });
  
  // delete data by ids that query result returned
  const deleteRet = await milvusClient.delete({
    collection_name: COLLECTION_NAME,
    ids,
  })
  console.log('delete result', deleteRet);

  // drop collection
  await milvusClient.dropCollection({
    collection_name: COLLECTION_NAME,
  });
})();
```