### PR TITLE
fix: prevent dynamic field overwrite when building dynamic row

### DIFF
--- a/milvus/utils/Format.ts
+++ b/milvus/utils/Format.ts
@@ -453,6 +453,10 @@ export const buildDynamicRow = (
 
   // iterate through each key in the input data object
   for (let key in originRow) {
+    if (key === dynamicFieldName) {
+      // ignore the dynamic field key for now
+      continue;
+    }
     row[dynamicFieldName] = row[dynamicFieldName] || ({} as JSON); // initialize the dynamic field object
 
     if (fieldMap.has(key)) {
@@ -465,6 +469,13 @@ export const buildDynamicRow = (
         obj[key] = originRow[key];
       }
     }
+  }
+
+  // do this last to prevent any non-deterministic behavior with loop order
+  if (originRow[dynamicFieldName]) {
+    // extend the dynamic field object with the input dynamic field object
+    row[dynamicFieldName] = row[dynamicFieldName] || ({} as JSON);
+    Object.assign(row[dynamicFieldName] as JSON, originRow[dynamicFieldName]);
   }
 
   return row; // return the generated dynamic row object

--- a/test/utils/Format.spec.ts
+++ b/test/utils/Format.spec.ts
@@ -615,6 +615,71 @@ describe('utils/format', () => {
     });
   });
 
+  it('should return an object with dynamicField key when data contains keys not in fieldsDataMap and an empty dynamicField object', () => {
+    const dynamicField = 'dynamic';
+    const data = { key1: 'value1', key2: 'value2', [dynamicField]: {} };
+    const fieldsDataMap = new Map([
+      [
+        'key1',
+        {
+          name: 'key1',
+          type: 'VarChar',
+          data: [{ key1: 'value1' }],
+        } as _Field,
+      ],
+      [
+        // this mirrors the dynamic field map in grpc.Data._insert method
+        dynamicField,
+        {
+          name: dynamicField,
+          type: 'JSON',
+          data: [],
+        } as _Field,
+      ],
+    ]);
+    const result = buildDynamicRow(data, fieldsDataMap, dynamicField, []);
+    expect(result).toEqual({
+      key1: 'value1',
+      [dynamicField]: { key2: 'value2' },
+    });
+  });
+
+  it('should return an object with dynamicField key when data contains keys not in fieldsDataMap and a non-empty dynamicField object', () => {
+    const dynamicField = 'dynamic';
+    const data = {
+      key1: 'value1',
+      key2: 'value2',
+      [dynamicField]: {
+        key2: 'value22',
+        key3: 'value3',
+      },
+    };
+    const fieldsDataMap = new Map([
+      [
+        'key1',
+        {
+          name: 'key1',
+          type: 'VarChar',
+          data: [{ key1: 'value1' }],
+        } as _Field,
+      ],
+      [
+        // this mirrors the dynamic field map in grpc.Data._insert method
+        dynamicField,
+        {
+          name: dynamicField,
+          type: 'JSON',
+          data: [],
+        } as _Field,
+      ],
+    ]);
+    const result = buildDynamicRow(data, fieldsDataMap, dynamicField, []);
+    expect(result).toEqual({
+      key1: 'value1',
+      [dynamicField]: { key2: 'value22', key3: 'value3' },
+    });
+  });
+
   it('should return an empty string if no credentials are provided', () => {
     const authString = getAuthString({});
     expect(authString).toEqual('');


### PR DESCRIPTION
See #399 for context

This should fix the non-deterministic behaviour of dynamic fields; however, the behaviour when the user provides a non-empty dynamic field should be discussed.