### PR TITLE
add a count function

### DIFF
--- a/milvus/const/defaults.ts
+++ b/milvus/const/defaults.ts
@@ -11,3 +11,4 @@ export const DEFAULT_PARTITIONS_NUMBER = 64;
 export const DEFAULT_RESOURCE_GROUP = '__default_resource_group';
 export const DEFAULT_DB = 'default';
 export const DEFAULT_DYNAMIC_FIELD = '$meta';
+export const DEFAULT_COUNT_QUERY_STRING = 'count(*)';

--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -56,6 +56,9 @@ import {
   Vectors,
   BinaryVectors,
   RowData,
+  CountReq,
+  CountResult,
+  DEFAULT_COUNT_QUERY_STRING,
 } from '../';
 import { Collection } from './Collection';
 
@@ -788,6 +791,18 @@ export class Data extends Collection {
     return {
       status: promise.status,
       data: results,
+    };
+  }
+
+  async count(data: CountReq): Promise<CountResult> {
+    const queryResult = await this.query({
+      collection_name: data.collection_name,
+      output_fields: [DEFAULT_COUNT_QUERY_STRING],
+    });
+
+    return {
+      status: queryResult.status,
+      data: Number(queryResult.data[0][DEFAULT_COUNT_QUERY_STRING]),
     };
   }
 

--- a/milvus/types/Data.ts
+++ b/milvus/types/Data.ts
@@ -69,7 +69,7 @@ export interface FlushReq extends GrpcTimeOut {
   collection_names: string[];
 }
 
-
+export interface CountReq extends collectionNameReq {}
 
 export interface InsertReq extends collectionNameReq {
   partition_name?: string;
@@ -181,6 +181,10 @@ export interface MutationResult extends resStatusResponse {
 
 export interface QueryResults extends resStatusResponse {
   data: { [x: string]: any }[];
+}
+
+export interface CountResult extends resStatusResponse {
+  data: number;
 }
 
 export interface SearchResultData {

--- a/test/Data.spec.ts
+++ b/test/Data.spec.ts
@@ -4,6 +4,7 @@ import {
   ErrorCode,
   ERROR_REASONS,
   DEFAULT_TOPK,
+  DEFAULT_COUNT_QUERY_STRING,
 } from '../milvus';
 import {
   IP,
@@ -450,7 +451,11 @@ describe(`Data.API`, () => {
       output_fields: [queryString],
     });
 
-    expect(res.data.length).toEqual(1);
+    const count = await milvusClient.count({
+      collection_name: COLLECTION_NAME,
+    });
+
+    expect(Number(res.data[0][DEFAULT_COUNT_QUERY_STRING])).toEqual(count.data);
   });
 
   it(`Query with data limit only`, async () => {


### PR DESCRIPTION
In this pr, it will add a count function, the example code looks like this:

```javascript
const count = await milvusClient.count({
    collection_name: COLLECTION_NAME,
});
```

```javascript
{
      status: { error_code: 'Success', reason: '', code: 0 },
      data:  123 // the data count
}

