### PR TITLE
feat: set grpc keepalive interval to 10s with 5s timeout

### DIFF
--- a/milvus/grpc/BaseClient.ts
+++ b/milvus/grpc/BaseClient.ts
@@ -126,7 +126,7 @@ export class BaseClient {
       // So SDK should support max_receive_message_length unlimited.
       'grpc.max_receive_message_length': -1, // set max_receive_message_length to unlimited
       'grpc.max_send_message_length': -1, // set max_send_message_length to unlimited
-      'grpc.keepalive_time_ms': 55 * 1000, // Send keepalive pings every 55 seconds, default is 2 hours.
+      'grpc.keepalive_time_ms': 10 * 1000, // Send keepalive pings every 10 seconds, default is 2 hours.
       'grpc.keepalive_timeout_ms': 5 * 1000, // Keepalive ping timeout after 5 seconds, default is 20 seconds.
       'grpc.keepalive_permit_without_calls': 1, // Allow keepalive pings when there are no gRPC calls.
       'grpc.enable_retries': 1, // enable retry

--- a/test/grpc/MilvusClient.spec.ts
+++ b/test/grpc/MilvusClient.spec.ts
@@ -195,6 +195,36 @@ describe(`Milvus client`, () => {
     }
   });
 
+  it(`should have default keepalive options set to 10s interval and 5s timeout`, async () => {
+    const client = new MilvusClient({
+      address: IP,
+      __SKIP_CONNECT__: true,
+    });
+
+    expect(client.channelOptions['grpc.keepalive_time_ms']).toEqual(10000);
+    expect(client.channelOptions['grpc.keepalive_timeout_ms']).toEqual(5000);
+    expect(client.channelOptions['grpc.keepalive_permit_without_calls']).toEqual(
+      1
+    );
+  });
+
+  it(`should allow overriding keepalive options via channelOptions`, async () => {
+    const client = new MilvusClient({
+      address: IP,
+      channelOptions: {
+        'grpc.keepalive_time_ms': 20000,
+        'grpc.keepalive_timeout_ms': 8000,
+      },
+      __SKIP_CONNECT__: true,
+    });
+
+    expect(client.channelOptions['grpc.keepalive_time_ms']).toEqual(20000);
+    expect(client.channelOptions['grpc.keepalive_timeout_ms']).toEqual(8000);
+    expect(client.channelOptions['grpc.keepalive_permit_without_calls']).toEqual(
+      1
+    );
+  });
+
   it(`should add trace interceptor if enableTrace is true`, async () => {
     const nonTraceClient = new MilvusClient({
       address: IP,


### PR DESCRIPTION
## Summary
- Reduce `grpc.keepalive_time_ms` default from 55s to 10s for faster dead connection detection
- Keep `grpc.keepalive_timeout_ms` at 5s (unchanged)
- Add tests verifying default keepalive options (10s interval, 5s timeout, permit without calls)
- Add test verifying user can override keepalive options via `channelOptions`

## Test plan
- [ ] Verify existing gRPC client tests pass
- [ ] Verify new keepalive default test asserts 10s interval & 5s timeout
- [ ] Verify new override test confirms user-provided channelOptions take precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)