### PR TITLE
fix(test): remove unnecessary reload after truncate

### DIFF
--- a/test/grpc/TruncateCollection.spec.ts
+++ b/test/grpc/TruncateCollection.spec.ts
@@ -71,15 +71,7 @@ describe(`TruncateCollection API`, () => {
     });
     expect(res.status.error_code).toEqual(ErrorCode.SUCCESS);
 
-    // need to reload after truncate to query
-    await milvusClient.releaseCollection({
-      collection_name: COLLECTION_NAME,
-    });
-    await milvusClient.loadCollectionSync({
-      collection_name: COLLECTION_NAME,
-    });
-
-    // verify data is gone
+    // collection should still be loaded after truncate, verify data is gone
     const count = await milvusClient.count({
       collection_name: COLLECTION_NAME,
     });


### PR DESCRIPTION
## Summary
- Remove redundant `releaseCollection` + `loadCollectionSync` calls in `TruncateCollection` test
- Truncate preserves collection load state: if loaded before truncate, it stays loaded after (confirmed by Milvus dev)

## Test plan
- [ ] Run `NODE_ENV=dev npx jest test/grpc/TruncateCollection.spec.ts` against a Milvus instance to verify the test passes without reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)