### PR TITLE
fix: pass db_name in addCollectionFields to addCollectionField

### DIFF
--- a/milvus/grpc/Collection.ts
+++ b/milvus/grpc/Collection.ts
@@ -306,6 +306,7 @@ export class Collection extends Database {
     for (const field of data.fields) {
       const result = await this.addCollectionField({
         collection_name: data.collection_name,
+        db_name: data.db_name,
         field,
         timeout: data.timeout,
       });

--- a/test/grpc/Database.spec.ts
+++ b/test/grpc/Database.spec.ts
@@ -266,6 +266,51 @@ describe(`Database API`, () => {
     });
     expect(releaseCollection.error_code).toEqual(ErrorCode.SUCCESS);
 
+    // addCollectionField with db_name
+    const addField = await milvusClient.addCollectionField({
+      collection_name: COLLECTION_NAME2,
+      db_name: DB_NAME2,
+      field: {
+        name: 'new_field_single',
+        data_type: 'VarChar',
+        max_length: 128,
+        nullable: true,
+      },
+    });
+    expect(addField.error_code).toEqual(ErrorCode.SUCCESS);
+
+    // addCollectionFields (plural) with db_name
+    const addFields = await milvusClient.addCollectionFields({
+      collection_name: COLLECTION_NAME2,
+      db_name: DB_NAME2,
+      fields: [
+        {
+          name: 'new_field_batch_1',
+          data_type: 'VarChar',
+          max_length: 128,
+          nullable: true,
+        },
+        {
+          name: 'new_field_batch_2',
+          data_type: 'Int64',
+          nullable: true,
+        },
+      ],
+    });
+    expect(addFields.error_code).toEqual(ErrorCode.SUCCESS);
+
+    // verify the new fields exist in the correct database
+    const descAfterAdd = await milvusClient.describeCollection({
+      collection_name: COLLECTION_NAME2,
+      db_name: DB_NAME2,
+    });
+    const fieldNames = descAfterAdd.schema.fields.map(
+      (f: { name: string }) => f.name
+    );
+    expect(fieldNames).toContain('new_field_single');
+    expect(fieldNames).toContain('new_field_batch_1');
+    expect(fieldNames).toContain('new_field_batch_2');
+
     // drop collection
     const dropCollections = await milvusClient.dropCollection({
       collection_name: COLLECTION_NAME2,


### PR DESCRIPTION
## Summary
- `addCollectionFields` internally loops over fields and calls `addCollectionField` for each one, but was **not forwarding `db_name`**, causing all fields to be silently added to the `default` database instead of the specified one.
- Added `db_name: data.db_name` to the forwarded parameters.
- Added test coverage for both `addCollectionField` and `addCollectionFields` with `db_name` in `Database.spec.ts`.

## Test plan
- [ ] Existing tests pass (`npm test`)
- [ ] New test in `Database.spec.ts` verifies fields are added to the correct database via `db_name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)