### PR TITLE
fix: remove partial_update check for default value validation

### DIFF
--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -318,8 +318,7 @@ export class Data extends Collection {
         const needValidData =
           key !== 'vectors' &&
           (field.nullable === true ||
-            (!isPartialUpdate &&
-              typeof field.default_value !== 'undefined' &&
+            (typeof field.default_value !== 'undefined' &&
               field.default_value !== null));
 
         // get valid data


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Pull Request Summary: Remove Partial Update Check for Default Value Validation

**Core Invariant:** Fields with schema-defined, non-null default values must generate valid_data arrays to ensure proper protobuf serialization, independent of operation type (insert, full upsert, or partial upsert).

**What Was Removed and Why:** Commit 06a14a5 introduced a `partial_update` check that excluded default_value validation during partial updates. This PR removes that restriction, simplifying the condition from:
```
needValidData = !vectors && (nullable || (!isPartialUpdate && default_value exists))
```
to:
```
needValidData = !vectors && (nullable || default_value exists)
```
This is redundant because valid_data serves a *formatting* purpose, not a data-provision purpose. Field serialization requirements should depend on the schema, not the operation mode.

**Why No Data Loss or Regression:** Partial updates continue to only transmit explicitly provided fields to the server; this change only affects how valid_data arrays are formatted internally for those fields. Default values are never written to the database from valid_data—they fill gaps in the serialization protocol. Removing the artificial distinction between partial and full updates ensures consistent field handling across all mutation operations.

**Concrete Fix:** Eliminates the `&& !isPartialUpdate` clause that incorrectly skipped valid_data generation for fields with defaults during partial updates, restoring uniform validation logic across all insert/upsert code paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->