### PR TITLE
feat: downgrade @grpc/grpc-js to 1.7.3

### DIFF
--- a/milvus/grpc/BaseClient.ts
+++ b/milvus/grpc/BaseClient.ts
@@ -6,7 +6,6 @@ import {
   ChannelOptions,
   credentials,
   ChannelCredentials,
-  VerifyOptions,
 } from '@grpc/grpc-js';
 import { Pool } from 'generic-pool';
 import {
@@ -20,6 +19,12 @@ import {
 } from '../';
 import milvusProtoJson from '../proto-json/milvus.base';
 import schemaProtoJson from '../proto-json/schema.base';
+
+// Define VerifyOptions interface
+interface VerifyOptions {
+  checkServerIdentity?: (host: string, cert: any) => Error | undefined;
+  rejectUnauthorized?: boolean;
+}
 
 /**
  * Base gRPC client, setup all configuration here

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "proto:json": "yarn test test/utils/ProtoJson.spec.ts"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.12.1",
+    "@grpc/grpc-js": "1.7.3",
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "^1.9.0",
     "@petamoriken/float16": "^3.8.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -289,15 +289,25 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@grpc/grpc-js@^1.12.1":
-  version "1.12.2"
-  resolved "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.2.tgz"
-  integrity sha512-bgxdZmgTrJZX50OjyVwz3+mNEnCTNkh3cIqGPWVNeW9jX6bn1ZkU80uPd+67/ZpIJIjRQ9qaHCjhavyoWYxumg==
+"@grpc/grpc-js@1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.7.3.tgz#f2ea79f65e31622d7f86d4b4c9ae38f13ccab99a"
+  integrity sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==
   dependencies:
-    "@grpc/proto-loader" "^0.7.13"
-    "@js-sdsl/ordered-map" "^4.4.2"
+    "@grpc/proto-loader" "^0.7.0"
+    "@types/node" ">=12.12.47"
 
-"@grpc/proto-loader@^0.7.10", "@grpc/proto-loader@^0.7.13":
+"@grpc/proto-loader@^0.7.0":
+  version "0.7.15"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.15.tgz#4cdfbf35a35461fc843abe8b9e2c0770b5095e60"
+  integrity sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==
+  dependencies:
+    lodash.camelcase "^4.3.0"
+    long "^5.0.0"
+    protobufjs "^7.2.5"
+    yargs "^17.7.2"
+
+"@grpc/proto-loader@^0.7.10":
   version "0.7.13"
   resolved "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz"
   integrity sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==
@@ -555,11 +565,6 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@js-sdsl/ordered-map@^4.4.2":
-  version "4.4.2"
-  resolved "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz"
-  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
-
 "@opentelemetry/api@^1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
@@ -741,6 +746,13 @@
   version "20.2.3"
   resolved "https://registry.npmjs.org/@types/node/-/node-20.2.3.tgz"
   integrity sha512-pg9d0yC4rVNWQzX8U7xb4olIOFuuVL9za3bzMT2pu2SU0SNEi66i2qrvhE2qt0HvkhuCaWJu7pLNOt/Pj8BIrw==
+
+"@types/node@>=12.12.47":
+  version "24.0.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.0.1.tgz#e9bfcb1c35547437c294403b7bec497772a88b0a"
+  integrity sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw==
+  dependencies:
+    undici-types "~7.8.0"
 
 "@types/prettier@^2.1.5":
   version "2.7.2"
@@ -2472,6 +2484,11 @@ typescript@^5.0.4:
   version "5.0.4"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz"
   integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+
+undici-types@~7.8.0:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.8.0.tgz#de00b85b710c54122e44fbfd911f8d70174cd294"
+  integrity sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==
 
 update-browserslist-db@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
Why we're downgrading:
Versions >= 1.8.0 of @grpc/grpc-js trigger intermittent INTERNAL: Received RST_STREAM with code 0 errors when retry logic is enabled and Envoy (e.g., Istio sidecar) is in the path. This was reported in [grpc-node#2569](https://github.com/grpc/grpc-node/issues/2569), where large concurrent calls routed through Envoy consistently resulted in RST_STREAM resets and failed retries.

Until the upstream issue is resolved, we are locking the version at 1.7.3, the last known stable release for our use case.


