### PR TITLE
fix issue with returning a connection to the pool too early

### DIFF
--- a/milvus/utils/Function.ts
+++ b/milvus/utils/Function.ts
@@ -41,14 +41,17 @@ export async function promisify(
           if (err) {
             // If there was an error, reject the Promise with the error
             reject(err);
+          } else {
+            // Otherwise, resolve the Promise with the result
+            resolve(result);
           }
-          // Otherwise, resolve the Promise with the result
-          resolve(result);
+          if (client) {
+            pool.release(client);
+          }
         }
       );
     } catch (e: any) {
       reject(e);
-    } finally {
       if (client) {
         pool.release(client);
       }


### PR DESCRIPTION
Because the `promisify` function wraps a callback-style function,
the `finally` block runs right after the function call.

So, I moved the release code into the callback function.
