### PR TITLE
feat: add batchDescribeCollections API

### DIFF
--- a/milvus/grpc/Collection.ts
+++ b/milvus/grpc/Collection.ts
@@ -7,6 +7,7 @@ import {
   CollectionData,
   CreateCollectionReq,
   DescribeCollectionReq,
+  BatchDescribeCollectionReq,
   DropCollectionReq,
   GetCollectionStatisticsReq,
   LoadCollectionReq,
@@ -30,6 +31,7 @@ import {
   ResStatus,
   CompactionResponse,
   DescribeCollectionResponse,
+  BatchDescribeCollectionResponse,
   GetCompactionPlansResponse,
   GetCompactionStateResponse,
   ShowCollectionsResponse,
@@ -630,6 +632,55 @@ export class Collection extends Database {
     this.collectionInfoCache.set(key, results);
 
     return results;
+  }
+
+  /**
+   * Batch describe collections. Returns schema and details for multiple collections in one call.
+   *
+   * @param {BatchDescribeCollectionReq} data - The request parameters.
+   * @param {string[]} data.collection_names - The names of the collections to describe.
+   * @param {string} [data.db_name] - The database name.
+   * @param {number[]} [data.collectionIDs] - The IDs of the collections to describe.
+   * @param {number} [data.timeout] - An optional duration of time in milliseconds to allow for the RPC.
+   *
+   * @returns {Promise<BatchDescribeCollectionResponse>} The response from the server.
+   * @returns {string} status.error_code - The error code of the operation.
+   * @returns {string} status.reason - The reason for the error, if any.
+   * @returns {DescribeCollectionResponse[]} responses - Array of describe collection responses.
+   *
+   * @example
+   * ```
+   *  const milvusClient = new MilvusClient(MILVUS_ADDRESS);
+   *  const res = await milvusClient.batchDescribeCollections({
+   *    collection_names: ['collection1', 'collection2'],
+   *  });
+   * ```
+   */
+  async batchDescribeCollections(
+    data: BatchDescribeCollectionReq
+  ): Promise<BatchDescribeCollectionResponse> {
+    const promise = await promisify(
+      this.channelPool,
+      'BatchDescribeCollection',
+      {
+        collection_name: data.collection_names,
+        db_name: data.db_name,
+        collectionID: data.collectionIDs || [],
+      },
+      data.timeout || this.timeout
+    );
+
+    if (
+      promise.status.error_code !== ErrorCode.SUCCESS ||
+      !promise.responses
+    ) {
+      return promise;
+    }
+
+    // format each collection response
+    promise.responses = promise.responses.map(formatDescribedCol);
+
+    return promise;
   }
 
   /**

--- a/milvus/types/Collection.ts
+++ b/milvus/types/Collection.ts
@@ -154,6 +154,12 @@ export interface DescribeCollectionReq extends collectionNameReq {
   cache?: boolean;
 }
 
+export interface BatchDescribeCollectionReq extends GrpcTimeOut {
+  collection_names: string[]; // required, collection names to describe
+  db_name?: string; // optional, db name
+  collectionIDs?: number[]; // optional, collection IDs to describe
+}
+
 export interface GetCollectionStatisticsReq extends collectionNameReq {}
 
 export interface LoadCollectionReq extends collectionNameReq {
@@ -253,6 +259,10 @@ export interface DescribeCollectionResponse extends TimeStamp {
   anns_fields: Record<string, FieldSchema>;
   scalar_fields: Record<string, FieldSchema>;
   function_fields: Record<string, FieldSchema>;
+}
+
+export interface BatchDescribeCollectionResponse extends resStatusResponse {
+  responses: DescribeCollectionResponse[];
 }
 
 export interface GetCompactionPlansResponse extends resStatusResponse {

--- a/test/grpc/BatchDescribeCollection.spec.ts
+++ b/test/grpc/BatchDescribeCollection.spec.ts
@@ -1,0 +1,98 @@
+import {
+  MilvusClient,
+  DataType,
+  ErrorCode,
+} from '../../milvus';
+import {
+  IP,
+  genCollectionParams,
+  VECTOR_FIELD_NAME,
+  GENERATE_NAME,
+} from '../tools';
+
+const milvusClient = new MilvusClient({ address: IP, logLevel: 'info' });
+const COLLECTION_NAME_1 = GENERATE_NAME();
+const COLLECTION_NAME_2 = GENERATE_NAME();
+
+const dbParam = {
+  db_name: 'BatchDescribeCollection',
+};
+
+describe(`BatchDescribeCollection API`, () => {
+  beforeAll(async () => {
+    await milvusClient.createDatabase(dbParam);
+    await milvusClient.use(dbParam);
+
+    // create two collections
+    const res1 = await milvusClient.createCollection({
+      ...genCollectionParams({
+        collectionName: COLLECTION_NAME_1,
+        dim: [128],
+      }),
+      consistency_level: 'Eventually',
+    });
+    expect(res1.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const res2 = await milvusClient.createCollection({
+      ...genCollectionParams({
+        collectionName: COLLECTION_NAME_2,
+        dim: [64],
+      }),
+      consistency_level: 'Strong',
+    });
+    expect(res2.error_code).toEqual(ErrorCode.SUCCESS);
+  });
+
+  afterAll(async () => {
+    await milvusClient.dropCollection({ collection_name: COLLECTION_NAME_1 });
+    await milvusClient.dropCollection({ collection_name: COLLECTION_NAME_2 });
+    await milvusClient.dropDatabase(dbParam);
+  });
+
+  it(`Batch describe collections should return info for multiple collections`, async () => {
+    const res = await milvusClient.batchDescribeCollections({
+      collection_names: [COLLECTION_NAME_1, COLLECTION_NAME_2],
+    });
+
+    expect(res.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(res.responses.length).toEqual(2);
+
+    // find each collection in the responses
+    const col1 = res.responses.find(
+      r => r.collection_name === COLLECTION_NAME_1
+    );
+    const col2 = res.responses.find(
+      r => r.collection_name === COLLECTION_NAME_2
+    );
+
+    expect(col1).toBeDefined();
+    expect(col2).toBeDefined();
+
+    // verify schema fields are formatted
+    expect(col1!.schema.name).toEqual(COLLECTION_NAME_1);
+    expect(col2!.schema.name).toEqual(COLLECTION_NAME_2);
+
+    col1!.schema.fields.forEach(f => {
+      expect(typeof f.dataType).toEqual('number');
+      expect(typeof f.data_type).toEqual('string');
+    });
+  });
+
+  it(`Batch describe with single collection should succeed`, async () => {
+    const res = await milvusClient.batchDescribeCollections({
+      collection_names: [COLLECTION_NAME_1],
+    });
+
+    expect(res.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(res.responses.length).toEqual(1);
+    expect(res.responses[0].collection_name).toEqual(COLLECTION_NAME_1);
+  });
+
+  it(`Batch describe with empty collection names should return error`, async () => {
+    const res = await milvusClient.batchDescribeCollections({
+      collection_names: [],
+    });
+
+    expect(res.status.error_code).not.toEqual(ErrorCode.SUCCESS);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `batchDescribeCollections()` method to describe multiple collections in a single gRPC call, wrapping the `BatchDescribeCollection` proto RPC
- Add `BatchDescribeCollectionReq` and `BatchDescribeCollectionResponse` types
- Each response in the batch is formatted with `formatDescribedCol`, consistent with `describeCollection()`

## Test plan
- [x] Batch describe multiple collections — verifies response count, schema names, and field formatting
- [x] Batch describe single collection — verifies normal operation
- [x] Empty collection names — verifies server returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)