### PR TITLE
fix: resolve filter/expr field conflict in queryIterator method

### DIFF
--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -715,16 +715,19 @@ export class Data extends Collection {
       collection_name: data.collection_name,
       expr: userExpr,
     });
+    // remove filter field to avoid conflict with expr in query method
+    const queryData = { ...data };
+    delete queryData.filter;
     // if limit not set, set it to count
-    if (!data.limit || data.limit === NO_LIMIT) {
-      data.limit = count.data;
+    if (!queryData.limit || queryData.limit === NO_LIMIT) {
+      queryData.limit = count.data;
     }
     // total should be the minimum of total and count
-    const total = data.limit > count.data ? count.data : data.limit;
+    const total = queryData.limit > count.data ? count.data : queryData.limit;
     const batchSize =
-      data.batchSize > DEFAULT_MAX_SEARCH_SIZE
+      queryData.batchSize > DEFAULT_MAX_SEARCH_SIZE
         ? DEFAULT_MAX_SEARCH_SIZE
-        : data.batchSize;
+        : queryData.batchSize;
 
     // local variables
     let expr = userExpr;
@@ -744,17 +747,17 @@ export class Data extends Collection {
               return { done: true, value: lastBatchRes };
             }
             // set limit for current batch
-            data.limit = currentBatchSize; // Use the current batch size
+            queryData.limit = currentBatchSize; // Use the current batch size
 
             // get current page expr
-            data.expr = getQueryIteratorExpr({
+            queryData.expr = getQueryIteratorExpr({
               expr: expr,
               pkField,
               lastPKId,
             });
 
             // search data
-            const res = await client.query(data as QueryReq);
+            const res = await client.query(queryData as QueryReq);
 
             // get last item of the data
             const lastItem = res.data[res.data.length - 1];

--- a/test/grpc/Iterator.spec.ts
+++ b/test/grpc/Iterator.spec.ts
@@ -340,6 +340,36 @@ describe(`Iterator API`, () => {
     });
   });
 
+  it(`query iterator with filter should success`, async () => {
+    const iterator = await milvusClient.queryIterator({
+      collection_name: COLLECTION,
+      batchSize: 1000,
+      expr: 'id > 0',
+      output_fields: ['id'],
+    });
+
+    const results: any = [];
+    let page = 0;
+    for await (const value of iterator) {
+      results.push(...value);
+      page += 1;
+    }
+
+    expect(page).toEqual(Math.ceil(data.length / 1000));
+    expect(results.length).toEqual(data.length);
+
+    const idSet = new Set();
+    results.forEach((result: any) => {
+      idSet.add(result.id);
+    });
+    expect(idSet.size).toEqual(data.length);
+
+    results.forEach((result: any) => {
+      const item = dataMap.get(result.id.toString());
+      expect(typeof item !== 'undefined').toEqual(true);
+    });
+  });
+
   it(`query iterator with limit = -1 should success`, async () => {
     // page size
     const batchSize = 5000;


### PR DESCRIPTION
- Remove filter field from queryData to avoid conflict with expr
- query method prioritizes filter over expr, causing issues when both exist
- Create separate queryData object to prevent modifying original parameters
- Fixes type conflict between filter and expr fields in QueryReq type

#463 