### PR TITLE
fix(database): align database properties support

### DIFF
--- a/milvus/grpc/Database.ts
+++ b/milvus/grpc/Database.ts
@@ -19,6 +19,7 @@ export class Database extends BaseClient {
    *
    * @param {CreateDatabaseRequest} data - The data for the new database.
    * @param {string} data.db_name - The name of the new database.
+   * @param {Object} [data.properties] - Optional database properties, such as { "database.resource_groups": "rg1" }.
    * @param {number} [data.timeout] - An optional duration of time in milliseconds to allow for the RPC. If it is set to undefined, the client keeps waiting until the server responds or error occurs. Default is undefined.
    *
    * @returns {Promise<ResStatus>} The response status of the operation.
@@ -28,7 +29,10 @@ export class Database extends BaseClient {
    * @example
    * ```
    *  const milvusClient = new milvusClient(MILUVS_ADDRESS);
-   *  const resStatus = await milvusClient.createDatabase({ db_name: 'new_db' });
+   *  const resStatus = await milvusClient.createDatabase({
+   *    db_name: 'new_db',
+   *    properties: { 'database.resource_groups': 'rg1' }
+   *  });
    * ```
    */
   async createDatabase(data: CreateDatabaseRequest): Promise<ResStatus> {
@@ -58,6 +62,9 @@ export class Database extends BaseClient {
    * @returns {Promise<ListDatabasesResponse>} The response from the server.
    * @returns {string} status.error_code - The error code of the operation.
    * @returns {string} status.reason - The reason for the error, if any.
+   * @returns {string[]} db_names - The names of databases.
+   * @returns {string[]} db_ids - The IDs of databases.
+   * @returns {string[]} created_timestamp - The created timestamps of databases.
    *
    * @example
    * ```
@@ -157,7 +164,8 @@ export class Database extends BaseClient {
    *
    * @param {AlterDatabaseRequest} data - The request parameters.
    * @param {string} data.db_name - The name of the database to modify.
-   * @param {Object} data.properties - The properties to modify. For example, to change the TTL, use {"database.replica.number": 18000}.
+   * @param {string} [data.db_id] - The ID of the database to modify.
+   * @param {Object} data.properties - The properties to modify. For example, use { "database.resource_groups": "rg1" } to set database resource groups.
    * @param {number} [data.timeout] - An optional duration of time in milliseconds to allow for the RPC. If it is set to undefined, the client keeps waiting until the server responds or error occurs. Default is undefined.
    *
    * @returns {Promise<ResStatus>} The response status of the operation.
@@ -168,8 +176,8 @@ export class Database extends BaseClient {
    * ```
    *  const milvusClient = new milvusClient(MILUVS_ADDRESS);
    *  const resStatus = await milvusClient.alterDatabase({
-   *    database: 'my-db',
-   *    properties: {"database.replica.number": 18000}
+   *    db_name: 'my-db',
+   *    properties: { 'database.resource_groups': 'rg1' }
    *  });
    * ```
    */
@@ -179,6 +187,7 @@ export class Database extends BaseClient {
       'AlterDatabase',
       {
         db_name: data.db_name,
+        db_id: data.db_id,
         properties: parseToKeyValue(data.properties),
       },
       data?.timeout || this.timeout

--- a/milvus/types/Database.ts
+++ b/milvus/types/Database.ts
@@ -17,6 +17,8 @@ export interface DescribeDatabaseRequest extends databaseReq {}
 export interface ListDatabasesRequest extends GrpcTimeOut {}
 export interface ListDatabasesResponse extends resStatusResponse {
   db_names: string[]; // database names
+  db_ids: string[]; // database ids
+  created_timestamp: string[]; // created timestamps
 }
 export interface DescribeDatabaseResponse extends resStatusResponse {
   db_name: string; // database name

--- a/milvus/types/Http.ts
+++ b/milvus/types/Http.ts
@@ -1,4 +1,5 @@
 import { FloatVector } from '..';
+import type { Properties } from './Collection';
 type Fetch = (input: any, init?: any) => Promise<any>;
 
 // Class types
@@ -157,6 +158,7 @@ export interface HttpCollectionDropPropertiesResponse extends HttpBaseResponse {
 
 export interface HttpDatabaseCreateReq {
   dbName: string;
+  properties?: Properties;
 }
 
 export interface HttpDatabaseDropReq {

--- a/test/grpc/Database.spec.ts
+++ b/test/grpc/Database.spec.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_DB,
   formatKeyValueData,
   findKeyValue,
+  ListDatabasesResponse,
 } from '../../milvus';
 import {
   IP,
@@ -12,7 +13,12 @@ import {
   generateInsertData,
 } from '../tools';
 
-let milvusClient = new MilvusClient({ address: IP, logLevel: 'info' });
+let milvusClient = new MilvusClient({
+  address: IP,
+  logLevel: 'info',
+  username: process.env.MILVUS_USERNAME || 'root',
+  password: process.env.MILVUS_PASSWORD || 'Milvus',
+});
 const DEFAULT = 'default';
 const DB_NAME = GENERATE_NAME('database');
 const DB_NAME2 = GENERATE_NAME('database');
@@ -65,14 +71,27 @@ describe(`Database API`, () => {
 
   it(`using database with address should be ok`, async () => {
     // use another client with db
-    const newClient = new MilvusClient({ address: IP, database: DB_NAME });
+    const newClient = new MilvusClient({
+      address: IP,
+      database: DB_NAME,
+      username: process.env.MILVUS_USERNAME || 'root',
+      password: process.env.MILVUS_PASSWORD || 'Milvus',
+      __SKIP_CONNECT__: true,
+    });
     expect(newClient.config.database).toEqual(DB_NAME);
   });
 
   it(`ListDatabases should be ok`, async () => {
-    const allDatabases = await milvusClient.listDatabases();
+    const allDatabases: ListDatabasesResponse =
+      await milvusClient.listDatabases();
     expect(allDatabases.status.error_code).toEqual(ErrorCode.SUCCESS);
     expect(allDatabases.db_names.length).toBeGreaterThan(1);
+    expect(allDatabases.db_ids.length).toEqual(allDatabases.db_names.length);
+    expect(allDatabases.created_timestamp.length).toEqual(
+      allDatabases.db_names.length
+    );
+    expect(typeof allDatabases.db_ids[0]).toEqual('string');
+    expect(typeof allDatabases.created_timestamp[0]).toEqual('string');
   });
 
   it(`describe database should be ok`, async () => {
@@ -363,6 +382,20 @@ describe(`Database API`, () => {
     expect(describe.properties).toEqual([
       { key: 'database.diskQuota.mb', value: '2048' },
     ]);
+
+    const alterById = await milvusClient.alterDatabase({
+      db_name: DB_NAME2,
+      db_id: String(describe.dbID),
+      properties: { 'database.diskQuota.mb': 4096 },
+    });
+    expect(alterById.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const describeAfterAlterById = await milvusClient.describeDatabase({
+      db_name: DB_NAME2,
+    });
+    expect(describeAfterAlterById.properties).toEqual([
+      { key: 'database.diskQuota.mb', value: '4096' },
+    ]);
   });
 
   it(`drop database properties should be ok`, async () => {
@@ -379,30 +412,31 @@ describe(`Database API`, () => {
   });
 
   it(`create db with property set should be successful`, async () => {
-    const res = await milvusClient.createDatabase({
-      db_name: DB_WITH_PROPERTY,
-      properties: {
-        'replicate.id': 'local-mac',
-      },
-    });
-    expect(res.error_code).toEqual(ErrorCode.SUCCESS);
+    try {
+      const res = await milvusClient.createDatabase({
+        db_name: DB_WITH_PROPERTY,
+        properties: {
+          'replicate.id': 'local-mac',
+        },
+      });
+      expect(res.error_code).toEqual(ErrorCode.SUCCESS);
 
-    const describe = await milvusClient.describeDatabase({
-      db_name: DB_WITH_PROPERTY,
-    });
+      const describe = await milvusClient.describeDatabase({
+        db_name: DB_WITH_PROPERTY,
+      });
 
-    expect(
-      String(
-        formatKeyValueData(describe.properties, ['replicate.id'])[
-          'replicate.id'
-        ]
-      )
-    ).toEqual('local-mac');
-
-    // drop collection
-    await milvusClient.dropDatabase({
-      db_name: DB_WITH_PROPERTY,
-    });
+      expect(
+        String(
+          formatKeyValueData(describe.properties, ['replicate.id'])[
+            'replicate.id'
+          ]
+        )
+      ).toEqual('local-mac');
+    } finally {
+      await milvusClient.dropDatabase({
+        db_name: DB_WITH_PROPERTY,
+      });
+    }
   });
 
   // it(`drop database should be ok`, async () => {


### PR DESCRIPTION
## Summary
- Expose proto-backed database list metadata fields (`db_ids`, `created_timestamp`) with string long handling.
- Pass `db_id` through `alterDatabase` and document database properties/resource group usage.
- Allow HTTP create database requests to include database `properties` and extend database integration coverage.

## Test plan
- [x] NODE_ENV=dev npx jest test/grpc/Database.spec.ts --runInBand
- [x] yarn build

🤖 Generated with [Claude Code](https://claude.com/claude-code)