### PR TITLE
fix: vector field data array concat turns very slow when row count grows

### DIFF
--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -70,6 +70,7 @@ import {
   convertToDataType,
   GetQuerySegmentInfoResponse,
   SearchData,
+  FloatVector,
 } from '../';
 import { Collection } from './Collection';
 
@@ -244,7 +245,7 @@ export class Data extends Collection {
         switch (field.type) {
           case DataType.BinaryVector:
           case DataType.FloatVector:
-            field.data = field.data.concat(buildFieldData(rowData, field));
+            field.data.push(...buildFieldData(rowData, field) as FloatVector | BinaryVector);
             break;
           default:
             field.data[rowIndex] = buildFieldData(


### PR DESCRIPTION
The array `concat` method has a linear time cost that grows with the array size, because it needs to copy the entire array on each call. Since `concat` is applied to every row here, the data preparation process effectively ends up with a time complexity of **O(n²)**.

In practical tests, when uploading a 1024-dimensional `FloatVector`, if the insert row size reaches around 1,000, each `concat` call takes about **200 ms** on a server with mainstream performance, and the entire data preparation process takes on the order of **100 seconds**. If `concat` is replaced with `push`, the time overhead can be greatly reduced, and the whole process can be completed in just a few seconds.
