### PR TITLE
Remove __dirname

### DIFF
--- a/milvus/grpc/BaseClient.ts
+++ b/milvus/grpc/BaseClient.ts
@@ -12,14 +12,8 @@ import {
 } from '../';
 
 // path
-const milvusProtoPath = path.resolve(
-  __dirname,
-  '../../proto/proto/milvus.proto'
-);
-const schemaProtoPath = path.resolve(
-  __dirname,
-  '../../proto/proto/schema.proto'
-);
+const milvusProtoPath = path.resolve('../../proto/proto/milvus.proto');
+const schemaProtoPath = path.resolve('../../proto/proto/schema.proto');
 
 /**
  * Base gRPC client, setup all configuration here
@@ -80,6 +74,8 @@ export class BaseClient {
     channelOptions?: ChannelOptions
   ) {
     let config: ClientConfig;
+
+    console.log(milvusProtoPath);
 
     // If a configuration object is provided, use it. Otherwise, create a new object with the provided parameters.
     if (typeof configOrAddress === 'object') {

--- a/milvus/grpc/BaseClient.ts
+++ b/milvus/grpc/BaseClient.ts
@@ -75,8 +75,6 @@ export class BaseClient {
   ) {
     let config: ClientConfig;
 
-    console.log(milvusProtoPath);
-
     // If a configuration object is provided, use it. Otherwise, create a new object with the provided parameters.
     if (typeof configOrAddress === 'object') {
       config = configOrAddress;


### PR DESCRIPTION
As an npm package, we should avoid using __dirname directly in the code.  We already provided a way to configure the protofile path, but anyway, we should avoid using __dirname in the code. 
