### PR TITLE
feat(client): pass connect reserved options

### DIFF
--- a/milvus/grpc/GrpcClient.ts
+++ b/milvus/grpc/GrpcClient.ts
@@ -397,6 +397,7 @@ export class GRPCClient extends User {
         sdk_version: sdkVersion,
         local_time: dayjs().format(`YYYY-MM-DD HH:mm:ss.SSS`),
         user: this.config.username,
+        reserved: this.config.option || {},
       },
     };
 

--- a/milvus/types/Client.ts
+++ b/milvus/types/Client.ts
@@ -21,6 +21,8 @@ export interface ClientConfig {
   password?: string;
   // Additional options to pass to the gRPC channel.
   channelOptions?: ChannelOptions;
+  // Reserved connection options sent in ConnectRequest client info.
+  option?: Record<string, string>;
   // The timeout for requests, in milliseconds.
   timeout?: number | string;
   // number of retries

--- a/test/utils/GlobalConnection.spec.ts
+++ b/test/utils/GlobalConnection.spec.ts
@@ -243,6 +243,63 @@ describe('Global connection lifecycle', () => {
     client.topologyRefresher?.stop();
   });
 
+  it('should pass client option values to Connect reserved fields', async () => {
+    let capturedConnectRequest: any;
+    const client = new MilvusClient({
+      address: 'localhost:19530',
+      token: 'test-token',
+      option: { cluster_id: 'cluster-a' },
+      __SKIP_CONNECT__: true,
+    });
+    client.channelPool = {
+      acquire: jest.fn().mockResolvedValue({
+        Connect: (request: any, _options: any, callback: Function) => {
+          capturedConnectRequest = request;
+          callback(null, { identifier: 'client-1', server_info: {} });
+        },
+      }),
+      release: jest.fn(),
+    } as any;
+
+    await (client as any)._getServerInfo('test-version');
+
+    expect(capturedConnectRequest.client_info.reserved).toEqual({
+      cluster_id: 'cluster-a',
+    });
+  });
+
+  it('should pass client option values to Connect reserved fields after global init', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(validTopologyResponse),
+    }) as any;
+
+    let capturedConnectRequest: any;
+    const client = new MilvusClient({
+      address: 'https://glo-xxx.global-cluster.xyz',
+      token: 'test-token',
+      option: { cluster_id: 'cluster-a' },
+      __SKIP_CONNECT__: true,
+    });
+    (client as any).createChannelPool = jest.fn(() => ({
+      acquire: jest.fn().mockResolvedValue({
+        Connect: (request: any, _options: any, callback: Function) => {
+          capturedConnectRequest = request;
+          callback(null, { identifier: 'client-1', server_info: {} });
+        },
+      }),
+      release: jest.fn(),
+    }));
+
+    await (client as any)._initGlobalConnection('test-version');
+
+    expect(client.config.address).toBe('primary-host:19530');
+    expect(capturedConnectRequest.client_info.reserved).toEqual({
+      cluster_id: 'cluster-a',
+    });
+    client.topologyRefresher?.stop();
+  });
+
   it('should reconnect when primary changes', async () => {
     let fetchCount = 0;
     global.fetch = jest.fn().mockImplementation(() => {


### PR DESCRIPTION
## Summary
- Add `ClientConfig.option` for pymilvus-style connection reserved values such as `cluster_id`.
- Forward option values into `ConnectRequest.client_info.reserved` during gRPC connection setup.
- Cover both regular and global cluster connect paths without requiring a real Lakebase cluster.

## Test plan
- [x] npx jest test/utils/GlobalConnection.spec.ts --runInBand --silent
- [x] yarn build

🤖 Generated with [Claude Code](https://claude.com/claude-code)