### PR TITLE
fix: add missing fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "files": [
     "dist"
   ],
+  "license": "Apache-2.0",
+  "repository": "github:milvus-io/milvus-sdk-node",
   "scripts": {
     "pre": "git submodule update --remote && rm -rf proto/proto/google && mkdir -p proto/proto/google/protobuf && wget https://raw.githubusercontent.com/protocolbuffers/protobuf/main/src/google/protobuf/descriptor.proto -O proto/proto/google/protobuf/descriptor.proto",
     "build": "rm -rf dist && tsc --declaration && node build.js",


### PR DESCRIPTION
Adds the "license" and "repository" fields.  These are used on npmjs.org to display the license and link back to the github repository.

Verified the "repository" entry by running `npm repo` and verifying https://github.com/milvus-io/milvus-sdk-node opened in the browser.

Fixes #459 