### PR TITLE
Add client id

### DIFF
--- a/milvus/grpc/BaseClient.ts
+++ b/milvus/grpc/BaseClient.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import crypto from 'crypto';
 import protobuf, { Root, Type } from 'protobufjs';
 import { Client, ChannelOptions } from '@grpc/grpc-js';
 import {
@@ -25,6 +26,8 @@ const schemaProtoPath = path.resolve(
  * Base gRPC client, setup all configuration here
  */
 export class BaseClient {
+  // Client ID
+  clientId: string = `${crypto.randomUUID()}`;
   // flags to indicate that if the connection is established and its state
   connectStatus = CONNECT_STATUS.NOT_CONNECTED;
   connectPromise = Promise.resolve();
@@ -102,6 +105,11 @@ export class BaseClient {
     // make sure these are strings.
     config.username = config.username || '';
     config.password = config.password || '';
+
+    // overwrite ID if necessary
+    if (config.id) {
+      this.clientId = config.id;
+    }
 
     // Assign the configuration object.
     this.config = config;

--- a/milvus/grpc/GrpcClient.ts
+++ b/milvus/grpc/GrpcClient.ts
@@ -48,6 +48,7 @@ export class GRPCClient extends User {
         typeof this.config.retryDelay === 'undefined'
           ? DEFAULT_RETRY_DELAY
           : this.config.retryDelay,
+      clientId: this.clientId,
     });
     // interceptors
     const interceptors = [metaInterceptor, retryInterceptor];

--- a/milvus/types/Client.ts
+++ b/milvus/types/Client.ts
@@ -4,6 +4,7 @@ import { ChannelOptions } from '@grpc/grpc-js';
  * Configuration options for the Milvus client.
  */
 export interface ClientConfig {
+  id?: string;
   // optional proto file paths
   // refer to https://github.com/milvus-io/milvus-proto
   protoFilePath?: {

--- a/milvus/utils/Grpc.ts
+++ b/milvus/utils/Grpc.ts
@@ -93,9 +93,11 @@ export const getMetaInterceptor = (
 export const getRetryInterceptor = ({
   maxRetries = 3,
   retryDelay = 30,
+  clientId = ''
 }: {
   maxRetries: number;
   retryDelay: number;
+  clientId: string;
 }) =>
   function (options: any, nextCall: any) {
     let savedMetadata: any;
@@ -153,7 +155,7 @@ export const getRetryInterceptor = ({
               const _timeout = deadline.getTime() - startTime.getTime();
               // log
               logger.debug(
-                `[DB:${dbname}:${methodName}] executed failed, status: ${JSON.stringify(
+                `[${clientId}>${dbname}>${methodName}] executed failed, status: ${JSON.stringify(
                   status
                 )}, timeout set: ${_timeout}ms, retry after ${_retryDelay} ms.`
               );
@@ -173,7 +175,7 @@ export const getRetryInterceptor = ({
                       }, _retryDelay);
                     } else {
                       logger.debug(
-                        `[DB:${dbname}:${methodName}] retry run out of ${retries} times. ${JSON.stringify(
+                        `[${clientId}>${dbname}>${methodName}] retry run out of ${retries} times. ${JSON.stringify(
                           status
                         )}`
                       );
@@ -185,7 +187,7 @@ export const getRetryInterceptor = ({
                     }
                   } else {
                     logger.debug(
-                      `[DB:${dbname}:${methodName}] retried successfully in ${
+                      `[${clientId}>${dbname}>${methodName}] retried successfully in ${
                         Date.now() - startTime.getTime()
                       }ms.`
                     );
@@ -210,7 +212,7 @@ export const getRetryInterceptor = ({
               case grpcStatus.UNIMPLEMENTED:
                 // const returnMsg = { error_code: 'Success', reason: '' };
                 logger.debug(
-                  `[DB:${dbname}:${methodName}] returns ${JSON.stringify(
+                  `[${clientId}>${dbname}>${methodName}] returns ${JSON.stringify(
                     status
                   )}`
                 );
@@ -223,7 +225,7 @@ export const getRetryInterceptor = ({
               default:
                 // OK
                 logger.debug(
-                  `[DB:${dbname}:${methodName}] executed in ${
+                  `[${clientId}>${dbname}>${methodName}] executed in ${
                     Date.now() - startTime.getTime()
                   }ms, returns ${JSON.stringify(savedReceiveMessage)}`
                 );
@@ -237,7 +239,7 @@ export const getRetryInterceptor = ({
       },
       sendMessage: function (message: any, next: any) {
         logger.debug(
-          `[DB:${dbname}:${methodName}] sending ${JSON.stringify(message)}`
+          `[${clientId}>${dbname}>${methodName}] sending ${JSON.stringify(message)}`
         );
         savedSendMessage = message;
         next(message);

--- a/test/MilvusClient.spec.ts
+++ b/test/MilvusClient.spec.ts
@@ -2,31 +2,35 @@ import { MilvusClient, ERROR_REASONS, CONNECT_STATUS } from '../milvus';
 import sdkInfo from '../sdk.json';
 import { IP } from './tools';
 
-const milvusClient = new MilvusClient({ address: IP });
+const milvusClient = new MilvusClient({
+  address: IP,
+});
 
 describe(`Milvus client`, () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  // it(`should create a grpc client with cert file successfully`, () => {
-  //   const milvusClient = new MilvusClient({
-  //     address: 'localhost:19530',
-  //     tls: {
-  //       rootCertPath: `test/cert/ca.pem`,
-  //       privateKeyPath: `test/cert/client.key`,
-  //       certChainPath: `test/cert/client.pem`,
-  //       serverName: 'localhost',
-  //     },
-  //   });
+  it(`should create a grpc client with cert file successfully`, async () => {
+    const milvusClient = new MilvusClient({
+      address: IP,
+      tls: {
+        rootCertPath: `test/cert/ca.pem`,
+        privateKeyPath: `test/cert/client.key`,
+        certChainPath: `test/cert/client.pem`,
+        serverName: IP,
+      },
+      id: '1',
+    });
 
-  //   expect(milvusClient.client).toBeDefined();
-  //   expect(milvusClient.tlsMode).toEqual(2);
-  // });
+    expect(milvusClient.client).toBeDefined();
+    expect(milvusClient.tlsMode).toEqual(2);
+    expect(milvusClient.clientId).toEqual('1');
+  });
 
   it(`should create a grpc client without SSL credentials when ssl is false`, () => {
     const milvusClient = new MilvusClient({
-      address: 'localhost:19530',
+      address: IP,
       ssl: false,
       username: 'username',
       password: 'password',

--- a/test/MilvusClient.spec.ts
+++ b/test/MilvusClient.spec.ts
@@ -11,22 +11,22 @@ describe(`Milvus client`, () => {
     jest.clearAllMocks();
   });
 
-  it(`should create a grpc client with cert file successfully`, async () => {
-    const milvusClient = new MilvusClient({
-      address: IP,
-      tls: {
-        rootCertPath: `test/cert/ca.pem`,
-        privateKeyPath: `test/cert/client.key`,
-        certChainPath: `test/cert/client.pem`,
-        serverName: IP,
-      },
-      id: '1',
-    });
+  // it(`should create a grpc client with cert file successfully`, async () => {
+  //   const milvusClient = new MilvusClient({
+  //     address: IP,
+  //     tls: {
+  //       rootCertPath: `test/cert/ca.pem`,
+  //       privateKeyPath: `test/cert/client.key`,
+  //       certChainPath: `test/cert/client.pem`,
+  //       serverName: IP,
+  //     },
+  //     id: '1',
+  //   });
 
-    expect(milvusClient.client).toBeDefined();
-    expect(milvusClient.tlsMode).toEqual(2);
-    expect(milvusClient.clientId).toEqual('1');
-  });
+  //   expect(milvusClient.client).toBeDefined();
+  //   expect(milvusClient.tlsMode).toEqual(2);
+  //   expect(milvusClient.clientId).toEqual('1');
+  // });
 
   it(`should create a grpc client without SSL credentials when ssl is false`, () => {
     const milvusClient = new MilvusClient({
@@ -34,8 +34,10 @@ describe(`Milvus client`, () => {
       ssl: false,
       username: 'username',
       password: 'password',
+      id: '1',
     });
 
+    expect(milvusClient.clientId).toEqual('1');
     expect(milvusClient.client).toBeDefined();
   });
 

--- a/test/tools/index.ts
+++ b/test/tools/index.ts
@@ -4,4 +4,4 @@ export * from './const';
 export * from './utils';
 
 // test IP
-export const IP = '127.0.0.1:19530';
+export const IP = '10.102.6.214:19530';

--- a/test/tools/index.ts
+++ b/test/tools/index.ts
@@ -4,4 +4,4 @@ export * from './const';
 export * from './utils';
 
 // test IP
-export const IP = '10.102.6.214:19530';
+export const IP = '127.0.0.1:19530';


### PR DESCRIPTION
In this pr,

it will add a uuid as the client id after client creation, user is able to change it by passing `clientId` in the `clientConfig`, for example: 

```javascript
const milvusClient = new MilvusClient({
  address: IP,
  id: '1',
});
```

and we will also modify the debug log format with the client id: 

```
[2023-10-20T03:45:20.902Z] Milvus-sdk-node debug: [ac19aabc-b7ab-43de-8567-351d3f39245e>default>Connect] executed in 132ms, ...
```