### PR TITLE
fix: skip validation for nullable/default fields when partial_update is true

### DIFF
--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -309,7 +309,7 @@ export class Data extends Collection {
           (field.nullable === true ||
             (typeof field.default_value !== 'undefined' &&
               field.default_value !== null)) &&
-          params.partial_update !== true;
+          !('partial_update' in data && data.partial_update === true);
 
         // get valid data
         const valid_data = needValidData

--- a/test/grpc/Upsert.spec.ts
+++ b/test/grpc/Upsert.spec.ts
@@ -319,9 +319,10 @@ describe(`Upsert API`, () => {
       collection_name: MORE_SCALAR_COLLECTION_NAME,
       expr: 'id == 1 or id == 2',
     });
-    console.dir(query.data, { depth: null });
     expect(query.data[0].int).toEqual(2);
     expect(query.data[1].int).toEqual(3);
+    expect(query.data[0].double).toEqual(1.12);
+    expect(query.data[1].double).toEqual(1.12);
   });
 
   it(`Upsert Data throw type error`, async () => {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Skip validation for nullable/default fields during partial updates

- Allow partial updates without requiring all nullable fields

- Add test coverage for nullable fields in upsert operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Partial Update Request"] --> B["Check partial_update Flag"]
  B --> C["Skip Validation for Nullable/Default Fields"]
  C --> D["Build Column Data Successfully"]
  B --> E["Validate All Fields as Normal"]
  E --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Data.ts</strong><dd><code>Skip nullable field validation for partial updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

milvus/grpc/Data.ts

<ul><li>Added condition to skip validation for nullable and default value <br>fields when <code>partial_update</code> is true<br> <li> Refactored validation logic to check <code>params.partial_update !== true</code> <br>before validating nullable/default fields<br> <li> Improved code formatting for better readability in vector field data <br>building<br> <li> Added clarifying comments explaining nullable and default value <br>validation behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus-sdk-node/pull/485/files#diff-4b75065c473a7badf3fad7edba8bbf3d6298d2c3208806f4f1e9b06bd78cee32">+11/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Upsert.spec.ts</strong><dd><code>Add nullable field test coverage for upsert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/grpc/Upsert.spec.ts

<ul><li>Added <code>nullable: true</code> property to the 'double' field in test schema<br> <li> Added debug logging to inspect query results during partial update <br>test<br> <li> Enhanced test coverage for nullable fields in upsert operations</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus-sdk-node/pull/485/files#diff-5f51285f663a1c49e2131dc5877fe6660d5ad8fc4b129ccf92de7405518d505e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Partial updates no longer incorrectly trigger validation for certain non-vector fields, so updates that rely on nullable/default behavior now apply as expected.

* **Tests**
  * Tests expanded to cover nullable scalar fields and verify correct values after partial updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->