### PR TITLE
add transformers for bf16 and f16 data-type

### DIFF
--- a/milvus/utils/Bytes.ts
+++ b/milvus/utils/Bytes.ts
@@ -40,18 +40,18 @@ export const f32ArrayToBinaryBytes = (array: BinaryVector) => {
 /**
  * Converts a float16 vector into bytes format.
  *
- * @param {Float16Vector} f16Array - The float16 vector to convert.
+ * @param {Float16Vector} array - The float16 vector(f32 format) to convert.
  * @returns {Buffer} Bytes representing the float16 vector.
  */
-export const f32ArrayToF16Bytes = (f16Array: Float16Vector) => {
-  const float16Bytes = new Float16Array(f16Array);
+export const f32ArrayToF16Bytes = (array: Float16Vector) => {
+  const float16Bytes = new Float16Array(array);
   return Buffer.from(float16Bytes.buffer);
 };
 
 /**
  * Convert float16 bytes to float32 array.
  * @param {Uint8Array} f16Bytes - The float16 bytes to convert.
- * @returns {Float32Array} The float32 array.
+ * @returns {Array} The float32 array.
  */
 export const f16BytesToF32Array = (f16Bytes: Uint8Array) => {
   const buffer = new ArrayBuffer(f16Bytes.length);
@@ -59,21 +59,21 @@ export const f16BytesToF32Array = (f16Bytes: Uint8Array) => {
   view.set(f16Bytes);
 
   const f16Array = new Float16Array(buffer);
-  return f16Array;
+  return Array.from(f16Array);
 };
 
 /**
- *  Convert float32 array to BFloat16 bytes.
- * @param {BFloat16Vector} float32Array - The float32 array to convert.
+ *  Convert float32 array to BFloat16 bytes, not a real conversion, just take the last 2 bytes of float32.
+ * @param {BFloat16Vector} array - The float32 array to convert.
  * @returns {Buffer} The BFloat16 bytes.
  */
-export const f32ArrayToBf16Bytes = (float32Array: BFloat16Vector) => {
-  const totalBytesNeeded = float32Array.length * 2; // 2 bytes per float32
+export const f32ArrayToBf16Bytes = (array: BFloat16Vector) => {
+  const totalBytesNeeded = array.length * 2; // 2 bytes per float32
   const buffer = new ArrayBuffer(totalBytesNeeded);
   const bfloatView = new Uint8Array(buffer);
 
   let byteIndex = 0;
-  float32Array.forEach(float32 => {
+  array.forEach(float32 => {
     const floatBuffer = new ArrayBuffer(4);
     const floatView = new Float32Array(floatBuffer);
     const bfloatViewSingle = new Uint8Array(floatBuffer);
@@ -83,13 +83,13 @@ export const f32ArrayToBf16Bytes = (float32Array: BFloat16Vector) => {
     byteIndex += 2;
   });
 
-  return bfloatView;
+  return Buffer.from(bfloatView);
 };
 
 /**
  * Convert BFloat16 bytes to Float32 array.
  * @param {Uint8Array} bf16Bytes - The BFloat16 bytes to convert.
- * @returns {float32Array} The Float32 array.
+ * @returns {Array} The Float32 array.
  */
 export const bf16BytesToF32Array = (bf16Bytes: Uint8Array) => {
   const float32Array: number[] = [];
@@ -150,7 +150,7 @@ export const getSparseFloatVectorType = (
 /**
  * Converts a sparse float vector into bytes format.
  *
- * @param {SparseFloatVector} data - The sparse float vector to convert.
+ * @param {SparseFloatVector} data - The sparse float vector to convert, support 'array' | 'coo' | 'csr' | 'dict'.
  *
  * @returns {Uint8Array} Bytes representing the sparse float vector.
  * @throws {Error} If the length of indices and values is not the same, or if the index is not within the valid range, or if the value is NaN.
@@ -213,9 +213,7 @@ export const sparseToBytes = (data: SparseFloatVector): Uint8Array => {
  *
  * @returns {Uint8Array[]} An array of bytes representing the sparse float vectors.
  */
-export const parseSparseRowsToBytes = (
-  data: SparseFloatVector[]
-): Uint8Array[] => {
+export const sparseRowsToBytes = (data: SparseFloatVector[]): Uint8Array[] => {
   const result: Uint8Array[] = [];
   for (const row of data) {
     result.push(sparseToBytes(row));
@@ -230,9 +228,7 @@ export const parseSparseRowsToBytes = (
  *
  * @returns {SparseFloatVector} The parsed sparse float vectors.
  */
-export const parseBufferToSparseRow = (
-  bufferData: Buffer
-): SparseFloatVector => {
+export const bytesToSparseRow = (bufferData: Buffer): SparseFloatVector => {
   const result: SparseFloatVector = {};
   for (let i = 0; i < bufferData.length; i += 8) {
     const key: string = bufferData.readUInt32LE(i).toString();

--- a/test/grpc/BFloat16Vector.spec.ts
+++ b/test/grpc/BFloat16Vector.spec.ts
@@ -4,6 +4,8 @@ import {
   DataType,
   IndexType,
   MetricType,
+  f32ArrayToBf16Bytes,
+  bf16BytesToF32Array,
 } from '../../milvus';
 import {
   IP,
@@ -63,6 +65,9 @@ describe(`BFloat16 vector API testing`, () => {
     const insert = await milvusClient.insert({
       collection_name: COLLECTION_NAME,
       data: data,
+      transformers: {
+        [DataType.BFloat16Vector]: f32ArrayToBf16Bytes,
+      },
     });
 
     // console.log(' insert', insert);
@@ -103,9 +108,12 @@ describe(`BFloat16 vector API testing`, () => {
       collection_name: COLLECTION_NAME,
       filter: 'id > 0',
       output_fields: ['vector', 'id'],
+      transformers: {
+        [DataType.BFloat16Vector]: bf16BytesToF32Array,
+      },
     });
 
-    console.dir(query, { depth: null });
+    // console.dir(query, { depth: null });
 
     // verify the query result
     data.forEach((obj, index) => {
@@ -123,6 +131,9 @@ describe(`BFloat16 vector API testing`, () => {
       collection_name: COLLECTION_NAME,
       output_fields: ['id', 'vector'],
       limit: 5,
+      transformers: {
+        [DataType.BFloat16Vector]: bf16BytesToF32Array,
+      },
     });
 
     // console.log('search', search);

--- a/test/grpc/Float16Vector.spec.ts
+++ b/test/grpc/Float16Vector.spec.ts
@@ -4,6 +4,8 @@ import {
   DataType,
   IndexType,
   MetricType,
+  f32ArrayToF16Bytes,
+  f16BytesToF32Array,
 } from '../../milvus';
 import {
   IP,
@@ -60,6 +62,9 @@ describe(`Float16 vector API testing`, () => {
     const insert = await milvusClient.insert({
       collection_name: COLLECTION_NAME,
       data,
+      transformers: {
+        [DataType.Float16Vector]: f32ArrayToF16Bytes,
+      },
     });
 
     // console.log(' insert', insert);
@@ -100,6 +105,9 @@ describe(`Float16 vector API testing`, () => {
       collection_name: COLLECTION_NAME,
       filter: 'id > 0',
       output_fields: ['vector', 'id'],
+      transformers: {
+        [DataType.Float16Vector]: f16BytesToF32Array,
+      },
     });
 
     // verify the query result

--- a/test/grpc/MultipleVectors.spec.ts
+++ b/test/grpc/MultipleVectors.spec.ts
@@ -6,6 +6,8 @@ import {
   MetricType,
   RRFRanker,
   WeightedRanker,
+  f32ArrayToF16Bytes,
+  f16BytesToF32Array,
 } from '../../milvus';
 import {
   IP,
@@ -66,6 +68,9 @@ describe(`Multiple vectors API testing`, () => {
     const insert = await milvusClient.insert({
       collection_name: COLLECTION_NAME,
       data,
+      transformers: {
+        [DataType.Float16Vector]: f32ArrayToF16Bytes,
+      },
     });
 
     expect(insert.status.error_code).toEqual(ErrorCode.SUCCESS);
@@ -123,6 +128,9 @@ describe(`Multiple vectors API testing`, () => {
       collection_name: COLLECTION_NAME,
       filter: 'id > 0',
       output_fields: ['vector', 'vector1', 'vector2', 'vector3'],
+      transformers: {
+        [DataType.Float16Vector]: f16BytesToF32Array,
+      },
     });
 
     expect(query.status.error_code).toEqual(ErrorCode.SUCCESS);


### PR DESCRIPTION
we shouldn't do the data transform by default for `bf16` and `f16` data type, although it doesn't exist in javascript. 
but we provide these helpers:
`f32ArrayToF16Bytes`
`f16BytesToF32Array`
`f32ArrayToBf16Bytes`
`bf16BytesToF32Array` 

So that user can use in the `insert`, `query`, `search` api.  like this
```javascript
 const insert = await milvusClient.insert({
      collection_name: COLLECTION_NAME,
      data: data,
      transformers: {
        [DataType.BFloat16Vector]: f32ArrayToBf16Bytes,
      },
    });

const query = await milvusClient.query({
      collection_name: COLLECTION_NAME,
      filter: 'id > 0',
      output_fields: ['vector', 'id'],
      transformers: {
        [DataType.BFloat16Vector]: bf16BytesToF32Array,
      },
    });

const search = await milvusClient.search({
      vector: data[0].vector,
      collection_name: COLLECTION_NAME,
      output_fields: ['id', 'vector'],
      limit: 5,
      transformers: {
        [DataType.BFloat16Vector]: bf16BytesToF32Array,
      },
    });

```

