### PR TITLE
Support return Long for int64 type

### DIFF
--- a/milvus/grpc/GrpcClient.ts
+++ b/milvus/grpc/GrpcClient.ts
@@ -28,6 +28,15 @@ import {
 } from '../';
 import { User } from './User';
 
+// default loader options
+const LOADER_OPTIONS = {
+  keepCase: true, // preserve field names
+  longs: String, // convert int64 fields to strings
+  enums: String, // convert enum fields to strings
+  defaults: true, // populate default values
+  oneofs: true, // populate oneof fields
+};
+
 /**
  * A client for interacting with the Milvus server via gRPC.
  */
@@ -51,10 +60,13 @@ export class GRPCClient extends User {
     super(configOrAddress, ssl, username, password, channelOptions);
 
     // Get the gRPC service for Milvus
-    const MilvusService = getGRPCService({
-      protoPath: this.protoFilePath.milvus,
-      serviceName: this.protoInternalPath.serviceName, // the name of the Milvus service
-    });
+    const MilvusService = getGRPCService(
+      {
+        protoPath: this.protoFilePath.milvus,
+        serviceName: this.protoInternalPath.serviceName, // the name of the Milvus service
+      },
+      { ...LOADER_OPTIONS, ...this.config.loaderOptions }
+    );
 
     // setup auth if necessary
     const auth = getAuthString(this.config);

--- a/milvus/grpc/GrpcClient.ts
+++ b/milvus/grpc/GrpcClient.ts
@@ -29,7 +29,7 @@ import {
 import { User } from './User';
 
 // default loader options
-const LOADER_OPTIONS = {
+export const LOADER_OPTIONS = {
   keepCase: true, // preserve field names
   longs: String, // convert int64 fields to strings
   enums: String, // convert enum fields to strings

--- a/milvus/types/Client.ts
+++ b/milvus/types/Client.ts
@@ -1,4 +1,5 @@
 import { ChannelOptions } from '@grpc/grpc-js';
+import { Options as LoaderOption } from '@grpc/proto-loader';
 import { Options } from 'generic-pool';
 
 /**
@@ -54,6 +55,9 @@ export interface ClientConfig {
 
   // internal property for debug & test
   __SKIP_CONNECT__?: boolean;
+
+  // loader options
+  loaderOptions?: LoaderOption;
 }
 
 export interface ServerInfo {

--- a/milvus/types/Client.ts
+++ b/milvus/types/Client.ts
@@ -56,7 +56,10 @@ export interface ClientConfig {
   // internal property for debug & test
   __SKIP_CONNECT__?: boolean;
 
-  // loader options
+  // loaderOptions : { longs: Function | Number | String },
+  // Function converts int64 to Long.js format
+  // Number converts int64 to number, it will lose precision
+  // String converts int64 to string, it's the default behavior
   loaderOptions?: LoaderOption;
 }
 

--- a/milvus/utils/Grpc.ts
+++ b/milvus/utils/Grpc.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { loadSync } from '@grpc/proto-loader';
+import { loadSync, Options } from '@grpc/proto-loader';
 import {
   loadPackageDefinition,
   ServiceClientConstructor,
@@ -9,14 +9,6 @@ import {
 } from '@grpc/grpc-js';
 import { extractMethodName, isStatusCodeMatched, logger } from '.';
 import { DEFAULT_DB } from '../const';
-
-const PROTO_OPTIONS = {
-  keepCase: true,
-  longs: String,
-  enums: String,
-  defaults: true,
-  oneofs: true,
-};
 
 interface IServiceDetails {
   protoPath: string; // file to your proto file
@@ -29,12 +21,13 @@ interface IServiceDetails {
  * @returns A gRPC service client constructor.
  */
 export const getGRPCService = (
-  proto: IServiceDetails
+  proto: IServiceDetails,
+  options: Options
 ): ServiceClientConstructor => {
   // Resolve the proto file path.
   const PROTO_PATH = path.resolve(__dirname, proto.protoPath);
   // Load the proto file.
-  const packageDefinition = loadSync(PROTO_PATH, PROTO_OPTIONS);
+  const packageDefinition = loadSync(PROTO_PATH, options);
   // Load the gRPC object.
   const grpcObj: GrpcObject = loadPackageDefinition(packageDefinition);
   // Get the service object from the gRPC object.
@@ -93,7 +86,7 @@ export const getMetaInterceptor = (
 export const getRetryInterceptor = ({
   maxRetries = 3,
   retryDelay = 30,
-  clientId = ''
+  clientId = '',
 }: {
   maxRetries: number;
   retryDelay: number;
@@ -239,7 +232,9 @@ export const getRetryInterceptor = ({
       },
       sendMessage: function (message: any, next: any) {
         logger.debug(
-          `[${clientId}>${dbname}>${methodName}] sending ${JSON.stringify(message)}`
+          `[${clientId}>${dbname}>${methodName}] sending ${JSON.stringify(
+            message
+          )}`
         );
         savedSendMessage = message;
         next(message);

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "doc-json": "npx typedoc milvus --json"
   },
   "dependencies": {
-    "@grpc/grpc-js": "1.8.17",
-    "@grpc/proto-loader": "0.7.7",
+    "@grpc/grpc-js": "^1.10.1",
+    "@grpc/proto-loader": "^0.7.10",
     "dayjs": "^1.11.7",
     "generic-pool": "^3.9.0",
     "lru-cache": "^9.1.2",
-    "protobufjs": "7.2.4",
+    "protobufjs": "^7.2.6",
     "winston": "^3.9.0"
   },
   "devDependencies": {
@@ -33,6 +33,7 @@
     "@types/jest": "^29.5.1",
     "@types/node-fetch": "^2.6.8",
     "jest": "^29.5.0",
+    "long": "^5.2.3",
     "node-fetch": "2",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",

--- a/test/grpc/Insert.spec.ts
+++ b/test/grpc/Insert.spec.ts
@@ -15,9 +15,9 @@ import {
 } from '../tools';
 
 const milvusClient = new MilvusClient({ address: IP });
-const bigIntClient = new MilvusClient({
+const longClient = new MilvusClient({
   address: IP,
-  loaderOptions: { longs: BigInt },
+  loaderOptions: { longs: Function },
 });
 
 const COLLECTION_NAME = GENERATE_NAME();
@@ -47,7 +47,7 @@ describe(`Insert API`, () => {
     // create db and use db
     await milvusClient.createDatabase(dbParam);
     await milvusClient.use(dbParam);
-    await bigIntClient.use(dbParam);
+    await longClient.use(dbParam);
     // create collection autoid = false and float_vector
     await milvusClient.createCollection(COLLECTION_NAME_PARAMS);
     // create index before load
@@ -319,14 +319,17 @@ describe(`Insert API`, () => {
     const int64Data = query.data.map(d => d.int64);
     expect(query.status.error_code).toEqual(ErrorCode.SUCCESS);
 
-    const queryInt64 = await bigIntClient.query({
+    const queryInt64 = await longClient.query({
       collection_name: COLLECTION_NAME,
       expr: 'id > 0',
       output_fields: ['json', 'id', 'varChar_array', 'int64'],
     });
 
     const int64Data2 = queryInt64.data.map(d => d.int64);
+    // console.log('int64Data', int64Data);
+    // console.log('int64Data2', int64Data2);
     int64Data.forEach((item, i) => {
+      expect(BigInt(item)).toEqual(BigInt(int64Data2[i]));
       expect(item).toEqual(int64Data2[i].toString());
     });
 

--- a/test/grpc/Insert.spec.ts
+++ b/test/grpc/Insert.spec.ts
@@ -15,6 +15,11 @@ import {
 } from '../tools';
 
 const milvusClient = new MilvusClient({ address: IP });
+const bigIntClient = new MilvusClient({
+  address: IP,
+  loaderOptions: { longs: BigInt },
+});
+
 const COLLECTION_NAME = GENERATE_NAME();
 const BINARY_COLLECTION_NAME = GENERATE_NAME();
 const COLLECTION_NAME_AUTO_ID = GENERATE_NAME();
@@ -42,6 +47,7 @@ describe(`Insert API`, () => {
     // create db and use db
     await milvusClient.createDatabase(dbParam);
     await milvusClient.use(dbParam);
+    await bigIntClient.use(dbParam);
     // create collection autoid = false and float_vector
     await milvusClient.createCollection(COLLECTION_NAME_PARAMS);
     // create index before load
@@ -307,10 +313,22 @@ describe(`Insert API`, () => {
     const query = await milvusClient.query({
       collection_name: COLLECTION_NAME,
       expr: 'id > 0',
-      output_fields: ['json', 'id', 'varChar_array'],
+      output_fields: ['json', 'id', 'varChar_array', 'int64'],
     });
-     // console.log('query', query.data);
+    // console.log('query', query.data);
+    const int64Data = query.data.map(d => d.int64);
     expect(query.status.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const queryInt64 = await bigIntClient.query({
+      collection_name: COLLECTION_NAME,
+      expr: 'id > 0',
+      output_fields: ['json', 'id', 'varChar_array', 'int64'],
+    });
+
+    const int64Data2 = queryInt64.data.map(d => d.int64);
+    int64Data.forEach((item, i) => {
+      expect(item).toEqual(int64Data2[i].toString());
+    });
 
     const search = await milvusClient.search({
       collection_name: COLLECTION_NAME,

--- a/test/tools/data.ts
+++ b/test/tools/data.ts
@@ -5,6 +5,7 @@ import {
   FieldType,
 } from '../../milvus';
 import { MAX_LENGTH, P_KEY_VALUES } from './const';
+import Long from 'long';
 
 interface DataGenerator {
   (param?: {
@@ -133,13 +134,20 @@ export const genArray: DataGenerator = params => {
 
 export const genNone: DataGenerator = () => 'none';
 
+export const genInt64: DataGenerator = () => {
+  // Generate two random 32-bit integers and combine them into a 64-bit integer
+  const low = Math.floor(Math.random() * 0x7fffffff); // 0x7FFFFFFF is the maximum positive 32-bit integer value
+  const high = Math.floor(Math.random() * 0x7fffffff);
+  return Long.fromBits(low, high, true); // true for unsigned
+};
+
 export const dataGenMap: { [key in DataType]: DataGenerator } = {
   [DataType.None]: genNone,
   [DataType.Bool]: genBool,
   [DataType.Int8]: genInt,
   [DataType.Int16]: genInt,
   [DataType.Int32]: genInt,
-  [DataType.Int64]: genInt,
+  [DataType.Int64]: genInt64,
   [DataType.Float]: genFloat,
   [DataType.Double]: genFloat,
   [DataType.VarChar]: genVarChar,

--- a/test/utils/Grpc.spec.ts
+++ b/test/utils/Grpc.spec.ts
@@ -1,6 +1,10 @@
 import path from 'path';
 import { InterceptingCall } from '@grpc/grpc-js';
-import { getGRPCService, getMetaInterceptor } from '../../milvus';
+import {
+  getGRPCService,
+  getMetaInterceptor,
+  LOADER_OPTIONS,
+} from '../../milvus';
 // mock
 jest.mock('@grpc/grpc-js', () => {
   const actual = jest.requireActual(`@grpc/grpc-js`);
@@ -24,7 +28,7 @@ describe(`utils/grpc`, () => {
       protoPath,
       serviceName: `milvus.proto.milvus.MilvusService`,
     };
-    const service = getGRPCService(proto);
+    const service = getGRPCService(proto, LOADER_OPTIONS);
     expect(service).toBeDefined();
   });
 
@@ -34,7 +38,7 @@ describe(`utils/grpc`, () => {
       protoPath,
       serviceName: `milvus.proto.milvus.MilvusService2`,
     };
-    expect(() => getGRPCService(proto)).toThrowError();
+    expect(() => getGRPCService(proto, LOADER_OPTIONS)).toThrowError();
   });
 
   it('should add an authorization header to the metadata of a gRPC call', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,35 +401,23 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@grpc/grpc-js@1.8.17":
-  version "1.8.17"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.8.17.tgz#a3a2f826fc033eae7d2f5ee41e0ab39cee948838"
-  integrity sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==
+"@grpc/grpc-js@^1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.10.1.tgz#be450560c990c08274bc19d514e181ea205ccaa8"
+  integrity sha512-55ONqFytZExfOIjF1RjXPcVmT/jJqFzbbDqxK9jmRV4nxiYWtL9hENSW1Jfx0SdZfrvoqd44YJ/GJTqfRrawSQ==
   dependencies:
-    "@grpc/proto-loader" "^0.7.0"
+    "@grpc/proto-loader" "^0.7.8"
     "@types/node" ">=12.12.47"
 
-"@grpc/proto-loader@0.7.7":
-  version "0.7.7"
-  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.7.tgz#d33677a77eea8407f7c66e2abd97589b60eb4b21"
-  integrity sha512-1TIeXOi8TuSCQprPItwoMymZXxWT0CPxUhkrkeCUH+D8U7QDwQ6b7SUz2MaLuWM2llT+J/TVFLmQI5KtML3BhQ==
+"@grpc/proto-loader@^0.7.10", "@grpc/proto-loader@^0.7.8":
+  version "0.7.10"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.10.tgz#6bf26742b1b54d0a473067743da5d3189d06d720"
+  integrity sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==
   dependencies:
-    "@types/long" "^4.0.1"
     lodash.camelcase "^4.3.0"
-    long "^4.0.0"
-    protobufjs "^7.0.0"
+    long "^5.0.0"
+    protobufjs "^7.2.4"
     yargs "^17.7.2"
-
-"@grpc/proto-loader@^0.7.0":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.3.tgz#75a6f95b51b85c5078ac7394da93850c32d36bb8"
-  integrity sha512-5dAvoZwna2Py3Ef96Ux9jIkp3iZ62TUsV00p3wVBPNX5K178UbNi8Q7gQVqwXT1Yq9RejIGG9G2IPEo93T6RcA==
-  dependencies:
-    "@types/long" "^4.0.1"
-    lodash.camelcase "^4.3.0"
-    long "^4.0.0"
-    protobufjs "^7.0.0"
-    yargs "^16.2.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -874,11 +862,6 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
-"@types/long@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
-  integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
-
 "@types/node-fetch@^2.6.8":
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.8.tgz#9a2993583975849c2e1f360b6ca2f11755b2c504"
@@ -1162,15 +1145,6 @@ cjs-module-lexer@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
-
-cliui@^7.0.2:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
-  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
-  dependencies:
-    string-width "^4.2.0"
-    strip-ansi "^6.0.0"
-    wrap-ansi "^7.0.0"
 
 cliui@^8.0.1:
   version "8.0.1"
@@ -2151,15 +2125,15 @@ logform@^2.3.2, logform@^2.4.0:
     safe-stable-stringify "^2.3.1"
     triple-beam "^1.3.0"
 
-long@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
-  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
-
 long@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/long/-/long-5.2.0.tgz#2696dadf4b4da2ce3f6f6b89186085d94d52fd61"
   integrity sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w==
+
+long@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
+  integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -2422,10 +2396,10 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-protobufjs@7.2.4, protobufjs@^7.0.0:
-  version "7.2.4"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.4.tgz#3fc1ec0cdc89dd91aef9ba6037ba07408485c3ae"
-  integrity sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==
+protobufjs@^7.2.4, protobufjs@^7.2.6:
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.6.tgz#4a0ccd79eb292717aacf07530a07e0ed20278215"
+  integrity sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -2884,28 +2858,10 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yargs-parser@^20.2.2:
-  version "20.2.9"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
-
 yargs-parser@^21.0.1, yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
-
-yargs@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
-  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
-  dependencies:
-    cliui "^7.0.2"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.0"
-    y18n "^5.0.5"
-    yargs-parser "^20.2.2"
 
 yargs@^17.3.1, yargs@^17.7.2:
   version "17.7.2"


### PR DESCRIPTION
In this pr
-  I add a `loaderOptions` in ClientConfig, it controls protobuf.js how to parse int64

The default loader options is 
```javascript
const LOADER_OPTIONS = {
  keepCase: true, // preserve field names
  longs: String, // convert int64 fields to strings
  enums: String, // convert enum fields to strings
  defaults: true, // populate default values
  oneofs: true, // populate oneof fields
};
```

If user want the sdk to return real `int64` data, user can change it to this:
```javascript
const longClient = new MilvusClient({
  address: IP,
  loaderOptions: { longs: Function },
});
```

- I updated the test functions to support int64 verification
- I upgrade grpc packages
- I add the `long.js` package as dev dependency. 

