### PR TITLE
Support connection pool

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   testTimeout: 60000,
   // because user will cause other test fail, but we still have user spec
-  coveragePathIgnorePatterns: ['/milvus/User.ts'],
+  coveragePathIgnorePatterns: ['dist'],
   testPathIgnorePatterns: ['cloud.spec.ts', 'serverless.spec.ts'], // add this line
   testEnvironmentOptions: {
     NODE_ENV: 'production',

--- a/milvus/MilvusClient.ts
+++ b/milvus/MilvusClient.ts
@@ -60,8 +60,14 @@ export class MilvusClient extends GRPCClient {
     logger.debug(
       `new client initialized, version: ${MilvusClient.sdkInfo.version} `
     );
-    // connect();
-    this.connect(MilvusClient.sdkInfo.version);
+
+    // If the configOrAddress is a string (i.e., the server's address), or if the configOrAddress object does not have the __SKIP_CONNECT__ property set to true, then establish a connection to the Milvus server using the current SDK version.
+    if (
+      typeof configOrAddress === 'string' ||
+      !(configOrAddress as ClientConfig).__SKIP_CONNECT__
+    ) {
+      this.connect(MilvusClient.sdkInfo.version);
+    }
   }
 
   // High level API: align with pymilvus

--- a/milvus/const/client.ts
+++ b/milvus/const/client.ts
@@ -6,9 +6,10 @@ export enum METADATA {
 
 export enum CONNECT_STATUS {
   NOT_CONNECTED,
-  CONNECTING,
-  CONNECTED,
+  CONNECTING = 0, // GRPC channel state connecting
+  CONNECTED = 1, // GRPC channel state ready
   UNIMPLEMENTED,
+  SHUTDOWN = 5, // GRPC channel state shutdown
 }
 
 export enum TLS_MODE {

--- a/milvus/const/defaults.ts
+++ b/milvus/const/defaults.ts
@@ -16,3 +16,6 @@ export const DEFAULT_DYNAMIC_FIELD = '$meta';
 export const DEFAULT_COUNT_QUERY_STRING = 'count(*)';
 export const DEFAULT_HTTP_TIMEOUT = 60000; // 60s
 export const DEFAULT_HTTP_ENDPOINT_VERSION = 'v1'; // api version, default v1
+
+export const DEFAULT_POOL_MAX = 10; // default max pool client number
+export const DEFAULT_POOL_MIN = 2; // default min pool client number

--- a/milvus/grpc/BaseClient.ts
+++ b/milvus/grpc/BaseClient.ts
@@ -35,36 +35,12 @@ const schemaProtoPath = path.resolve(
 export class BaseClient {
   // channel pool
   public channelPool!: Pool<Client>;
-  // ChannelCredentials object used for authenticating the client on the gRPC channel.
-  protected creds!: ChannelCredentials;
   // Client ID
   public clientId: string = `${crypto.randomUUID()}`;
   // flags to indicate that if the connection is established and its state
   public connectStatus = CONNECT_STATUS.NOT_CONNECTED;
+  // connection promise
   public connectPromise = Promise.resolve();
-  // metadata
-  protected metadata: Map<string, string> = new Map<string, string>();
-  // The path to the Milvus protobuf file.
-  protected protoFilePath = {
-    milvus: milvusProtoPath,
-    schema: schemaProtoPath,
-  };
-  // The protobuf schema.
-  protected schemaProto: Root;
-  // The Milvus protobuf.
-  protected milvusProto: Root;
-  // The milvus collection schema Type
-  protected collectionSchemaType: Type;
-  // The milvus field schema Type
-  protected fieldSchemaType: Type;
-
-  // milvus proto
-  protected readonly protoInternalPath = {
-    serviceName: 'milvus.proto.milvus.MilvusService',
-    collectionSchema: 'milvus.proto.schema.CollectionSchema',
-    fieldSchema: 'milvus.proto.schema.FieldSchema',
-  };
-
   // TLS mode, by default it is disabled
   public readonly tlsMode: TLS_MODE = TLS_MODE.DISABLED;
   // The client configuration.
@@ -77,6 +53,30 @@ export class BaseClient {
   // public client!: Promise<Client>;
   // The timeout for connecting to the Milvus service.
   public timeout: number = DEFAULT_CONNECT_TIMEOUT;
+  // The path to the Milvus protobuf file, user can define it from clientConfig
+  public protoFilePath = {
+    milvus: milvusProtoPath,
+    schema: schemaProtoPath,
+  };
+
+  // ChannelCredentials object used for authenticating the client on the gRPC channel.
+  protected creds!: ChannelCredentials;
+  // global metadata, send each grpc request with it
+  protected metadata: Map<string, string> = new Map<string, string>();
+  // The protobuf schema.
+  protected schemaProto: Root;
+  // The Milvus protobuf.
+  protected milvusProto: Root;
+  // The milvus collection schema Type
+  protected collectionSchemaType: Type;
+  // The milvus field schema Type
+  protected fieldSchemaType: Type;
+  // milvus proto
+  protected readonly protoInternalPath = {
+    serviceName: 'milvus.proto.milvus.MilvusService',
+    collectionSchema: 'milvus.proto.schema.CollectionSchema',
+    fieldSchema: 'milvus.proto.schema.FieldSchema',
+  };
 
   /**
    * Sets up the configuration object for the gRPC client.

--- a/milvus/grpc/Collection.ts
+++ b/milvus/grpc/Collection.ts
@@ -153,7 +153,7 @@ export class Collection extends Database {
 
     // Call the promisify function to create the collection.
     const createPromise = await promisify(
-      this.client,
+      this.channelPool,
       'CreateCollection',
       {
         ...data,
@@ -201,7 +201,7 @@ export class Collection extends Database {
 
     // avoid to call describe collection, because it has cache
     const res = await promisify(
-      this.client,
+      this.channelPool,
       'DescribeCollection',
       data,
       data.timeout || this.timeout
@@ -242,7 +242,7 @@ export class Collection extends Database {
     data?: ShowCollectionsReq
   ): Promise<ShowCollectionsResponse> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'ShowCollections',
       {
         type: data ? data.type : ShowCollectionsType.All,
@@ -290,7 +290,7 @@ export class Collection extends Database {
   async alterCollection(data: AlterCollectionReq): Promise<ResStatus> {
     checkCollectionName(data);
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'AlterCollection',
       {
         collection_name: data.collection_name,
@@ -346,7 +346,7 @@ export class Collection extends Database {
 
     // get new data
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'DescribeCollection',
       data,
       data.timeout || this.timeout
@@ -391,7 +391,7 @@ export class Collection extends Database {
     checkCollectionName(data);
 
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'GetCollectionStatistics',
       data,
       data.timeout || this.timeout
@@ -432,7 +432,7 @@ export class Collection extends Database {
     checkCollectionName(data);
 
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'LoadCollection',
       data,
       data.timeout || this.timeout
@@ -470,7 +470,7 @@ export class Collection extends Database {
     checkCollectionName(data);
 
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'LoadCollection',
       data,
       data.timeout || this.timeout
@@ -529,7 +529,7 @@ export class Collection extends Database {
     checkCollectionName(data);
 
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'ReleaseCollection',
       data,
       data.timeout || this.timeout
@@ -564,7 +564,7 @@ export class Collection extends Database {
    */
   async renameCollection(data: RenameCollectionReq): Promise<ResStatus> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'RenameCollection',
       {
         oldName: data.collection_name,
@@ -602,7 +602,7 @@ export class Collection extends Database {
     checkCollectionName(data);
 
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'DropCollection',
       data,
       data.timeout || this.timeout
@@ -649,7 +649,7 @@ export class Collection extends Database {
       throw new Error(ERROR_REASONS.ALIAS_NAME_IS_REQUIRED);
     }
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'CreateAlias',
       data,
       data.timeout || this.timeout
@@ -688,7 +688,7 @@ export class Collection extends Database {
       throw new Error(ERROR_REASONS.ALIAS_NAME_IS_REQUIRED);
     }
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'DropAlias',
       data,
       data.timeout || this.timeout
@@ -728,7 +728,7 @@ export class Collection extends Database {
       throw new Error(ERROR_REASONS.ALIAS_NAME_IS_REQUIRED);
     }
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'AlterAlias',
       data,
       data.timeout || this.timeout
@@ -763,7 +763,7 @@ export class Collection extends Database {
     checkCollectionName(data);
     const collectionInfo = await this.describeCollection(data);
     const res = await promisify(
-      this.client,
+      this.channelPool,
       'ManualCompaction',
       {
         collectionID: collectionInfo.collectionID,
@@ -803,7 +803,7 @@ export class Collection extends Database {
       throw new Error(ERROR_REASONS.COMPACTION_ID_IS_REQUIRED);
     }
     const res = await promisify(
-      this.client,
+      this.channelPool,
       'GetCompactionState',
       data,
       data.timeout || this.timeout
@@ -841,7 +841,7 @@ export class Collection extends Database {
       throw new Error(ERROR_REASONS.COMPACTION_ID_IS_REQUIRED);
     }
     const res = await promisify(
-      this.client,
+      this.channelPool,
       'GetCompactionStateWithPlans',
       data,
       data.timeout || this.timeout
@@ -894,7 +894,7 @@ export class Collection extends Database {
       throw new Error(ERROR_REASONS.COLLECTION_ID_IS_REQUIRED);
     }
     const res = await promisify(
-      this.client,
+      this.channelPool,
       'GetReplicas',
       data,
       data.timeout || this.timeout
@@ -935,7 +935,7 @@ export class Collection extends Database {
       throw new Error(ERROR_REASONS.COLLECTION_NAME_IS_REQUIRED);
     }
     const res = await promisify(
-      this.client,
+      this.channelPool,
       'GetLoadingProgress',
       data,
       data.timeout || this.timeout
@@ -973,7 +973,7 @@ export class Collection extends Database {
       throw new Error(ERROR_REASONS.COLLECTION_NAME_IS_REQUIRED);
     }
     const res = await promisify(
-      this.client,
+      this.channelPool,
       'GetLoadState',
       data,
       data.timeout || this.timeout

--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -259,7 +259,7 @@ export class Data extends Collection {
     const timeout = typeof data.timeout === 'undefined' ? 0 : data.timeout;
     // execute Insert
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       upsert ? 'Upsert' : 'Insert',
       params,
       timeout
@@ -310,7 +310,7 @@ export class Data extends Collection {
     data.expr = data.filter || data.expr;
 
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'Delete',
       data,
       data.timeout || this.timeout
@@ -487,7 +487,7 @@ export class Data extends Collection {
       ).finish();
 
       const promise: SearchRes = await promisify(
-        this.client,
+        this.channelPool,
         'Search',
         {
           collection_name: data.collection_name,
@@ -627,7 +627,7 @@ export class Data extends Collection {
       throw new Error(ERROR_REASONS.COLLECTION_NAME_IS_REQUIRED);
     }
     const res = await promisify(
-      this.client,
+      this.channelPool,
       'Flush',
       data,
       data.timeout || this.timeout
@@ -669,7 +669,7 @@ export class Data extends Collection {
     }
     // copy flushed collection names
     const res = await promisify(
-      this.client,
+      this.channelPool,
       'Flush',
       data,
       data.timeout || this.timeout
@@ -740,7 +740,7 @@ export class Data extends Collection {
 
     // Execute the query and get the results
     const promise: QueryRes = await promisify(
-      this.client,
+      this.channelPool,
       'Query',
       {
         ...data,
@@ -871,7 +871,7 @@ export class Data extends Collection {
       throw new Error(ERROR_REASONS.GET_METRIC_CHECK_PARAMS);
     }
     const res: GetMetricsResponse = await promisify(
-      this.client,
+      this.channelPool,
       'GetMetrics',
       {
         request: JSON.stringify(data.request),
@@ -914,7 +914,7 @@ export class Data extends Collection {
       throw new Error(ERROR_REASONS.GET_FLUSH_STATE_CHECK_PARAMS);
     }
     const res = await promisify(
-      this.client,
+      this.channelPool,
       'GetFlushState',
       data,
       data.timeout || this.timeout
@@ -954,7 +954,7 @@ export class Data extends Collection {
       throw new Error(ERROR_REASONS.LOAD_BALANCE_CHECK_PARAMS);
     }
     const res = await promisify(
-      this.client,
+      this.channelPool,
       'LoadBalance',
       data,
       data.timeout || this.timeout
@@ -994,7 +994,7 @@ export class Data extends Collection {
       throw new Error(ERROR_REASONS.COLLECTION_NAME_IS_REQUIRED);
     }
     const res = await promisify(
-      this.client,
+      this.channelPool,
       'GetQuerySegmentInfo',
       data,
       data.timeout || this.timeout
@@ -1034,7 +1034,7 @@ export class Data extends Collection {
       throw new Error(ERROR_REASONS.COLLECTION_NAME_IS_REQUIRED);
     }
     const res = await promisify(
-      this.client,
+      this.channelPool,
       'GetPersistentSegmentInfo',
       data,
       data.timeout || this.timeout
@@ -1078,7 +1078,7 @@ export class Data extends Collection {
       throw new Error(ERROR_REASONS.IMPORT_FILE_CHECK);
     }
     const res = await promisify(
-      this.client,
+      this.channelPool,
       'Import',
       {
         ...data,
@@ -1126,7 +1126,7 @@ export class Data extends Collection {
       throw new Error(ERROR_REASONS.COLLECTION_NAME_IS_REQUIRED);
     }
     const res = await promisify(
-      this.client,
+      this.channelPool,
       'ListImportTasks',
       {
         ...data,
@@ -1171,7 +1171,7 @@ export class Data extends Collection {
   //   }
 
   //   const res = await promisify(
-  //     this.client,
+  //     this.channelPool,
   //     'ListIndexedSegment',
   //     data,
   //     data.timeout || this.timeout
@@ -1213,7 +1213,7 @@ export class Data extends Collection {
   //   }
 
   //   const res = await promisify(
-  //     this.client,
+  //     this.channelPool,
   //     'DescribeSegmentIndexData',
   //     data,
   //     data.timeout || this.timeout

--- a/milvus/grpc/Database.ts
+++ b/milvus/grpc/Database.ts
@@ -37,7 +37,7 @@ export class Database extends BaseClient {
     });
 
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'CreateDatabase',
       data,
       data.timeout || this.timeout
@@ -74,7 +74,7 @@ export class Database extends BaseClient {
     });
 
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'ListDatabases',
       {},
       data?.timeout || this.timeout
@@ -110,7 +110,7 @@ export class Database extends BaseClient {
     });
 
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'DropDatabase',
       data,
       data.timeout || this.timeout

--- a/milvus/grpc/GrpcClient.ts
+++ b/milvus/grpc/GrpcClient.ts
@@ -49,6 +49,7 @@ export class GRPCClient extends User {
   ) {
     // setup the configuration
     super(configOrAddress, ssl, username, password, channelOptions);
+    
 
     // Get the gRPC service for Milvus
     const MilvusService = getGRPCService({

--- a/milvus/grpc/GrpcClient.ts
+++ b/milvus/grpc/GrpcClient.ts
@@ -49,7 +49,6 @@ export class GRPCClient extends User {
   ) {
     // setup the configuration
     super(configOrAddress, ssl, username, password, channelOptions);
-    
 
     // Get the gRPC service for Milvus
     const MilvusService = getGRPCService({
@@ -133,9 +132,9 @@ export class GRPCClient extends User {
           });
         },
       },
-      {
-        max: this.config.pool?.max ?? DEFAULT_POOL_MAX, // maximum size of the pool
-        min: this.config.pool?.min ?? DEFAULT_POOL_MIN, // minimum size of the pool
+      this.config.pool ?? {
+        min: DEFAULT_POOL_MIN,
+        max: DEFAULT_POOL_MAX,
       }
     );
   }

--- a/milvus/grpc/GrpcClient.ts
+++ b/milvus/grpc/GrpcClient.ts
@@ -226,9 +226,8 @@ export class GRPCClient extends User {
 
       // update status
       this.connectStatus = CONNECT_STATUS.SHUTDOWN;
-
-      return this.connectStatus;
     }
+    return this.connectStatus;
   }
 
   /**

--- a/milvus/grpc/MilvusIndex.ts
+++ b/milvus/grpc/MilvusIndex.ts
@@ -88,7 +88,7 @@ export class Index extends Data {
 
     // Call the 'CreateIndex' gRPC method and return the result
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'CreateIndex',
       createIndexParams,
       data.timeout || this.timeout
@@ -124,7 +124,7 @@ export class Index extends Data {
   async describeIndex(data: DescribeIndexReq): Promise<DescribeIndexResponse> {
     checkCollectionName(data);
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'DescribeIndex',
       data,
       data.timeout || this.timeout
@@ -160,7 +160,7 @@ export class Index extends Data {
   async getIndexState(data: GetIndexStateReq): Promise<GetIndexStateResponse> {
     checkCollectionName(data);
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'GetIndexState',
       data,
       data.timeout || this.timeout
@@ -201,7 +201,7 @@ export class Index extends Data {
   ): Promise<GetIndexBuildProgressResponse> {
     checkCollectionName(data);
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'GetIndexBuildProgress',
       data,
       data.timeout || this.timeout
@@ -239,7 +239,7 @@ export class Index extends Data {
   async dropIndex(data: DropIndexReq): Promise<ResStatus> {
     checkCollectionName(data);
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'DropIndex',
       data,
       data.timeout || this.timeout

--- a/milvus/grpc/Partition.ts
+++ b/milvus/grpc/Partition.ts
@@ -48,7 +48,7 @@ export class Partition extends Index {
   async createPartition(data: CreatePartitionReq): Promise<ResStatus> {
     checkCollectionAndPartitionName(data);
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'CreatePartition',
       data,
       data.timeout || this.timeout
@@ -85,7 +85,7 @@ export class Partition extends Index {
   async hasPartition(data: HasPartitionReq): Promise<BoolResponse> {
     checkCollectionAndPartitionName(data);
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'HasPartition',
       data,
       data.timeout || this.timeout
@@ -124,7 +124,7 @@ export class Partition extends Index {
   ): Promise<ShowPartitionsResponse> {
     checkCollectionName(data);
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'ShowPartitions',
       data,
       data.timeout || this.timeout
@@ -165,7 +165,7 @@ export class Partition extends Index {
   ): Promise<StatisticsResponse> {
     checkCollectionAndPartitionName(data);
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'GetPartitionStatistics',
       data,
       data.timeout || this.timeout
@@ -207,7 +207,7 @@ export class Partition extends Index {
       throw new Error(ERROR_REASONS.PARTITION_NAMES_IS_REQUIRED);
     }
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'LoadPartitions',
       data,
       data.timeout || this.timeout
@@ -247,7 +247,7 @@ export class Partition extends Index {
       throw new Error(ERROR_REASONS.PARTITION_NAMES_IS_REQUIRED);
     }
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'ReleasePartitions',
       data,
       data.timeout || this.timeout
@@ -290,7 +290,7 @@ export class Partition extends Index {
   async dropPartition(data: DropPartitionReq): Promise<ResStatus> {
     checkCollectionAndPartitionName(data);
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'DropPartition',
       data,
       data.timeout || this.timeout

--- a/milvus/grpc/Resource.ts
+++ b/milvus/grpc/Resource.ts
@@ -39,7 +39,7 @@ export class Resource extends Partition {
    */
   async createResourceGroup(data: CreateResourceGroupReq): Promise<ResStatus> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'CreateResourceGroup',
       data,
       data.timeout || this.timeout
@@ -68,7 +68,7 @@ export class Resource extends Partition {
     data?: GrpcTimeOut
   ): Promise<ListResourceGroupsResponse> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'ListResourceGroups',
       {},
       data?.timeout || this.timeout
@@ -108,7 +108,7 @@ export class Resource extends Partition {
     data: DescribeResourceGroupsReq
   ): Promise<DescribeResourceGroupResponse> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'DescribeResourceGroup',
       data,
       data.timeout || this.timeout
@@ -140,7 +140,7 @@ export class Resource extends Partition {
    */
   async dropResourceGroup(data: DropResourceGroupsReq): Promise<ResStatus> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'DropResourceGroup',
       data,
       data.timeout || this.timeout
@@ -180,7 +180,7 @@ export class Resource extends Partition {
   /* istanbul ignore next */
   async transferReplica(data: TransferReplicaReq): Promise<ResStatus> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'TransferReplica',
       data,
       data.timeout || this.timeout
@@ -218,7 +218,7 @@ export class Resource extends Partition {
   /* istanbul ignore next */
   async transferNode(data: TransferNodeReq): Promise<ResStatus> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'TransferNode',
       data,
       data.timeout || this.timeout

--- a/milvus/grpc/User.ts
+++ b/milvus/grpc/User.ts
@@ -61,7 +61,7 @@ export class User extends Resource {
     }
     const encryptedPassword = stringToBase64(data.password);
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'CreateCredential',
       {
         username: data.username,
@@ -110,7 +110,7 @@ export class User extends Resource {
     const encryptedNewPwd = stringToBase64(data.newPassword);
 
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'UpdateCredential',
       {
         username: data.username,
@@ -150,7 +150,7 @@ export class User extends Resource {
       throw new Error(ERROR_REASONS.USERNAME_IS_REQUIRED);
     }
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'DeleteCredential',
       {
         username: data.username,
@@ -182,7 +182,7 @@ export class User extends Resource {
    */
   async listUsers(data?: ListUsersReq): Promise<ListCredUsersResponse> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'ListCredUsers',
       {},
       data?.timeout || this.timeout
@@ -213,7 +213,7 @@ export class User extends Resource {
    */
   async createRole(data: CreateRoleReq): Promise<ResStatus> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'CreateRole',
       {
         entity: { name: data.roleName },
@@ -246,7 +246,7 @@ export class User extends Resource {
    */
   async dropRole(data: DropRoleReq): Promise<ResStatus> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'DropRole',
       {
         role_name: data.roleName,
@@ -280,7 +280,7 @@ export class User extends Resource {
    */
   async addUserToRole(data: AddUserToRoleReq): Promise<ResStatus> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'OperateUserRole',
       {
         username: data.username,
@@ -316,7 +316,7 @@ export class User extends Resource {
    */
   async removeUserFromRole(data: RemoveUserFromRoleReq): Promise<ResStatus> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'OperateUserRole',
       {
         username: data.username,
@@ -352,7 +352,7 @@ export class User extends Resource {
    */
   async selectRole(data: SelectRoleReq): Promise<SelectRoleResponse> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'SelectRole',
       {
         role: { name: data.roleName },
@@ -386,7 +386,7 @@ export class User extends Resource {
    */
   async listRoles(data?: listRoleReq): Promise<SelectRoleResponse> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'SelectRole',
       {
         include_user_info: data?.includeUserInfo || true,
@@ -420,7 +420,7 @@ export class User extends Resource {
    */
   async selectUser(data: SelectUserReq): Promise<SelectUserResponse> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'SelectUser',
       {
         user: { name: data.username },
@@ -463,7 +463,7 @@ export class User extends Resource {
    */
   async grantRolePrivilege(data: OperateRolePrivilegeReq): Promise<ResStatus> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'OperatePrivilege',
       {
         entity: {
@@ -513,7 +513,7 @@ export class User extends Resource {
    */
   async revokeRolePrivilege(data: OperateRolePrivilegeReq): Promise<ResStatus> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'OperatePrivilege',
       {
         entity: {
@@ -621,7 +621,7 @@ export class User extends Resource {
    */
   async selectGrant(data: SelectGrantReq): Promise<SelectGrantResponse> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'SelectGrant',
       {
         entity: {
@@ -663,7 +663,7 @@ export class User extends Resource {
    */
   async listGrants(data: ListGrantsReq): Promise<SelectGrantResponse> {
     const promise = await promisify(
-      this.client,
+      this.channelPool,
       'SelectGrant',
       {
         entity: {

--- a/milvus/types/Client.ts
+++ b/milvus/types/Client.ts
@@ -1,4 +1,5 @@
 import { ChannelOptions } from '@grpc/grpc-js';
+import { Options } from 'generic-pool';
 
 /**
  * Configuration options for the Milvus client.
@@ -47,11 +48,8 @@ export interface ClientConfig {
     serverName?: string;
   };
 
-  // connection pool
-  pool?: {
-    min: number;
-    max: number;
-  };
+  // generic-pool options: refer to https://github.com/coopernurse/node-pool
+  pool?: Options;
 
   // internal property for debug & test
   __SKIP_CONNECT__?: boolean;

--- a/milvus/types/Client.ts
+++ b/milvus/types/Client.ts
@@ -46,6 +46,12 @@ export interface ClientConfig {
     // server name
     serverName?: string;
   };
+
+  // connection pool
+  pool?: {
+    min: number;
+    max: number;
+  };
 }
 
 export interface ServerInfo {

--- a/milvus/types/Client.ts
+++ b/milvus/types/Client.ts
@@ -52,6 +52,9 @@ export interface ClientConfig {
     min: number;
     max: number;
   };
+
+  // internal property for debug & test
+  __SKIP_CONNECT__?: boolean;
 }
 
 export interface ServerInfo {

--- a/milvus/utils/Function.ts
+++ b/milvus/utils/Function.ts
@@ -1,4 +1,5 @@
 import { KeyValuePair, DataType, ERROR_REASONS } from '../';
+import { Pool } from 'generic-pool';
 
 /**
  * Promisify a function call with optional timeout
@@ -9,7 +10,7 @@ import { KeyValuePair, DataType, ERROR_REASONS } from '../';
  * @returns A Promise that resolves with the result of the target function call
  */
 export async function promisify(
-  pool: any,
+  pool: Pool<any>,
   target: string,
   params: any,
   timeout: number

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@grpc/grpc-js": "1.8.17",
     "@grpc/proto-loader": "0.7.7",
     "dayjs": "^1.11.7",
+    "generic-pool": "^3.9.0",
     "lru-cache": "^9.1.2",
     "protobufjs": "7.2.4",
     "winston": "^3.9.0"

--- a/test/grpc/Collection.spec.ts
+++ b/test/grpc/Collection.spec.ts
@@ -513,7 +513,9 @@ describe(`Collection API`, () => {
       collection_name: LOAD_COLLECTION_NAME,
     });
 
-    expect(Number(formatKeyValueData(describe.properties, [key])[key])).toEqual(value);
+    expect(Number(formatKeyValueData(describe.properties, [key])[key])).toEqual(
+      value
+    );
   });
 
   it(`Create alias success`, async () => {

--- a/test/grpc/MilvusClient.spec.ts
+++ b/test/grpc/MilvusClient.spec.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import {
   MilvusClient,
   ERROR_REASONS,
@@ -10,6 +11,16 @@ import { IP } from '../tools';
 const milvusClient = new MilvusClient({
   address: IP,
 });
+
+// path
+const milvusProtoPath = path.resolve(
+  __dirname,
+  '../../proto/proto/milvus.proto'
+);
+const schemaProtoPath = path.resolve(
+  __dirname,
+  '../../proto/proto/schema.proto'
+);
 
 describe(`Milvus client`, () => {
   afterEach(() => {
@@ -65,6 +76,21 @@ describe(`Milvus client`, () => {
   it(`should create a grpc client with authentication when username and password are provided`, async () => {
     const m5 = new MilvusClient(IP, false, `username`, `password`);
     expect(await m5.client).toBeDefined();
+  });
+
+  it(`should setup protofile path successfully`, async () => {
+    const m6 = new MilvusClient({
+      address: IP,
+      protoFilePath: {
+        milvus: milvusProtoPath,
+        schema: schemaProtoPath,
+      },
+      __SKIP_CONNECT__: true,
+    });
+
+    expect(await m6.client).toBeDefined();
+    expect(m6.protoFilePath.milvus).toEqual(milvusProtoPath);
+    expect(m6.protoFilePath.schema).toEqual(schemaProtoPath);
   });
 
   it(`Should throw MILVUS_ADDRESS_IS_REQUIRED`, async () => {

--- a/test/grpc/MilvusClient.spec.ts
+++ b/test/grpc/MilvusClient.spec.ts
@@ -1,4 +1,9 @@
-import { MilvusClient, ERROR_REASONS, CONNECT_STATUS } from '../../milvus';
+import {
+  MilvusClient,
+  ERROR_REASONS,
+  CONNECT_STATUS,
+  TLS_MODE,
+} from '../../milvus';
 import sdkInfo from '../../sdk.json';
 import { IP } from '../tools';
 
@@ -11,55 +16,55 @@ describe(`Milvus client`, () => {
     jest.clearAllMocks();
   });
 
-  // it(`should create a grpc client with cert file successfully`, async () => {
-  //   const milvusClient = new MilvusClient({
-  //     address: IP,
-  //     tls: {
-  //       rootCertPath: `test/cert/ca.pem`,
-  //       privateKeyPath: `test/cert/client.key`,
-  //       certChainPath: `test/cert/client.pem`,
-  //       serverName: IP,
-  //     },
-  //     id: '1',
-  //   });
-
-  //   expect(milvusClient.client).toBeDefined();
-  //   expect(milvusClient.tlsMode).toEqual(2);
-  //   expect(milvusClient.clientId).toEqual('1');
-  // });
-
-  it(`should create a grpc client without SSL credentials when ssl is false`, () => {
-    const milvusClient = new MilvusClient({
+  it(`should create a grpc client with cert file successfully`, async () => {
+    const m1 = new MilvusClient({
       address: IP,
-      ssl: false,
+      tls: {
+        rootCertPath: `test/cert/ca.pem`,
+        privateKeyPath: `test/cert/client.key`,
+        certChainPath: `test/cert/client.pem`,
+        serverName: IP,
+      },
+      id: '1',
+      __SKIP_CONNECT__: true,
+    });
+
+    expect(await m1.client).toBeDefined();
+    expect(m1.tlsMode).toEqual(TLS_MODE.TWO_WAY);
+    expect(m1.clientId).toEqual('1');
+  });
+
+  it(`should create a grpc client without SSL credentials when ssl is false`, async () => {
+    const m2 = new MilvusClient({
+      address: IP,
+      ssl: true,
       username: 'username',
       password: 'password',
       id: '1',
+      __SKIP_CONNECT__: true,
     });
 
-    expect(milvusClient.clientId).toEqual('1');
-    expect(milvusClient.client).toBeDefined();
+    expect(m2.clientId).toEqual('1');
+    expect(await m2.client).toBeDefined();
+    expect(m2.tlsMode).toEqual(TLS_MODE.ONE_WAY);
   });
 
   it(`should create a grpc client without authentication when username and password are not provided`, () => {
-    const milvusClient = new MilvusClient(IP, false);
-
-    expect(milvusClient.client).toBeDefined();
+    const m3 = new MilvusClient(IP, false);
+    expect(m3.client).toBeDefined();
   });
 
   it(`should have connect promise and connectStatus`, async () => {
-    const milvusClient = new MilvusClient(IP, false);
-    expect(milvusClient.connectPromise).toBeDefined();
+    const m4 = new MilvusClient(IP, false);
+    expect(m4.connectPromise).toBeDefined();
 
-    await milvusClient.connectPromise;
-    expect(milvusClient.connectStatus).not.toEqual(
-      CONNECT_STATUS.NOT_CONNECTED
-    );
+    await m4.connectPromise;
+    expect(m4.connectStatus).not.toEqual(CONNECT_STATUS.NOT_CONNECTED);
   });
 
-  it(`should create a grpc client with authentication when username and password are provided`, () => {
-    const milvusClient = new MilvusClient(IP, false, `username`, `password`);
-    expect(milvusClient.client).toBeDefined();
+  it(`should create a grpc client with authentication when username and password are provided`, async () => {
+    const m5 = new MilvusClient(IP, false, `username`, `password`);
+    expect(await m5.client).toBeDefined();
   });
 
   it(`Should throw MILVUS_ADDRESS_IS_REQUIRED`, async () => {

--- a/test/grpc/MilvusClient.spec.ts
+++ b/test/grpc/MilvusClient.spec.ts
@@ -88,7 +88,10 @@ describe(`Milvus client`, () => {
   });
 
   it(`Expect close connection success`, async () => {
-    const res = milvusClient.closeConnection();
-    expect(res).toEqual(4);
+    expect(milvusClient.channelPool.size).toBeGreaterThan(0);
+
+    const res = await milvusClient.closeConnection();
+    expect(milvusClient.channelPool.size).toBe(0);
+    expect(res).toBe(CONNECT_STATUS.SHUTDOWN);
   });
 });

--- a/test/tools/ip.ts
+++ b/test/tools/ip.ts
@@ -1,3 +1,3 @@
 // test IP
-export const IP = '127.0.0.1:19530';
+export const IP = '10.102.6.107:19530';
 export const ENDPOINT = `http://${IP}`;

--- a/test/tools/ip.ts
+++ b/test/tools/ip.ts
@@ -1,3 +1,3 @@
 // test IP
-export const IP = '10.102.6.107:19530';
+export const IP = '127.0.0.1:19530';
 export const ENDPOINT = `http://${IP}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1472,6 +1472,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+generic-pool@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.9.0.tgz#36f4a678e963f4fdb8707eab050823abc4e8f5e4"
+  integrity sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"


### PR DESCRIPTION
In this pr, according to the https://grpc.io/docs/guides/performance/, I add a connection pool for the node sdk, it will have a breaking change for the `closeConnection` function.  it should close until all channels are cleaned in the pool and return the connect status.  All other methods should be compatible with old version. 

User now is able to set up the pool `min` and `max` in the `ClientConfig` object.  by default it is 10 and 2. 