### PR TITLE
Support more types of sparse vectors

### DIFF
--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -57,8 +57,6 @@ import {
   parseSparseRowsToBytes,
   getSparseDim,
   parseBinaryVectorToBytes,
-  parseFloat16VectorToBytes,
-  Float16Vector,
 } from '../';
 import { Collection } from './Collection';
 
@@ -183,7 +181,7 @@ export class Data extends Collection {
         }
         if (
           DataTypeMap[field.type] === DataType.BinaryVector &&
-          (rowData[name] as VectorTypes).length !== field.dim! / 8
+          (rowData[name] as BinaryVector).length !== field.dim! / 8
         ) {
           throw new Error(ERROR_REASONS.INSERT_CHECK_WRONG_DIM);
         }

--- a/milvus/types/Data.ts
+++ b/milvus/types/Data.ts
@@ -18,7 +18,7 @@ export type FloatVector = number[];
 export type Float16Vector = number[];
 export type BFloat16Vector = number[];
 export type BinaryVector = number[];
-export type SparseVectorArray = number[];
+export type SparseVectorArray = (number | undefined)[];
 export type SparseVectorDic = { [key: string]: number };
 export type SparseVectorCSR = {
   values: number[];

--- a/milvus/types/Data.ts
+++ b/milvus/types/Data.ts
@@ -18,7 +18,21 @@ export type FloatVector = number[];
 export type Float16Vector = number[];
 export type BFloat16Vector = number[];
 export type BinaryVector = number[];
-export type SparseFloatVector = { [key: string]: number };
+export type SparseVectorArray = number[];
+export type SparseVectorDic = { [key: string]: number };
+export type SparseVectorCSR = {
+  values: number[];
+  indices: number[];
+};
+export type SparseVectorCOO = { row: number; column: number; value: number }[];
+
+export type SparseFloatVector =
+  | SparseVectorArray
+  | SparseVectorDic
+  | SparseVectorCSR
+  | SparseVectorCOO;
+
+// export type SparseFloatVector = { [key: string]: number };
 export type VectorTypes =
   | FloatVector
   | Float16Vector

--- a/milvus/types/Data.ts
+++ b/milvus/types/Data.ts
@@ -21,8 +21,8 @@ export type BinaryVector = number[];
 export type SparseVectorArray = (number | undefined)[];
 export type SparseVectorDic = { [key: string]: number };
 export type SparseVectorCSR = {
-  values: number[];
   indices: number[];
+  values: number[];
 };
 export type SparseVectorCOO = { row: number; column: number; value: number }[];
 

--- a/milvus/types/Data.ts
+++ b/milvus/types/Data.ts
@@ -24,7 +24,7 @@ export type SparseVectorCSR = {
   indices: number[];
   values: number[];
 };
-export type SparseVectorCOO = { row: number; column: number; value: number }[];
+export type SparseVectorCOO = { index: number; value: number }[];
 
 export type SparseFloatVector =
   | SparseVectorArray

--- a/milvus/utils/Bytes.ts
+++ b/milvus/utils/Bytes.ts
@@ -53,7 +53,7 @@ export const parseBytesToFloat16Vector = (float16Bytes: Uint8Array) => {
 };
 
 /**
- * Converts a sparse float vector into bytes format.
+ * Get SparseVector type.
  * @param {SparseFloatVector} vector - The sparse float vector to convert.
  *
  * @returns string, 'array' | 'coo' | 'csr' | 'dict'

--- a/milvus/utils/Bytes.ts
+++ b/milvus/utils/Bytes.ts
@@ -63,6 +63,8 @@ export const parseSparseVectorToBytes = (
 ): Uint8Array => {
   const indices = Object.keys(data).map(Number);
   const values = Object.values(data);
+  // console.log('indices', indices);
+  // console.log('values', values);
 
   const bytes = new Uint8Array(8 * indices.length);
   for (let i = 0; i < indices.length; i++) {
@@ -73,9 +75,11 @@ export const parseSparseVectorToBytes = (
         `Sparse vector index must be positive and less than 2^32-1: ${index}`
       );
     }
-    if (isNaN(value)) {
-      throw new Error('Sparse vector value must not be NaN');
-    }
+    // // check if value is NaN, we should ignore undefine
+    // if (isNaN(value)) {
+    //   throw new Error(`Sparse vector value must be a number: ${value}`);
+    // }
+
     const indexBytes = new Uint32Array([index]);
     const valueBytes = new Float32Array([value]);
     bytes.set(new Uint8Array(indexBytes.buffer), i * 8);
@@ -115,7 +119,9 @@ export const parseBufferToSparseRow = (
   for (let i = 0; i < bufferData.length; i += 8) {
     const key: string = bufferData.readUInt32LE(i).toString();
     const value: number = bufferData.readFloatLE(i + 4);
-    result[key] = value;
+    if (value) {
+      result[key] = value;
+    }
   }
   return result;
 };

--- a/milvus/utils/Bytes.ts
+++ b/milvus/utils/Bytes.ts
@@ -7,6 +7,7 @@ import {
   DataType,
   VectorTypes,
   Float16Vector,
+  SparseVectorCSR,
 } from '..';
 
 /**
@@ -61,12 +62,18 @@ export const parseBytesToFloat16Vector = (float16Bytes: Uint8Array) => {
 export const parseSparseVectorToBytes = (
   data: SparseFloatVector
 ): Uint8Array => {
-  const indices = Object.keys(data).map(Number);
-  const values = Object.values(data);
-  // console.log('indices', indices);
-  // console.log('values', values);
+  // if csr format, just get the indices and values from the object
+  // if array or object, get the keys and values
+  const indices =
+    (data as SparseVectorCSR).indices || Object.keys(data).map(Number);
+  const values = (data as SparseVectorCSR).values || Object.values(data);
 
+  // console.log('index', indices,)
+
+  // create a buffer to store the bytes
   const bytes = new Uint8Array(8 * indices.length);
+
+  // loop through the indices and values and add them to the buffer
   for (let i = 0; i < indices.length; i++) {
     const index = indices[i];
     const value = values[i];
@@ -75,10 +82,6 @@ export const parseSparseVectorToBytes = (
         `Sparse vector index must be positive and less than 2^32-1: ${index}`
       );
     }
-    // // check if value is NaN, we should ignore undefine
-    // if (isNaN(value)) {
-    //   throw new Error(`Sparse vector value must be a number: ${value}`);
-    // }
 
     const indexBytes = new Uint32Array([index]);
     const valueBytes = new Float32Array([value]);

--- a/milvus/utils/Bytes.ts
+++ b/milvus/utils/Bytes.ts
@@ -9,7 +9,6 @@ import {
   Float16Vector,
   SparseVectorCSR,
   SparseVectorCOO,
-  SparseVectorDic,
 } from '..';
 
 /**

--- a/test/grpc/SparseVector.array.spec.ts
+++ b/test/grpc/SparseVector.array.spec.ts
@@ -16,7 +16,7 @@ const milvusClient = new MilvusClient({ address: IP, logLevel: 'info' });
 const COLLECTION_NAME = GENERATE_NAME();
 
 const dbParam = {
-  db_name: 'sparse_object_vector_DB',
+  db_name: 'sparse_array_vector_DB',
 };
 
 const p = {
@@ -25,7 +25,9 @@ const p = {
   dim: [24], // useless
 };
 const collectionParams = genCollectionParams(p);
-const data = generateInsertData(collectionParams.fields, 10);
+const data = generateInsertData(collectionParams.fields, 10, {
+  sparseType: 'array',
+});
 
 describe(`Sparse vectors type:object API testing`, () => {
   beforeAll(async () => {
@@ -97,15 +99,21 @@ describe(`Sparse vectors type:object API testing`, () => {
       output_fields: ['vector', 'id'],
     });
 
-    const originKeys = Object.keys(data[0].vector);
-    const originValues = Object.values(data[0].vector);
+    // console.dir(query, { depth: null });
+
+    const originKeys = Object.keys(query.data[0].vector);
+    const originValues = Object.values(query.data[0].vector);
 
     const outputKeys: string[] = Object.keys(query.data[0].vector);
     const outputValues: number[] = Object.values(query.data[0].vector);
 
     expect(originKeys).toEqual(outputKeys);
+
+    // filter  undefined in originValues
     originValues.forEach((value, index) => {
-      expect(value).toBeCloseTo(outputValues[index]);
+      if (value) {
+        expect(value).toBeCloseTo(outputValues[index]);
+      }
     });
   });
 

--- a/test/grpc/SparseVector.csr.spec.ts
+++ b/test/grpc/SparseVector.csr.spec.ts
@@ -12,21 +12,24 @@ import {
   generateInsertData,
 } from '../tools';
 
-const milvusClient = new MilvusClient({ address: IP, logLevel: 'info' });
+const milvusClient = new MilvusClient({ address: IP, logLevel: 'debug' });
 const COLLECTION_NAME = GENERATE_NAME();
 
 const dbParam = {
-  db_name: 'sparse_object_vector_DB',
+  db_name: 'sparse_csr_vector_DB',
 };
 
 const p = {
   collectionName: COLLECTION_NAME,
   vectorType: [DataType.SparseFloatVector],
   dim: [24], // useless
+  sparseType: 'csr',
 };
 const collectionParams = genCollectionParams(p);
-const data = generateInsertData(collectionParams.fields, 10);
-
+const data = generateInsertData(collectionParams.fields, 10, {
+  sparseType: 'csr',
+});
+console.log(data);
 describe(`Sparse vectors type:object API testing`, () => {
   beforeAll(async () => {
     await milvusClient.createDatabase(dbParam);

--- a/test/grpc/SparseVector.csr.spec.ts
+++ b/test/grpc/SparseVector.csr.spec.ts
@@ -12,7 +12,7 @@ import {
   generateInsertData,
 } from '../tools';
 
-const milvusClient = new MilvusClient({ address: IP, logLevel: 'debug' });
+const milvusClient = new MilvusClient({ address: IP, logLevel: 'info' });
 const COLLECTION_NAME = GENERATE_NAME();
 
 const dbParam = {
@@ -26,11 +26,12 @@ const p = {
   sparseType: 'csr',
 };
 const collectionParams = genCollectionParams(p);
-const data = generateInsertData(collectionParams.fields, 10, {
+const data = generateInsertData(collectionParams.fields, 5, {
   sparseType: 'csr',
 });
-console.log(data);
-describe(`Sparse vectors type:object API testing`, () => {
+
+// console.dir(data, { depth: null });
+describe(`Sparse vectors type:CSR API testing`, () => {
   beforeAll(async () => {
     await milvusClient.createDatabase(dbParam);
     await milvusClient.use(dbParam);
@@ -100,14 +101,14 @@ describe(`Sparse vectors type:object API testing`, () => {
       output_fields: ['vector', 'id'],
     });
 
-    const originKeys = Object.keys(data[0].vector);
-    const originValues = Object.values(data[0].vector);
+    const originKeys = data[0].vector.indices.map((index: number) => index.toString());
+    const originValues = data[0].vector.values;
 
     const outputKeys: string[] = Object.keys(query.data[0].vector);
     const outputValues: number[] = Object.values(query.data[0].vector);
 
     expect(originKeys).toEqual(outputKeys);
-    originValues.forEach((value, index) => {
+    originValues.forEach((value: number, index: number) => {
       expect(value).toBeCloseTo(outputValues[index]);
     });
   });

--- a/test/grpc/SparseVector.spec.dict.ts
+++ b/test/grpc/SparseVector.spec.dict.ts
@@ -1,0 +1,123 @@
+import {
+  MilvusClient,
+  ErrorCode,
+  DataType,
+  IndexType,
+  MetricType,
+} from '../../milvus';
+import {
+  IP,
+  genCollectionParams,
+  GENERATE_NAME,
+  generateInsertData,
+} from '../tools';
+
+const milvusClient = new MilvusClient({ address: IP, logLevel: 'info' });
+const COLLECTION_NAME = GENERATE_NAME();
+
+const dbParam = {
+  db_name: 'sparse_dict_vector_DB',
+};
+
+const p = {
+  collectionName: COLLECTION_NAME,
+  vectorType: [DataType.SparseFloatVector],
+  dim: [24], // useless
+};
+const collectionParams = genCollectionParams(p);
+const data = generateInsertData(collectionParams.fields, 10);
+
+describe(`Sparse vectors type:dict API testing`, () => {
+  beforeAll(async () => {
+    await milvusClient.createDatabase(dbParam);
+    await milvusClient.use(dbParam);
+  });
+
+  afterAll(async () => {
+    await milvusClient.dropCollection({ collection_name: COLLECTION_NAME });
+    await milvusClient.dropDatabase(dbParam);
+  });
+
+  it(`Create collection with sparse vectors should be successful`, async () => {
+    const create = await milvusClient.createCollection(collectionParams);
+    expect(create.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const describe = await milvusClient.describeCollection({
+      collection_name: COLLECTION_NAME,
+    });
+
+    const sparseFloatVectorFields = describe.schema.fields.filter(
+      (field: any) => field.data_type === 'SparseFloatVector'
+    );
+    expect(sparseFloatVectorFields.length).toBe(1);
+
+    // console.dir(describe.schema, { depth: null });
+  });
+
+  it(`insert sparse vector data should be successful`, async () => {
+    const insert = await milvusClient.insert({
+      collection_name: COLLECTION_NAME,
+      data,
+    });
+
+    // console.log('data to insert', data);
+
+    expect(insert.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(insert.succ_index.length).toEqual(data.length);
+  });
+
+  it(`create index should be successful`, async () => {
+    const indexes = await milvusClient.createIndex([
+      {
+        collection_name: COLLECTION_NAME,
+        field_name: 'vector',
+        metric_type: MetricType.IP,
+        index_type: IndexType.SPARSE_WAND,
+        params: {
+          drop_ratio_build: 0.2,
+        },
+      },
+    ]);
+
+    expect(indexes.error_code).toEqual(ErrorCode.SUCCESS);
+  });
+
+  it(`load collection should be successful`, async () => {
+    const load = await milvusClient.loadCollection({
+      collection_name: COLLECTION_NAME,
+    });
+
+    expect(load.error_code).toEqual(ErrorCode.SUCCESS);
+  });
+
+  it(`query sparse vector should be successful`, async () => {
+    const query = await milvusClient.query({
+      collection_name: COLLECTION_NAME,
+      filter: 'id > 0',
+      output_fields: ['vector', 'id'],
+    });
+
+    const originKeys = Object.keys(data[0].vector);
+    const originValues = Object.values(data[0].vector);
+
+    const outputKeys: string[] = Object.keys(query.data[0].vector);
+    const outputValues: number[] = Object.values(query.data[0].vector);
+
+    expect(originKeys).toEqual(outputKeys);
+    originValues.forEach((value, index) => {
+      expect(value).toBeCloseTo(outputValues[index]);
+    });
+  });
+
+  it(`search with sparse vector should be successful`, async () => {
+    const search = await milvusClient.search({
+      vector: data[0].vector,
+      collection_name: COLLECTION_NAME,
+      output_fields: ['id', 'vector'],
+      limit: 5,
+    });
+
+    expect(search.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(search.results.length).toBeGreaterThan(0);
+  });
+});

--- a/test/tools/data.ts
+++ b/test/tools/data.ts
@@ -16,7 +16,7 @@ interface DataGenerator {
     max_capacity?: number;
     is_partition_key?: boolean;
     index?: number;
-    sparseType?: 'array' | 'object' | 'csr' | 'coo';
+    sparseType?: string;
   }): FieldData;
 }
 
@@ -238,7 +238,11 @@ export const dataGenMap: { [key in DataType]: DataGenerator } = {
  * @param count The number of data points to generate
  * @returns An array of objects representing the generated data
  */
-export const generateInsertData = (fields: FieldType[], count: number = 10) => {
+export const generateInsertData = (
+  fields: FieldType[],
+  count: number = 10,
+  options?: { sparseType: string }
+) => {
   const rows: { [x: string]: any }[] = []; // Initialize an empty array to store the generated data
 
   // Loop until we've generated the desired number of data points
@@ -274,6 +278,7 @@ export const generateInsertData = (fields: FieldType[], count: number = 10) => {
         ),
         index: count,
         is_partition_key: field.is_partition_key,
+        sparseType: options && options.sparseType,
       };
 
       // Generate data

--- a/test/tools/data.ts
+++ b/test/tools/data.ts
@@ -166,7 +166,7 @@ export const genSparseVector: DataGenerator = params => {
           0.5,
           0.3,
           undefined,
-          0.2
+          0.2]
       */
       const sparseArray = Array.from({ length: dim! }, () => Math.random());
       for (let i = 0; i < nonZeroCount; i++) {
@@ -176,12 +176,11 @@ export const genSparseVector: DataGenerator = params => {
 
     case 'csr':
       /*
-      const sparseDictionary = {
-          3: 1.5,
-          6: 2.0,
-          9: -3.5
+      const sparseCSR = {
+          indices: [2, 5, 8],
+          values: [5, 3, 7]
       };
-    */
+     */
       const indicesSet = new Set<number>();
       const csr = {
         indices: Array.from({ length: nonZeroCount }, () => {

--- a/test/tools/data.ts
+++ b/test/tools/data.ts
@@ -3,6 +3,7 @@ import {
   FieldData,
   convertToDataType,
   FieldType,
+  SparseVectorCOO,
 } from '../../milvus';
 import { MAX_LENGTH, P_KEY_VALUES } from './const';
 import Long from 'long';
@@ -157,46 +158,78 @@ export const genSparseVector: DataGenerator = params => {
   const nonZeroCount = Math.floor(Math.random() * dim!) || 4;
 
   switch (sparseType) {
-    // like this: [undefined, undefined, undefined, 1.5, undefined, undefined, 2.0, undefined, undefined, -3.5];
     case 'array':
-      const sparseArray = Array.from({ length: dim! }, (_, i) =>
-        i < nonZeroCount ? Math.random() : undefined
-      );
+      /*
+      const sparseArray = [
+          undefined,
+          0.0,
+          0.5,
+          0.3,
+          undefined,
+          0.2
+      */
+      const sparseArray = Array.from({ length: dim! }, () => Math.random());
+      for (let i = 0; i < nonZeroCount; i++) {
+        sparseArray[Math.floor(Math.random() * dim!)] = undefined as any;
+      }
       return sparseArray;
-    /*
+
+    case 'csr':
+      /*
       const sparseDictionary = {
           3: 1.5,
           6: 2.0,
           9: -3.5
       };
     */
-    case 'csr':
+      const indicesSet = new Set<number>();
       const csr = {
-        indices: Array.from({ length: nonZeroCount }, () =>
-          Math.floor(Math.random() * dim!)
-        ).sort((a, b) => a - b),
-        values: Array.from({ length: nonZeroCount }, () => Math.random()),
+        indices: Array.from({ length: nonZeroCount }, () => {
+          let index: number;
+          do {
+            index = Math.floor(Math.random() * dim!);
+          } while (indicesSet.has(index));
+          indicesSet.add(index);
+          return index;
+        }).sort((a, b) => a - b),
+        values: Array.from({ length: nonZeroCount }, (_, i) => Math.random()),
       };
       return csr;
+
     case 'coo':
-      const coo = {
-        row: [0],
-        col: Array.from({ length: nonZeroCount }, () =>
-          Math.floor(Math.random() * dim!)
-        ),
-        data: Array.from({ length: nonZeroCount }, () => Math.random()),
-      };
+      /*
+        const sparseCOO = [
+          { index: 2, value: 5 },
+          { index: 5, value: 3 },
+          { index: 8, value: 7 }
+        ];
+      */
+      const coo: SparseVectorCOO = [];
+      const indexSet = new Set<number>();
+
+      while (coo.length < nonZeroCount) {
+        const index = Math.floor(Math.random() * dim!);
+        if (!indexSet.has(index)) {
+          coo.push({
+            index: index,
+            value: Math.random(),
+          });
+          indexSet.add(index);
+        }
+      }
+
+      // sort by index
+      coo.sort((a, b) => a.index - b.index);
       return coo;
 
-    /* 
-      const sparseValues = [1.5, 2.0, -3.5]; 
-      const sparseRowIndices = [3, 6, 9]; 
-      const sparseVector = {
-          values: sparseValues,
-          rowIndices: sparseRowIndices
+    default: // object
+      /* 
+      const sparseObject = {
+          3: 1.5,
+          6: 2.0,
+          9: -3.5
       };
     */
-    default: // object
       const sparseObject: { [key: number]: number } = {};
       for (let i = 0; i < nonZeroCount; i++) {
         sparseObject[Math.floor(Math.random() * dim!)] = Math.random();

--- a/test/tools/data.ts
+++ b/test/tools/data.ts
@@ -157,14 +157,12 @@ export const genSparseVector: DataGenerator = params => {
   const nonZeroCount = Math.floor(Math.random() * dim!) || 4;
 
   switch (sparseType) {
-    // like this: [0, 0, 0, 1.5, 0, 0, 2.0, 0, 0, -3.5];
+    // like this: [undefined, undefined, undefined, 1.5, undefined, undefined, 2.0, undefined, undefined, -3.5];
     case 'array':
-      const sparseArray = Array.from({ length: dim! }, () => 0);
-      for (let i = 0; i < nonZeroCount; i++) {
-        sparseArray[Math.floor(Math.random() * dim!)] = Math.random();
-      }
+      const sparseArray = Array.from({ length: dim! }, (_, i) =>
+        i < nonZeroCount ? Math.random() : undefined
+      );
       return sparseArray;
-
     /*
       const sparseDictionary = {
           3: 1.5,

--- a/test/utils/Bytes.spec.ts
+++ b/test/utils/Bytes.spec.ts
@@ -3,6 +3,7 @@ import {
   parseSparseRowsToBytes,
   SparseFloatVector,
   parseSparseVectorToBytes,
+  getSparseFloatVectorType,
 } from '../../milvus';
 
 describe('Sparse rows <-> Bytes conversion', () => {
@@ -12,14 +13,6 @@ describe('Sparse rows <-> Bytes conversion', () => {
       4294967296: 2.7, // 2^32
     };
     expect(() => parseSparseVectorToBytes(invalidIndexData)).toThrow();
-  });
-
-  it('should throw error if value is NaN', () => {
-    const invalidValueData = {
-      0: 1.5,
-      3: NaN,
-    };
-    expect(() => parseSparseVectorToBytes(invalidValueData)).toThrow();
   });
 
   it('should return empty Uint8Array if data is empty', () => {
@@ -45,5 +38,29 @@ describe('Sparse rows <-> Bytes conversion', () => {
     originValues.forEach((value, index) => {
       expect(value).toBeCloseTo(outputValues[index]);
     });
+  });
+
+  it('should return "dict" if the input is an object', () => {
+    const data = { '12': 0.875, '17': 0.789, '19': 0.934 };
+    expect(getSparseFloatVectorType(data)).toEqual('dict');
+  });
+
+  it('should return "csr" if the input is an object with "indices" and "values"', () => {
+    const data = { indices: [12, 17, 19], values: [0.875, 0.789, 0.934] };
+    expect(getSparseFloatVectorType(data)).toEqual('csr');
+  });
+
+  it('should return "array" if the input is an array', () => {
+    const data = [0.875, 0.789, 0.934];
+    expect(getSparseFloatVectorType(data)).toEqual('array');
+  });
+
+  it('should return "coo" if the input is an array of objects with "index" and "value"', () => {
+    const data = [
+      { index: 12, value: 0.875 },
+      { index: 17, value: 0.789 },
+      { index: 19, value: 0.934 },
+    ];
+    expect(getSparseFloatVectorType(data)).toEqual('coo');
   });
 });

--- a/test/utils/Test.spec.ts
+++ b/test/utils/Test.spec.ts
@@ -8,6 +8,7 @@ import {
   SparseVectorArray,
   SparseVectorDic,
   SparseVectorCSR,
+  SparseVectorCOO,
 } from '../../milvus';
 
 describe(`utils/test`, () => {
@@ -215,22 +216,23 @@ describe(`utils/test`, () => {
     expect(csr.indices.length).toEqual(csr.values.length);
   });
 
-  // it('Generate COO sparse vector', () => {
-  //   const params = { sparseType: 'coo', dim: 24 } as any;
-  //   const coo = genSparseVector(params) as SparseVectorCOO;
-  //   expect(coo.hasOwnProperty('row')).toBe(true);
-  //   expect(coo.hasOwnProperty('col')).toBe(true);
-  //   expect(coo.hasOwnProperty('data')).toBe(true);
-  //   expect(coo.hasOwnProperty('shape')).toBe(true);
-  //   expect(Array.isArray(coo.row)).toBe(true);
-  //   expect(Array.isArray(coo.col)).toBe(true);
-  //   expect(Array.isArray(coo.data)).toBe(true);
-  //   expect(Array.isArray(coo.shape)).toBe(true);
-  //   expect(coo.row.length).toBe(1);
-  //   expect(coo.col.length).toBeLessThanOrEqual(24);
-  //   expect(coo.data.length).toBeLessThanOrEqual(24);
-  //   expect(coo.shape.length).toBe(2);
-  // });
+  it('Generate COO sparse vector', () => {
+    const params = { sparseType: 'coo', dim: 24 } as any;
+    const coo = genSparseVector(params) as SparseVectorCOO;
+    expect(Array.isArray(coo)).toBe(true);
+    expect(coo.length).toBeLessThanOrEqual(24);
+    // test every item should has index and value property, and value should be number
+    coo.forEach(item => {
+      expect(item.hasOwnProperty('index')).toBe(true);
+      expect(item.hasOwnProperty('value')).toBe(true);
+      expect(typeof item.index).toBe('number');
+      expect(typeof item.value).toBe('number');
+    });
+    // test index should be unique
+    const indices = coo.map(item => item.index);
+    const uniqueIndices = new Set(indices);
+    expect(uniqueIndices.size).toBe(indices.length);
+  });
 
   it('Generate dic sparse vector', () => {
     const params = { sparseType: 'object', dim: 24 } as any;

--- a/test/utils/Test.spec.ts
+++ b/test/utils/Test.spec.ts
@@ -7,7 +7,6 @@ import {
   DataType,
   SparseVectorArray,
   SparseVectorDic,
-  SparseVectorCOO,
   SparseVectorCSR,
 } from '../../milvus';
 

--- a/test/utils/Test.spec.ts
+++ b/test/utils/Test.spec.ts
@@ -205,10 +205,14 @@ describe(`utils/test`, () => {
     expect(Array.isArray(csr.indices)).toBe(true);
     // test csr indices should be sorted
     const sortedIndices = csr.indices.slice().sort((a, b) => a - b);
+    // test csr indices should be unique
+    const uniqueIndices = new Set(csr.indices);
+    expect(uniqueIndices.size).toBe(csr.indices.length);
     expect(csr.indices).toEqual(sortedIndices);
     expect(Array.isArray(csr.values)).toBe(true);
     expect(csr.indices.length).toBeLessThanOrEqual(24);
     expect(csr.values.length).toBeLessThanOrEqual(24);
+    expect(csr.indices.length).toEqual(csr.values.length);
   });
 
   // it('Generate COO sparse vector', () => {

--- a/test/utils/Test.spec.ts
+++ b/test/utils/Test.spec.ts
@@ -189,13 +189,13 @@ describe(`utils/test`, () => {
     const sparseArray = genSparseVector(params) as SparseVectorArray;
     expect(Array.isArray(sparseArray)).toBe(true);
     expect(sparseArray.length).toBeLessThanOrEqual(24);
-    sparseArray.forEach(item => {
-      expect(typeof item).toBe('number');
-    });
 
     // test some of items are zero
-    const nonZeroItems = sparseArray.filter(item => item !== 0);
+    const nonZeroItems = sparseArray.filter(item => item !== undefined);
     expect(nonZeroItems.length).toBeLessThanOrEqual(24);
+    // test some of items are undefined
+    const undefinedItems = sparseArray.filter(item => item === undefined);
+    expect(undefinedItems.length).toBeLessThanOrEqual(24);
   });
 
   it('Generate CSR sparse vector', () => {

--- a/test/utils/Test.spec.ts
+++ b/test/utils/Test.spec.ts
@@ -1,5 +1,15 @@
-import { generateInsertData, genCollectionParams } from '../tools';
-import { DataType } from '../../milvus';
+import {
+  generateInsertData,
+  genCollectionParams,
+  genSparseVector,
+} from '../tools';
+import {
+  DataType,
+  SparseVectorArray,
+  SparseVectorDic,
+  SparseVectorCOO,
+  SparseVectorCSR,
+} from '../../milvus';
 
 describe(`utils/test`, () => {
   it('should generate data for schema created by genCollectionParams', () => {
@@ -172,5 +182,62 @@ describe(`utils/test`, () => {
         Object.keys(d.sparse_vector2).every(d => typeof d === 'string')
       ).toBe(true);
     });
+  });
+
+  it('Generate sparse array vector', () => {
+    const params = { sparseType: 'array', dim: 24 } as any;
+    const sparseArray = genSparseVector(params) as SparseVectorArray;
+    expect(Array.isArray(sparseArray)).toBe(true);
+    expect(sparseArray.length).toBeLessThanOrEqual(24);
+    sparseArray.forEach(item => {
+      expect(typeof item).toBe('number');
+    });
+
+    // test some of items are zero
+    const nonZeroItems = sparseArray.filter(item => item !== 0);
+    expect(nonZeroItems.length).toBeLessThanOrEqual(24);
+  });
+
+  it('Generate CSR sparse vector', () => {
+    const params = { sparseType: 'csr', dim: 24 } as any;
+    const csr = genSparseVector(params) as SparseVectorCSR;
+    expect(csr.hasOwnProperty('indices')).toBe(true);
+    expect(csr.hasOwnProperty('values')).toBe(true);
+    expect(Array.isArray(csr.indices)).toBe(true);
+    // test csr indices should be sorted
+    const sortedIndices = csr.indices.slice().sort((a, b) => a - b);
+    expect(csr.indices).toEqual(sortedIndices);
+    expect(Array.isArray(csr.values)).toBe(true);
+    expect(csr.indices.length).toBeLessThanOrEqual(24);
+    expect(csr.values.length).toBeLessThanOrEqual(24);
+  });
+
+  // it('Generate COO sparse vector', () => {
+  //   const params = { sparseType: 'coo', dim: 24 } as any;
+  //   const coo = genSparseVector(params) as SparseVectorCOO;
+  //   expect(coo.hasOwnProperty('row')).toBe(true);
+  //   expect(coo.hasOwnProperty('col')).toBe(true);
+  //   expect(coo.hasOwnProperty('data')).toBe(true);
+  //   expect(coo.hasOwnProperty('shape')).toBe(true);
+  //   expect(Array.isArray(coo.row)).toBe(true);
+  //   expect(Array.isArray(coo.col)).toBe(true);
+  //   expect(Array.isArray(coo.data)).toBe(true);
+  //   expect(Array.isArray(coo.shape)).toBe(true);
+  //   expect(coo.row.length).toBe(1);
+  //   expect(coo.col.length).toBeLessThanOrEqual(24);
+  //   expect(coo.data.length).toBeLessThanOrEqual(24);
+  //   expect(coo.shape.length).toBe(2);
+  // });
+
+  it('Generate dic sparse vector', () => {
+    const params = { sparseType: 'object', dim: 24 } as any;
+    const sparseObject = genSparseVector(params) as SparseVectorDic;
+    expect(typeof sparseObject).toBe('object');
+    expect(Object.keys(sparseObject).length).toBeLessThanOrEqual(24);
+    for (const key in sparseObject) {
+      expect(parseInt(key, 10)).toBeGreaterThanOrEqual(0);
+      expect(parseInt(key, 10)).toBeLessThan(24);
+      expect(typeof sparseObject[key]).toBe('number');
+    }
   });
 });


### PR DESCRIPTION
Only support `array`, `coo`, `csr`, `dict` for nodejs.

`array`:

```javascript
const sparseArray = [
          undefined,
          0.0,
          0.5,
          0.3,
          undefined,
          0.2]
      */
```

`csr`:

```javascript
const sparseCSR = {
          indices: [2, 5, 8],
          values: [5, 3, 7]
      };
```


`coo`:

```javascript
const sparseCOO = [
          { index: 2, value: 5 },
          { index: 5, value: 3 },
          { index: 8, value: 7 }
        ];
```

`dict`:

```javascript
const sparseObject = {
          3: 1.5,
          6: 2.0,
          9: -3.5
      };
```