### PR TITLE
feat: support external collections

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,9 @@ jobs:
                 MILVUS_OPENAI_API_KEY: ${MILVUS_OPENAI_API_KEY}
           EOF
 
+          mkdir -p volumes/etcd volumes/minio volumes/milvus
+          chmod -R 777 volumes
+
           docker compose -f docker-compose.yml -f docker-compose.override.yml up -d
           docker compose -f docker-compose.yml -f docker-compose.override.yml ps
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,18 @@ jobs:
             sleep 2
           done
 
+      - name: Wait for Milvus to be ready
+        run: |
+          echo "Waiting for Milvus..."
+          for i in $(seq 1 90); do
+            if curl -sf http://localhost:9091/healthz > /dev/null 2>&1; then
+              echo "Milvus is ready"
+              break
+            fi
+            echo "Attempt $i/90..."
+            sleep 2
+          done
+
       - name: Install dependencies
         run: yarn
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
           services:
             standalone:
               environment:
+                MQ_TYPE: rocksmq
                 MILVUS_OPENAI_API_KEY: ${MILVUS_OPENAI_API_KEY}
           EOF
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,7 @@ jobs:
           EOF
 
           docker compose -f docker-compose.yml -f docker-compose.override.yml up -d
+          docker compose -f docker-compose.yml -f docker-compose.override.yml ps
 
       - name: Wait for MinIO to be ready
         run: |
@@ -63,23 +64,42 @@ jobs:
           for i in $(seq 1 30); do
             if curl -sf http://localhost:9000/minio/health/live > /dev/null 2>&1; then
               echo "MinIO is ready"
-              break
+              exit 0
             fi
             echo "Attempt $i/30..."
             sleep 2
           done
+          echo "MinIO did not become ready"
+          docker compose -f docker-compose.yml -f docker-compose.override.yml ps
+          docker logs milvus-minio
+          exit 1
 
       - name: Wait for Milvus to be ready
         run: |
           echo "Waiting for Milvus..."
           for i in $(seq 1 90); do
-            if curl -sf http://localhost:9091/healthz > /dev/null 2>&1; then
+            if curl -sf http://localhost:9091/healthz > /dev/null 2>&1 && timeout 1 bash -c '</dev/tcp/127.0.0.1/19530' > /dev/null 2>&1; then
               echo "Milvus is ready"
-              break
+              exit 0
             fi
             echo "Attempt $i/90..."
+            if [ $((i % 10)) -eq 0 ]; then
+              docker compose -f docker-compose.yml -f docker-compose.override.yml ps
+            fi
             sleep 2
           done
+          echo "Milvus did not become ready"
+          docker compose -f docker-compose.yml -f docker-compose.override.yml ps
+          docker logs milvus-standalone
+          exit 1
+
+      - name: Dump Milvus logs on failure
+        if: failure()
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.override.yml ps
+          docker logs milvus-standalone
+          docker logs milvus-etcd
+          docker logs milvus-minio
 
       - name: Install dependencies
         run: yarn

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "proto"]
 	path = proto
 	url = https://github.com/milvus-io/milvus-proto.git
-	branch = 2.6
+	branch = 3.0

--- a/3.0_change.md
+++ b/3.0_change.md
@@ -1,0 +1,418 @@
+# Milvus Proto 3.0 Changes
+
+This notes the main changes after updating the `proto` submodule from:
+
+```text
+882e58722273dc27b37b11a20de5b4592fe02da9
+```
+
+to:
+
+```text
+966f06209e2b02700aacd50a337623ac69e6559b
+```
+
+## Summary
+
+The 3.0 proto update adds external collection support, snapshot APIs, collection schema alteration APIs, client telemetry APIs, molecular data support, partial array upsert operations, and element-level query/search result metadata.
+
+Generated proto JSON files changed substantially:
+
+```text
+milvus/proto-json/milvus.base.ts | 2241 +++++++++++++++++++++++++++++++++++---
+milvus/proto-json/milvus.ts      | 2241 +++++++++++++++++++++++++++++++++++---
+milvus/proto-json/schema.base.ts |  906 ++++++++++++++-
+```
+
+## Go Package Path
+
+Proto `go_package` paths moved from v2 to v3:
+
+```text
+github.com/milvus-io/milvus-proto/go-api/v2/...
+```
+
+to:
+
+```text
+github.com/milvus-io/milvus-proto/go-api/v3/...
+```
+
+This does not directly affect Node SDK runtime behavior, but it indicates the proto line is now Milvus 3.0.
+
+## External Collection
+
+`schema.proto` adds external collection fields:
+
+```proto
+message FieldSchema {
+  string external_field = 17;
+}
+
+message CollectionSchema {
+  string external_source = 11;
+  string external_spec = 12;
+  bool do_physical_backfill = 13;
+  repeated int64 file_resource_ids = 14;
+}
+```
+
+`milvus.proto` adds refresh APIs:
+
+```proto
+rpc RefreshExternalCollection(RefreshExternalCollectionRequest) returns (RefreshExternalCollectionResponse) {}
+rpc GetRefreshExternalCollectionProgress(GetRefreshExternalCollectionProgressRequest) returns (GetRefreshExternalCollectionProgressResponse) {}
+rpc ListRefreshExternalCollectionJobs(ListRefreshExternalCollectionJobsRequest) returns (ListRefreshExternalCollectionJobsResponse) {}
+```
+
+Request fields:
+
+```proto
+message RefreshExternalCollectionRequest {
+  string db_name = 2;
+  string collection_name = 3;
+  string external_source = 4;
+  string external_spec = 5;
+}
+```
+
+Node SDK impact:
+
+```text
+milvus/types/Collection.ts
+  - Add external_source and external_spec to create collection request/schema types.
+  - Add external_field to FieldType and returned FieldSchema.
+  - Add do_physical_backfill and file_resource_ids if exposing full 3.0 schema features.
+
+milvus/utils/Schema.ts
+  - Pass external_field in formatFieldSchema().
+  - Pass external_source, external_spec, do_physical_backfill, and file_resource_ids in formatCollectionSchema().
+
+milvus/grpc/Collection.ts
+  - Add wrappers for refreshExternalCollection().
+  - Add wrappers for getRefreshExternalCollectionProgress().
+  - Add wrappers for listRefreshExternalCollectionJobs().
+```
+
+## Molecular Data
+
+`schema.proto` adds a new data type:
+
+```proto
+enum DataType {
+  Mol = 27;
+}
+```
+
+It also adds molecular function types:
+
+```proto
+enum FunctionType {
+  MinHash = 4;
+  MolFingerprint = 5;
+}
+```
+
+Scalar field payloads add molecular arrays:
+
+```proto
+message MolArray { repeated bytes data = 1; }
+message MolSmilesArray { repeated string data = 1; }
+
+message ScalarField {
+  MolArray mol_data = 13;
+  MolSmilesArray mol_smiles_data = 14;
+}
+```
+
+Node SDK impact:
+
+```text
+milvus/const/milvus.ts or DataType exports
+  - Add DataType.Mol.
+
+Data formatting/parsing utilities
+  - Add insert/upsert/query/search handling for mol_data and mol_smiles_data.
+  - Add value decoding for Mol fields in query/search results.
+
+Function support
+  - Add MinHash and MolFingerprint enum values where FunctionType is exposed.
+```
+
+## Partial Array Upsert
+
+`schema.proto` adds per-field partial update operations:
+
+```proto
+message FieldPartialUpdateOp {
+  enum OpType {
+    REPLACE = 0;
+    ARRAY_APPEND = 1;
+    ARRAY_REMOVE = 2;
+  }
+
+  string field_name = 1;
+  OpType op = 2;
+}
+```
+
+`milvus.proto` adds the operations to `UpsertRequest`:
+
+```proto
+message UpsertRequest {
+  repeated schema.FieldPartialUpdateOp field_ops = 11;
+}
+```
+
+Node SDK impact:
+
+```text
+milvus/types/Data.ts or upsert request types
+  - Add field_ops support.
+  - Expose op values REPLACE, ARRAY_APPEND, ARRAY_REMOVE.
+
+milvus/grpc/Data.ts and request preparation logic
+  - Pass field_ops through to UpsertRequest.
+```
+
+## Element-Level Query/Search
+
+`common.proto` adds element-level placeholder support:
+
+```proto
+message PlaceholderValue {
+  bool element_level = 4;
+}
+```
+
+`milvus.proto` adds element indices for query results:
+
+```proto
+message ElementIndices {
+  schema.LongArray indices = 1;
+}
+
+message QueryResults {
+  repeated ElementIndices element_indices = 7;
+}
+```
+
+`schema.proto` adds element and group-by metadata to search results:
+
+```proto
+message SearchResultData {
+  LongArray element_indices = 15;
+  reserved 16;
+  repeated FieldData group_by_field_values = 17;
+}
+```
+
+Node SDK impact:
+
+```text
+milvus/utils/Search.ts and result formatting
+  - Parse element_indices from query/search results.
+  - Parse group_by_field_values from SearchResultData.
+  - Ensure old order_by field handling does not conflict with reserved field 16.
+```
+
+## Snapshot APIs
+
+`milvus.proto` adds snapshot management APIs:
+
+```proto
+rpc CreateSnapshot(CreateSnapshotRequest) returns (common.Status) {}
+rpc DropSnapshot(DropSnapshotRequest) returns (common.Status) {}
+rpc ListSnapshots(ListSnapshotsRequest) returns (ListSnapshotsResponse) {}
+rpc DescribeSnapshot(DescribeSnapshotRequest) returns (DescribeSnapshotResponse) {}
+rpc RestoreSnapshot(RestoreSnapshotRequest) returns (RestoreSnapshotResponse) {}
+rpc GetRestoreSnapshotState(GetRestoreSnapshotStateRequest) returns (GetRestoreSnapshotStateResponse) {}
+rpc ListRestoreSnapshotJobs(ListRestoreSnapshotJobsRequest) returns (ListRestoreSnapshotJobsResponse) {}
+rpc PinSnapshotData(PinSnapshotDataRequest) returns (PinSnapshotDataResponse) {}
+rpc UnpinSnapshotData(UnpinSnapshotDataRequest) returns (common.Status) {}
+```
+
+`common.proto` adds related privileges:
+
+```proto
+PrivilegeCreateSnapshot = 79;
+PrivilegeDropSnapshot = 80;
+PrivilegeDescribeSnapshot = 81;
+PrivilegeListSnapshots = 82;
+PrivilegeRestoreSnapshot = 83;
+PrivilegePinSnapshotData = 87;
+PrivilegeUnpinSnapshotData = 88;
+```
+
+Node SDK impact:
+
+```text
+milvus/grpc/Collection.ts or a new Snapshot module
+  - Add client methods for all snapshot RPCs.
+
+milvus/types
+  - Add request and response types for snapshot operations.
+```
+
+## Alter Collection Schema
+
+`milvus.proto` adds schema alteration:
+
+```proto
+rpc AlterCollectionSchema(AlterCollectionSchemaRequest) returns (AlterCollectionSchemaResponse) {}
+```
+
+It supports adding fields/functions and dropping fields/functions:
+
+```proto
+message AlterCollectionSchemaRequest {
+  message AddRequest {
+    repeated FieldInfo field_infos = 1;
+    repeated schema.FunctionSchema func_schema = 2;
+    bool do_physical_backfill = 3;
+  }
+
+  message DropRequest {
+    oneof identifier {
+      string field_name = 1;
+      int64 field_id = 2;
+      string function_name = 3;
+    }
+  }
+}
+```
+
+Node SDK impact:
+
+```text
+Existing add field/function APIs may need to move to or additionally support AlterCollectionSchema.
+Expose do_physical_backfill for field additions.
+Expose drop function through AlterCollectionSchema.DropRequest.function_name.
+```
+
+## Client Telemetry
+
+`milvus.proto` adds a new service:
+
+```proto
+service ClientTelemetryService {
+  rpc ClientHeartbeat(ClientHeartbeatRequest) returns (ClientHeartbeatResponse) {}
+  rpc GetClientTelemetry(GetClientTelemetryRequest) returns (GetClientTelemetryResponse) {}
+  rpc PushClientCommand(PushClientCommandRequest) returns (PushClientCommandResponse) {}
+  rpc DeleteClientCommand(DeleteClientCommandRequest) returns (DeleteClientCommandResponse) {}
+}
+```
+
+`common.proto` adds telemetry structures:
+
+```proto
+message Metrics
+message OperationMetrics
+message ClientCommand
+message CommandReply
+```
+
+Node SDK impact:
+
+```text
+This likely requires a new telemetry client/channel wrapper if Node SDK plans to expose the telemetry service.
+```
+
+## Replicate API Deprecation
+
+Legacy CDC/replicate fields are marked deprecated:
+
+```proto
+rpc ReplicateMessage(...) {
+  option deprecated = true;
+}
+
+Replicate = 1212 [deprecated = true];
+ReplicateInfo replicateInfo = 7 [deprecated = true];
+message ReplicateMsg { option deprecated = true; }
+```
+
+Node SDK impact:
+
+```text
+No immediate runtime change unless these APIs are exposed.
+If exposed, mark them deprecated in TypeScript docs/types.
+```
+
+## Data Salvage and WAL Dump
+
+`milvus.proto` adds WAL dump APIs:
+
+```proto
+rpc DumpMessages(DumpMessagesRequest) returns (stream DumpMessagesResponse) {}
+```
+
+`GetReplicateInfoResponse` now has:
+
+```proto
+common.ReplicateCheckpoint salvage_checkpoint = 2;
+```
+
+Node SDK impact:
+
+```text
+Expose only if Node SDK needs admin/data salvage functionality.
+This is a streaming API and may need extra gRPC handling.
+```
+
+## Compute Phrase Match Slop
+
+`milvus.proto` adds:
+
+```proto
+rpc ComputePhraseMatchSlop(ComputePhraseMatchSlopRequest) returns (ComputePhraseMatchSlopResponse) {}
+```
+
+Node SDK impact:
+
+```text
+Expose if text analyzer utilities need phrase match slop computation.
+```
+
+## Batch Update Manifest
+
+`milvus.proto` adds:
+
+```proto
+rpc BatchUpdateManifest(BatchUpdateManifestRequest) returns (common.Status) {}
+```
+
+Node SDK impact:
+
+```text
+Likely internal/admin functionality unless explicitly needed by Node SDK users.
+```
+
+## Struct Array Nullable
+
+`schema.proto` adds nullable support for struct array fields:
+
+```proto
+message StructArrayFieldSchema {
+  bool nullable = 6;
+}
+```
+
+Node SDK impact:
+
+```text
+Add nullable handling for struct array field schemas if not already supported.
+```
+
+## Suggested Node SDK Implementation Order
+
+1. External collection schema fields:
+   `external_source`, `external_spec`, `external_field`.
+2. External collection refresh APIs.
+3. DataType and FunctionType enum updates:
+   `Mol`, `MinHash`, `MolFingerprint`.
+4. Query/search result parser updates:
+   `element_indices`, `group_by_field_values`.
+5. Partial upsert `field_ops`.
+6. Snapshot APIs and AlterCollectionSchema APIs.
+7. ClientTelemetryService and WAL dump APIs if product requirements need them.

--- a/milvus/const/error.ts
+++ b/milvus/const/error.ts
@@ -19,6 +19,10 @@ export const ERROR_REASONS = {
     'The `max_length` property is missing',
   CREATE_COLLECTION_CHECK_BINARY_DIM:
     'The `dim` property of the Binary vector should be value multiples of 8.',
+  CREATE_EXTERNAL_COLLECTION_AUTO_ID:
+    'External collections do not support auto_id.',
+  CREATE_EXTERNAL_COLLECTION_PRIMARY_KEY:
+    'External collections do not support primary key.',
   COLLECTION_NAME_IS_REQUIRED: 'The `collection_name` property is missing.',
   COLLECTION_ID_IS_REQUIRED: 'The `collectionID` property is missing.',
   COLLECTION_PARTITION_NAME_ARE_REQUIRED:
@@ -62,7 +66,8 @@ export const ERROR_REASONS = {
     'Only non-primary key Int64 or VarChar field support partition key.',
   PARTITION_KEY_FIELD_MAXED_OUT: `Only ${MAX_PARTITION_KEY_FIELD_COUNT} field supports partition key. `,
   IDS_REQUIRED: 'The `ids` is missing or empty.',
-  NO_ANNS_FEILD_FOUND_IN_SEARCH: 'Target anns field not found, please check your search parameters.',
+  NO_ANNS_FEILD_FOUND_IN_SEARCH:
+    'Target anns field not found, please check your search parameters.',
   FUNCTION_SCHEMA_IS_REQUIRED: 'The `function` property is missing.',
   FUNCTION_NAME_IS_REQUIRED: 'The `function_name` property is missing.',
 };

--- a/milvus/grpc/Collection.ts
+++ b/milvus/grpc/Collection.ts
@@ -43,7 +43,6 @@ import {
   ListAliasesResponse,
   promisify,
   formatKeyValueData,
-  checkCollectionFields,
   checkCollectionName,
   sleep,
   formatCollectionSchema,
@@ -62,11 +61,18 @@ import {
   isVectorType,
   AddCollectionFieldReq,
   AddCollectionFieldsReq,
+  checkCollectionFieldsWithOptions,
   formatFieldSchema,
   formatFunctionSchema,
   AddCollectionFunctionReq,
   AlterCollectionFunctionReq,
   DropCollectionFunctionReq,
+  RefreshExternalCollectionReq,
+  RefreshExternalCollectionResponse,
+  GetRefreshExternalCollectionProgressReq,
+  GetRefreshExternalCollectionProgressResponse,
+  ListRefreshExternalCollectionJobsReq,
+  ListRefreshExternalCollectionJobsResponse,
 } from '../';
 
 /**
@@ -150,8 +156,19 @@ export class Collection extends Database {
       throw new Error(ERROR_REASONS.CREATE_COLLECTION_CHECK_PARAMS);
     }
 
+    const isExternalCollection = !!data.external_source;
+    if (
+      isExternalCollection &&
+      ('auto_id' in data || fields.some(field => field.autoID))
+    ) {
+      throw new Error(ERROR_REASONS.CREATE_EXTERNAL_COLLECTION_AUTO_ID);
+    }
+    if (isExternalCollection && fields.some(field => field.is_primary_key)) {
+      throw new Error(ERROR_REASONS.CREATE_EXTERNAL_COLLECTION_PRIMARY_KEY);
+    }
+
     // Check if the fields are valid.
-    checkCollectionFields(fields);
+    checkCollectionFieldsWithOptions(fields, { isExternalCollection });
 
     // if num_partitions is set, validate it
     if (typeof num_partitions !== 'undefined') {
@@ -670,10 +687,7 @@ export class Collection extends Database {
       data.timeout || this.timeout
     );
 
-    if (
-      promise.status.error_code !== ErrorCode.SUCCESS ||
-      !promise.responses
-    ) {
+    if (promise.status.error_code !== ErrorCode.SUCCESS || !promise.responses) {
       return promise;
     }
 
@@ -1662,6 +1676,76 @@ export class Collection extends Database {
       this.channelPool,
       'DropCollectionFunction',
       req,
+      data.timeout || this.timeout
+    );
+  }
+
+  /**
+   * Trigger a data refresh for an external collection.
+   *
+   * @param {RefreshExternalCollectionReq} data - The request parameters.
+   * @param {string} data.collection_name - The external collection to refresh.
+   * @param {string} [data.external_source] - Optional new external source path.
+   * @param {string} [data.external_spec] - Optional new external spec configuration.
+   * @param {string} [data.db_name] - The database name.
+   * @param {number} [data.timeout] - An optional duration of time in milliseconds to allow for the RPC.
+   *
+   * @returns {Promise<RefreshExternalCollectionResponse>} The refresh job response.
+   */
+  async refreshExternalCollection(
+    data: RefreshExternalCollectionReq
+  ): Promise<RefreshExternalCollectionResponse> {
+    checkCollectionName(data);
+
+    return await promisify(
+      this.channelPool,
+      'RefreshExternalCollection',
+      data,
+      data.timeout || this.timeout
+    );
+  }
+
+  /**
+   * Get the progress of an external collection refresh job.
+   *
+   * @param {GetRefreshExternalCollectionProgressReq} data - The request parameters.
+   * @param {number|string} data.job_id - The job ID returned by refreshExternalCollection().
+   * @param {number} [data.timeout] - An optional duration of time in milliseconds to allow for the RPC.
+   *
+   * @returns {Promise<GetRefreshExternalCollectionProgressResponse>} The refresh job progress response.
+   */
+  async getRefreshExternalCollectionProgress(
+    data: GetRefreshExternalCollectionProgressReq
+  ): Promise<GetRefreshExternalCollectionProgressResponse> {
+    if (!data || typeof data.job_id === 'undefined') {
+      throw new Error('The `job_id` property is missing.');
+    }
+
+    return await promisify(
+      this.channelPool,
+      'GetRefreshExternalCollectionProgress',
+      data,
+      data.timeout || this.timeout
+    );
+  }
+
+  /**
+   * List external collection refresh jobs.
+   *
+   * @param {ListRefreshExternalCollectionJobsReq} data - The request parameters.
+   * @param {string} [data.collection_name] - Optional collection name filter.
+   * @param {string} [data.db_name] - Optional database name filter.
+   * @param {number} [data.timeout] - An optional duration of time in milliseconds to allow for the RPC.
+   *
+   * @returns {Promise<ListRefreshExternalCollectionJobsResponse>} The refresh jobs response.
+   */
+  async listRefreshExternalCollectionJobs(
+    data: ListRefreshExternalCollectionJobsReq = {}
+  ): Promise<ListRefreshExternalCollectionJobsResponse> {
+    return await promisify(
+      this.channelPool,
+      'ListRefreshExternalCollectionJobs',
+      data,
       data.timeout || this.timeout
     );
   }

--- a/milvus/proto-json/milvus.base.ts
+++ b/milvus/proto-json/milvus.base.ts
@@ -6,7 +6,7 @@ export default {
           "nested": {
             "milvus": {
               "options": {
-                "go_package": "github.com/milvus-io/milvus-proto/go-api/v2/milvuspb",
+                "go_package": "github.com/milvus-io/milvus-proto/go-api/v3/milvuspb",
                 "java_multiple_files": true,
                 "java_package": "io.milvus.grpc",
                 "java_outer_classname": "MilvusProto",
@@ -406,7 +406,15 @@ export default {
                     },
                     "ReplicateMessage": {
                       "requestType": "ReplicateMessageRequest",
-                      "responseType": "ReplicateMessageResponse"
+                      "responseType": "ReplicateMessageResponse",
+                      "options": {
+                        "deprecated": true
+                      },
+                      "parsedOptions": [
+                        {
+                          "deprecated": true
+                        }
+                      ]
                     },
                     "BackupRBAC": {
                       "requestType": "BackupRBACMetaRequest",
@@ -493,6 +501,91 @@ export default {
                       "requestStream": true,
                       "responseType": "ReplicateResponse",
                       "responseStream": true
+                    },
+                    "DumpMessages": {
+                      "requestType": "DumpMessagesRequest",
+                      "responseType": "DumpMessagesResponse",
+                      "responseStream": true
+                    },
+                    "ComputePhraseMatchSlop": {
+                      "requestType": "ComputePhraseMatchSlopRequest",
+                      "responseType": "ComputePhraseMatchSlopResponse"
+                    },
+                    "CreateSnapshot": {
+                      "requestType": "CreateSnapshotRequest",
+                      "responseType": "common.Status"
+                    },
+                    "DropSnapshot": {
+                      "requestType": "DropSnapshotRequest",
+                      "responseType": "common.Status"
+                    },
+                    "ListSnapshots": {
+                      "requestType": "ListSnapshotsRequest",
+                      "responseType": "ListSnapshotsResponse"
+                    },
+                    "DescribeSnapshot": {
+                      "requestType": "DescribeSnapshotRequest",
+                      "responseType": "DescribeSnapshotResponse"
+                    },
+                    "RestoreSnapshot": {
+                      "requestType": "RestoreSnapshotRequest",
+                      "responseType": "RestoreSnapshotResponse"
+                    },
+                    "GetRestoreSnapshotState": {
+                      "requestType": "GetRestoreSnapshotStateRequest",
+                      "responseType": "GetRestoreSnapshotStateResponse"
+                    },
+                    "ListRestoreSnapshotJobs": {
+                      "requestType": "ListRestoreSnapshotJobsRequest",
+                      "responseType": "ListRestoreSnapshotJobsResponse"
+                    },
+                    "PinSnapshotData": {
+                      "requestType": "PinSnapshotDataRequest",
+                      "responseType": "PinSnapshotDataResponse"
+                    },
+                    "UnpinSnapshotData": {
+                      "requestType": "UnpinSnapshotDataRequest",
+                      "responseType": "common.Status"
+                    },
+                    "AlterCollectionSchema": {
+                      "requestType": "AlterCollectionSchemaRequest",
+                      "responseType": "AlterCollectionSchemaResponse"
+                    },
+                    "BatchUpdateManifest": {
+                      "requestType": "BatchUpdateManifestRequest",
+                      "responseType": "common.Status"
+                    },
+                    "RefreshExternalCollection": {
+                      "requestType": "RefreshExternalCollectionRequest",
+                      "responseType": "RefreshExternalCollectionResponse"
+                    },
+                    "GetRefreshExternalCollectionProgress": {
+                      "requestType": "GetRefreshExternalCollectionProgressRequest",
+                      "responseType": "GetRefreshExternalCollectionProgressResponse"
+                    },
+                    "ListRefreshExternalCollectionJobs": {
+                      "requestType": "ListRefreshExternalCollectionJobsRequest",
+                      "responseType": "ListRefreshExternalCollectionJobsResponse"
+                    }
+                  }
+                },
+                "ClientTelemetryService": {
+                  "methods": {
+                    "ClientHeartbeat": {
+                      "requestType": "ClientHeartbeatRequest",
+                      "responseType": "ClientHeartbeatResponse"
+                    },
+                    "GetClientTelemetry": {
+                      "requestType": "GetClientTelemetryRequest",
+                      "responseType": "GetClientTelemetryResponse"
+                    },
+                    "PushClientCommand": {
+                      "requestType": "PushClientCommandRequest",
+                      "responseType": "PushClientCommandResponse"
+                    },
+                    "DeleteClientCommand": {
+                      "requestType": "DeleteClientCommandRequest",
+                      "responseType": "DeleteClientCommandResponse"
                     }
                   }
                 },
@@ -2053,6 +2146,11 @@ export default {
                       "options": {
                         "proto3_optional": true
                       }
+                    },
+                    "fieldOps": {
+                      "rule": "repeated",
+                      "type": "schema.FieldPartialUpdateOp",
+                      "id": 11
                     }
                   }
                 },
@@ -2562,6 +2660,14 @@ export default {
                     }
                   }
                 },
+                "ElementIndices": {
+                  "fields": {
+                    "indices": {
+                      "type": "schema.LongArray",
+                      "id": 1
+                    }
+                  }
+                },
                 "QueryResults": {
                   "fields": {
                     "status": {
@@ -2589,6 +2695,11 @@ export default {
                     "primaryFieldName": {
                       "type": "string",
                       "id": 6
+                    },
+                    "elementIndices": {
+                      "rule": "repeated",
+                      "type": "ElementIndices",
+                      "id": 7
                     }
                   }
                 },
@@ -4857,6 +4968,9 @@ export default {
                   }
                 },
                 "ReplicateMessageRequest": {
+                  "options": {
+                    "deprecated": true
+                  },
                   "fields": {
                     "base": {
                       "type": "common.MsgBase",
@@ -4892,6 +5006,9 @@ export default {
                   }
                 },
                 "ReplicateMessageResponse": {
+                  "options": {
+                    "deprecated": true
+                  },
                   "fields": {
                     "status": {
                       "type": "common.Status",
@@ -5445,6 +5562,10 @@ export default {
                     "checkpoint": {
                       "type": "common.ReplicateCheckpoint",
                       "id": 1
+                    },
+                    "salvageCheckpoint": {
+                      "type": "common.ReplicateCheckpoint",
+                      "id": 2
                     }
                   }
                 },
@@ -5498,6 +5619,46 @@ export default {
                     }
                   }
                 },
+                "DumpMessagesRequest": {
+                  "fields": {
+                    "pchannel": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "startMessageId": {
+                      "type": "common.MessageID",
+                      "id": 2
+                    },
+                    "startTimetick": {
+                      "type": "uint64",
+                      "id": 3
+                    },
+                    "endTimetick": {
+                      "type": "uint64",
+                      "id": 4
+                    }
+                  }
+                },
+                "DumpMessagesResponse": {
+                  "oneofs": {
+                    "response": {
+                      "oneof": [
+                        "status",
+                        "message"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "message": {
+                      "type": "common.ImmutableMessage",
+                      "id": 2
+                    }
+                  }
+                },
                 "TruncateCollectionRequest": {
                   "options": {
                     "(common.privilege_ext_obj).object_type": "Global",
@@ -5526,12 +5687,881 @@ export default {
                       "id": 1
                     }
                   }
+                },
+                "ComputePhraseMatchSlopRequest": {
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "analyzerParams": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "queryText": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "dataTexts": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 4
+                    }
+                  }
+                },
+                "ComputePhraseMatchSlopResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "isMatch": {
+                      "rule": "repeated",
+                      "type": "bool",
+                      "id": 2
+                    },
+                    "slops": {
+                      "rule": "repeated",
+                      "type": "int64",
+                      "id": 3
+                    }
+                  }
+                },
+                "CreateSnapshotRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeCreateSnapshot",
+                    "(common.privilege_ext_obj).object_name_index": 5
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "description": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "dbName": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "collectionName": {
+                      "type": "string",
+                      "id": 5
+                    },
+                    "compactionProtectionSeconds": {
+                      "type": "int64",
+                      "id": 6
+                    }
+                  }
+                },
+                "DropSnapshotRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeDropSnapshot",
+                    "(common.privilege_ext_obj).object_name_index": 4
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "dbName": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collectionName": {
+                      "type": "string",
+                      "id": 4
+                    }
+                  }
+                },
+                "ListSnapshotsRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeListSnapshots",
+                    "(common.privilege_ext_obj).object_name_index": 3
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "dbName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "collectionName": {
+                      "type": "string",
+                      "id": 3
+                    }
+                  }
+                },
+                "ListSnapshotsResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "snapshots": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                },
+                "DescribeSnapshotRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeDescribeSnapshot",
+                    "(common.privilege_ext_obj).object_name_index": 4
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "dbName": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collectionName": {
+                      "type": "string",
+                      "id": 4
+                    }
+                  }
+                },
+                "DescribeSnapshotResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "description": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collectionName": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "partitionNames": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 5
+                    },
+                    "createTs": {
+                      "type": "int64",
+                      "id": 6
+                    },
+                    "s3Location": {
+                      "type": "string",
+                      "id": 7
+                    }
+                  }
+                },
+                "RestoreSnapshotRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeRestoreSnapshot",
+                    "(common.privilege_ext_obj).object_name_index": 4
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "dbName": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collectionName": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "rewriteData": {
+                      "type": "bool",
+                      "id": 5
+                    },
+                    "targetDbName": {
+                      "type": "string",
+                      "id": 6
+                    },
+                    "targetCollectionName": {
+                      "type": "string",
+                      "id": 7
+                    }
+                  }
+                },
+                "RestoreSnapshotResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "jobId": {
+                      "type": "int64",
+                      "id": 2
+                    }
+                  }
+                },
+                "RestoreSnapshotState": {
+                  "values": {
+                    "RestoreSnapshotNone": 0,
+                    "RestoreSnapshotPending": 1,
+                    "RestoreSnapshotExecuting": 2,
+                    "RestoreSnapshotCompleted": 3,
+                    "RestoreSnapshotFailed": 4
+                  }
+                },
+                "RestoreSnapshotInfo": {
+                  "fields": {
+                    "jobId": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "snapshotName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "dbName": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collectionName": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "state": {
+                      "type": "RestoreSnapshotState",
+                      "id": 5
+                    },
+                    "progress": {
+                      "type": "int32",
+                      "id": 6
+                    },
+                    "reason": {
+                      "type": "string",
+                      "id": 7
+                    },
+                    "startTime": {
+                      "type": "uint64",
+                      "id": 8
+                    },
+                    "timeCost": {
+                      "type": "uint64",
+                      "id": 9
+                    }
+                  }
+                },
+                "GetRestoreSnapshotStateRequest": {
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "jobId": {
+                      "type": "int64",
+                      "id": 2
+                    }
+                  }
+                },
+                "GetRestoreSnapshotStateResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "info": {
+                      "type": "RestoreSnapshotInfo",
+                      "id": 2
+                    }
+                  }
+                },
+                "ListRestoreSnapshotJobsRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeRestoreSnapshot",
+                    "(common.privilege_ext_obj).object_name_index": 3
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "dbName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "collectionName": {
+                      "type": "string",
+                      "id": 3
+                    }
+                  }
+                },
+                "ListRestoreSnapshotJobsResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "jobs": {
+                      "rule": "repeated",
+                      "type": "RestoreSnapshotInfo",
+                      "id": 2
+                    }
+                  }
+                },
+                "PinSnapshotDataRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Global",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegePinSnapshotData",
+                    "(common.privilege_ext_obj).object_name_index": -1
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "dbName": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collectionName": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "ttlSeconds": {
+                      "type": "int64",
+                      "id": 5
+                    }
+                  }
+                },
+                "PinSnapshotDataResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "pinId": {
+                      "type": "int64",
+                      "id": 2
+                    }
+                  }
+                },
+                "UnpinSnapshotDataRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Global",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeUnpinSnapshotData",
+                    "(common.privilege_ext_obj).object_name_index": -1
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "pinId": {
+                      "type": "int64",
+                      "id": 2
+                    }
+                  }
+                },
+                "AlterCollectionSchemaRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeAlterCollectionSchema",
+                    "(common.privilege_ext_obj).object_name_index": 3
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "dbName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "collectionName": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collectionID": {
+                      "type": "int64",
+                      "id": 4
+                    },
+                    "action": {
+                      "type": "Action",
+                      "id": 5
+                    }
+                  },
+                  "nested": {
+                    "FieldInfo": {
+                      "fields": {
+                        "fieldSchema": {
+                          "type": "schema.FieldSchema",
+                          "id": 1
+                        },
+                        "indexName": {
+                          "type": "string",
+                          "id": 2
+                        },
+                        "extraParams": {
+                          "rule": "repeated",
+                          "type": "common.KeyValuePair",
+                          "id": 3
+                        }
+                      }
+                    },
+                    "AddRequest": {
+                      "fields": {
+                        "fieldInfos": {
+                          "rule": "repeated",
+                          "type": "FieldInfo",
+                          "id": 1
+                        },
+                        "funcSchema": {
+                          "rule": "repeated",
+                          "type": "schema.FunctionSchema",
+                          "id": 2
+                        },
+                        "doPhysicalBackfill": {
+                          "type": "bool",
+                          "id": 3
+                        }
+                      }
+                    },
+                    "DropRequest": {
+                      "oneofs": {
+                        "identifier": {
+                          "oneof": [
+                            "fieldName",
+                            "fieldId",
+                            "functionName"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "fieldName": {
+                          "type": "string",
+                          "id": 1
+                        },
+                        "fieldId": {
+                          "type": "int64",
+                          "id": 2
+                        },
+                        "functionName": {
+                          "type": "string",
+                          "id": 3
+                        }
+                      }
+                    },
+                    "Action": {
+                      "oneofs": {
+                        "op": {
+                          "oneof": [
+                            "addRequest",
+                            "dropRequest"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "addRequest": {
+                          "type": "AddRequest",
+                          "id": 1
+                        },
+                        "dropRequest": {
+                          "type": "DropRequest",
+                          "id": 2
+                        }
+                      }
+                    }
+                  }
+                },
+                "AlterCollectionSchemaResponse": {
+                  "fields": {
+                    "alterStatus": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "indexStatus": {
+                      "type": "common.Status",
+                      "id": 2
+                    }
+                  }
+                },
+                "BatchUpdateManifestRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeInsert",
+                    "(common.privilege_ext_obj).object_name_index": 3
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "dbName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "collectionName": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "fieldNames": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 4
+                    },
+                    "items": {
+                      "rule": "repeated",
+                      "type": "BatchUpdateManifestItem",
+                      "id": 5
+                    }
+                  }
+                },
+                "BatchUpdateManifestItem": {
+                  "fields": {
+                    "segmentId": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "manifestVersion": {
+                      "type": "int64",
+                      "id": 2
+                    }
+                  }
+                },
+                "ClientHeartbeatRequest": {
+                  "fields": {
+                    "clientInfo": {
+                      "type": "common.ClientInfo",
+                      "id": 1
+                    },
+                    "reportTimestamp": {
+                      "type": "int64",
+                      "id": 2
+                    },
+                    "metrics": {
+                      "rule": "repeated",
+                      "type": "common.OperationMetrics",
+                      "id": 3
+                    },
+                    "commandReplies": {
+                      "rule": "repeated",
+                      "type": "common.CommandReply",
+                      "id": 4
+                    },
+                    "configHash": {
+                      "type": "string",
+                      "id": 5
+                    },
+                    "lastCommandTimestamp": {
+                      "type": "int64",
+                      "id": 6
+                    }
+                  }
+                },
+                "ClientHeartbeatResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "serverTimestamp": {
+                      "type": "int64",
+                      "id": 2
+                    },
+                    "commands": {
+                      "rule": "repeated",
+                      "type": "common.ClientCommand",
+                      "id": 3
+                    }
+                  }
+                },
+                "GetClientTelemetryRequest": {
+                  "fields": {
+                    "database": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "clientId": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "includeMetrics": {
+                      "type": "bool",
+                      "id": 3
+                    }
+                  }
+                },
+                "ClientTelemetry": {
+                  "fields": {
+                    "clientInfo": {
+                      "type": "common.ClientInfo",
+                      "id": 1
+                    },
+                    "lastHeartbeatTime": {
+                      "type": "int64",
+                      "id": 2
+                    },
+                    "status": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "databases": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 4
+                    },
+                    "metrics": {
+                      "rule": "repeated",
+                      "type": "common.OperationMetrics",
+                      "id": 5
+                    }
+                  }
+                },
+                "GetClientTelemetryResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "clients": {
+                      "rule": "repeated",
+                      "type": "ClientTelemetry",
+                      "id": 2
+                    },
+                    "aggregated": {
+                      "type": "common.Metrics",
+                      "id": 3
+                    }
+                  }
+                },
+                "PushClientCommandRequest": {
+                  "fields": {
+                    "commandType": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "payload": {
+                      "type": "bytes",
+                      "id": 2
+                    },
+                    "targetClientId": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "targetDatabase": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "ttlSeconds": {
+                      "type": "int64",
+                      "id": 5
+                    },
+                    "persistent": {
+                      "type": "bool",
+                      "id": 6
+                    }
+                  }
+                },
+                "PushClientCommandResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "commandId": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                },
+                "DeleteClientCommandRequest": {
+                  "fields": {
+                    "commandId": {
+                      "type": "string",
+                      "id": 1
+                    }
+                  }
+                },
+                "DeleteClientCommandResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    }
+                  }
+                },
+                "RefreshExternalCollectionState": {
+                  "values": {
+                    "RefreshPending": 0,
+                    "RefreshInProgress": 1,
+                    "RefreshCompleted": 2,
+                    "RefreshFailed": 3
+                  }
+                },
+                "RefreshExternalCollectionRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeRefreshExternalCollection",
+                    "(common.privilege_ext_obj).object_name_index": 3
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "dbName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "collectionName": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "externalSource": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "externalSpec": {
+                      "type": "string",
+                      "id": 5
+                    }
+                  }
+                },
+                "RefreshExternalCollectionResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "jobId": {
+                      "type": "int64",
+                      "id": 2
+                    }
+                  }
+                },
+                "GetRefreshExternalCollectionProgressRequest": {
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "jobId": {
+                      "type": "int64",
+                      "id": 2
+                    }
+                  }
+                },
+                "RefreshExternalCollectionJobInfo": {
+                  "fields": {
+                    "jobId": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "collectionName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "state": {
+                      "type": "RefreshExternalCollectionState",
+                      "id": 3
+                    },
+                    "progress": {
+                      "type": "int64",
+                      "id": 4
+                    },
+                    "reason": {
+                      "type": "string",
+                      "id": 5
+                    },
+                    "externalSource": {
+                      "type": "string",
+                      "id": 6
+                    },
+                    "startTime": {
+                      "type": "int64",
+                      "id": 7
+                    },
+                    "endTime": {
+                      "type": "int64",
+                      "id": 8
+                    }
+                  }
+                },
+                "GetRefreshExternalCollectionProgressResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "jobInfo": {
+                      "type": "RefreshExternalCollectionJobInfo",
+                      "id": 2
+                    }
+                  }
+                },
+                "ListRefreshExternalCollectionJobsRequest": {
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "dbName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "collectionName": {
+                      "type": "string",
+                      "id": 3
+                    }
+                  }
+                },
+                "ListRefreshExternalCollectionJobsResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "jobs": {
+                      "rule": "repeated",
+                      "type": "RefreshExternalCollectionJobInfo",
+                      "id": 2
+                    }
+                  }
                 }
               }
             },
             "common": {
               "options": {
-                "go_package": "github.com/milvus-io/milvus-proto/go-api/v2/commonpb",
+                "go_package": "github.com/milvus-io/milvus-proto/go-api/v3/commonpb",
                 "java_multiple_files": true,
                 "java_package": "io.milvus.grpc",
                 "java_outer_classname": "CommonProto",
@@ -5737,6 +6767,10 @@ export default {
                       "rule": "repeated",
                       "type": "bytes",
                       "id": 3
+                    },
+                    "elementLevel": {
+                      "type": "bool",
+                      "id": 4
                     }
                   }
                 },
@@ -5762,6 +6796,11 @@ export default {
                   }
                 },
                 "MsgType": {
+                  "valuesOptions": {
+                    "Replicate": {
+                      "deprecated": true
+                    }
+                  },
                   "values": {
                     "Undefined": 0,
                     "CreateCollection": 100,
@@ -5885,7 +6924,20 @@ export default {
                     "AlterDatabase": 1804,
                     "DescribeDatabase": 1805,
                     "AddCollectionField": 1900,
-                    "AlterWAL": 2000
+                    "AlterWAL": 2000,
+                    "CreateSnapshot": 2100,
+                    "DropSnapshot": 2101,
+                    "ListSnapshots": 2102,
+                    "DescribeSnapshot": 2103,
+                    "RestoreSnapshot": 2104,
+                    "GetRestoreSnapshotState": 2105,
+                    "ListRestoreSnapshotJobs": 2106,
+                    "PinSnapshotData": 2107,
+                    "UnpinSnapshotData": 2108,
+                    "AlterCollectionSchema": 2200,
+                    "RefreshExternalCollection": 2300,
+                    "GetRefreshExternalCollectionProgress": 2301,
+                    "ListRefreshExternalCollectionJobs": 2302
                   }
                 },
                 "MsgBase": {
@@ -5917,11 +6969,17 @@ export default {
                     },
                     "replicateInfo": {
                       "type": "ReplicateInfo",
-                      "id": 7
+                      "id": 7,
+                      "options": {
+                        "deprecated": true
+                      }
                     }
                   }
                 },
                 "ReplicateInfo": {
+                  "options": {
+                    "deprecated": true
+                  },
                   "fields": {
                     "isReplicate": {
                       "type": "bool",
@@ -6075,7 +7133,16 @@ export default {
                     "PrivilegeRemoveFileResource": 73,
                     "PrivilegeListFileResources": 74,
                     "PrivilegeUpdateReplicateConfiguration": 78,
-                    "PrivilegeGetReplicateConfiguration": 85
+                    "PrivilegeCreateSnapshot": 79,
+                    "PrivilegeDropSnapshot": 80,
+                    "PrivilegeDescribeSnapshot": 81,
+                    "PrivilegeListSnapshots": 82,
+                    "PrivilegeRestoreSnapshot": 83,
+                    "PrivilegeAlterCollectionSchema": 84,
+                    "PrivilegeGetReplicateConfiguration": 85,
+                    "PrivilegeRefreshExternalCollection": 86,
+                    "PrivilegePinSnapshotData": 87,
+                    "PrivilegeUnpinSnapshotData": 88
                   }
                 },
                 "PrivilegeExt": {
@@ -6158,6 +7225,99 @@ export default {
                       "keyType": "string",
                       "type": "string",
                       "id": 6
+                    }
+                  }
+                },
+                "Metrics": {
+                  "fields": {
+                    "requestCount": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "successCount": {
+                      "type": "int64",
+                      "id": 2
+                    },
+                    "errorCount": {
+                      "type": "int64",
+                      "id": 3
+                    },
+                    "avgLatencyMs": {
+                      "type": "double",
+                      "id": 4
+                    },
+                    "p99LatencyMs": {
+                      "type": "double",
+                      "id": 5
+                    },
+                    "maxLatencyMs": {
+                      "type": "double",
+                      "id": 6
+                    }
+                  }
+                },
+                "OperationMetrics": {
+                  "fields": {
+                    "operation": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "global": {
+                      "type": "Metrics",
+                      "id": 2
+                    },
+                    "collectionMetrics": {
+                      "keyType": "string",
+                      "type": "Metrics",
+                      "id": 3
+                    }
+                  }
+                },
+                "ClientCommand": {
+                  "fields": {
+                    "commandId": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "commandType": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "payload": {
+                      "type": "bytes",
+                      "id": 3
+                    },
+                    "createTime": {
+                      "type": "int64",
+                      "id": 4
+                    },
+                    "persistent": {
+                      "type": "bool",
+                      "id": 5
+                    },
+                    "targetScope": {
+                      "type": "string",
+                      "id": 6
+                    }
+                  }
+                },
+                "CommandReply": {
+                  "fields": {
+                    "commandId": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "success": {
+                      "type": "bool",
+                      "id": 2
+                    },
+                    "errorMessage": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "payload": {
+                      "type": "bytes",
+                      "id": 4
                     }
                   }
                 },
@@ -6376,7 +7536,7 @@ export default {
             },
             "rg": {
               "options": {
-                "go_package": "github.com/milvus-io/milvus-proto/go-api/v2/rgpb",
+                "go_package": "github.com/milvus-io/milvus-proto/go-api/v3/rgpb",
                 "java_multiple_files": true,
                 "java_package": "io.milvus.grpc",
                 "java_outer_classname": "ResourceGroupProto",
@@ -6439,7 +7599,7 @@ export default {
             },
             "schema": {
               "options": {
-                "go_package": "github.com/milvus-io/milvus-proto/go-api/v2/schemapb",
+                "go_package": "github.com/milvus-io/milvus-proto/go-api/v3/schemapb",
                 "java_multiple_files": true,
                 "java_package": "io.milvus.grpc",
                 "java_outer_classname": "SchemaProto",
@@ -6464,6 +7624,7 @@ export default {
                     "Geometry": 24,
                     "Text": 25,
                     "Timestamptz": 26,
+                    "Mol": 27,
                     "BinaryVector": 100,
                     "FloatVector": 101,
                     "Float16Vector": 102,
@@ -6480,7 +7641,9 @@ export default {
                     "Unknown": 0,
                     "BM25": 1,
                     "TextEmbedding": 2,
-                    "Rerank": 3
+                    "Rerank": 3,
+                    "MinHash": 4,
+                    "MolFingerprint": 5
                   }
                 },
                 "FieldState": {
@@ -6558,6 +7721,10 @@ export default {
                     "isFunctionOutput": {
                       "type": "bool",
                       "id": 16
+                    },
+                    "externalField": {
+                      "type": "string",
+                      "id": 17
                     }
                   }
                 },
@@ -6669,6 +7836,23 @@ export default {
                       "type": "int32",
                       "id": 10
                     },
+                    "externalSource": {
+                      "type": "string",
+                      "id": 11
+                    },
+                    "externalSpec": {
+                      "type": "string",
+                      "id": 12
+                    },
+                    "doPhysicalBackfill": {
+                      "type": "bool",
+                      "id": 13
+                    },
+                    "fileResourceIds": {
+                      "rule": "repeated",
+                      "type": "int64",
+                      "id": 14
+                    },
                     "enableNamespace": {
                       "type": "bool",
                       "id": 15
@@ -6698,6 +7882,10 @@ export default {
                       "rule": "repeated",
                       "type": "common.KeyValuePair",
                       "id": 5
+                    },
+                    "nullable": {
+                      "type": "bool",
+                      "id": 6
                     }
                   }
                 },
@@ -6813,6 +8001,24 @@ export default {
                     }
                   }
                 },
+                "MolArray": {
+                  "fields": {
+                    "data": {
+                      "rule": "repeated",
+                      "type": "bytes",
+                      "id": 1
+                    }
+                  }
+                },
+                "MolSmilesArray": {
+                  "fields": {
+                    "data": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 1
+                    }
+                  }
+                },
                 "ValueField": {
                   "oneofs": {
                     "data": {
@@ -6878,7 +8084,9 @@ export default {
                         "jsonData",
                         "geometryData",
                         "timestamptzData",
-                        "geometryWktData"
+                        "geometryWktData",
+                        "molData",
+                        "molSmilesData"
                       ]
                     }
                   },
@@ -6930,6 +8138,14 @@ export default {
                     "geometryWktData": {
                       "type": "GeometryWktArray",
                       "id": 12
+                    },
+                    "molData": {
+                      "type": "MolArray",
+                      "id": 13
+                    },
+                    "molSmilesData": {
+                      "type": "MolSmilesArray",
+                      "id": 14
                     }
                   }
                 },
@@ -7018,6 +8234,27 @@ export default {
                       "rule": "repeated",
                       "type": "FieldData",
                       "id": 1
+                    }
+                  }
+                },
+                "FieldPartialUpdateOp": {
+                  "fields": {
+                    "fieldName": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "op": {
+                      "type": "OpType",
+                      "id": 2
+                    }
+                  },
+                  "nested": {
+                    "OpType": {
+                      "values": {
+                        "REPLACE": 0,
+                        "ARRAY_APPEND": 1,
+                        "ARRAY_REMOVE": 2
+                      }
                     }
                   }
                 },
@@ -7173,8 +8410,23 @@ export default {
                       "rule": "repeated",
                       "type": "common.HighlightResult",
                       "id": 14
+                    },
+                    "elementIndices": {
+                      "type": "LongArray",
+                      "id": 15
+                    },
+                    "groupByFieldValues": {
+                      "rule": "repeated",
+                      "type": "FieldData",
+                      "id": 17
                     }
-                  }
+                  },
+                  "reserved": [
+                    [
+                      16,
+                      16
+                    ]
+                  ]
                 },
                 "VectorClusteringInfo": {
                   "fields": {
@@ -7298,7 +8550,7 @@ export default {
             },
             "feder": {
               "options": {
-                "go_package": "github.com/milvus-io/milvus-proto/go-api/v2/federpb"
+                "go_package": "github.com/milvus-io/milvus-proto/go-api/v3/federpb"
               },
               "nested": {
                 "SegmentIndexData": {
@@ -7397,7 +8649,7 @@ export default {
             },
             "msg": {
               "options": {
-                "go_package": "github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+                "go_package": "github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
               },
               "nested": {
                 "InsertDataVersion": {
@@ -7754,6 +9006,9 @@ export default {
                   }
                 },
                 "ReplicateMsg": {
+                  "options": {
+                    "deprecated": true
+                  },
                   "fields": {
                     "base": {
                       "type": "common.MsgBase",
@@ -7844,15 +9099,40 @@ export default {
         "protobuf": {
           "nested": {
             "FileDescriptorSet": {
+              "edition": "proto2",
               "fields": {
                 "file": {
                   "rule": "repeated",
                   "type": "FileDescriptorProto",
                   "id": 1
                 }
+              },
+              "extensions": [
+                [
+                  536000000,
+                  536000000
+                ]
+              ]
+            },
+            "Edition": {
+              "edition": "proto2",
+              "values": {
+                "EDITION_UNKNOWN": 0,
+                "EDITION_LEGACY": 900,
+                "EDITION_PROTO2": 998,
+                "EDITION_PROTO3": 999,
+                "EDITION_2023": 1000,
+                "EDITION_2024": 1001,
+                "EDITION_1_TEST_ONLY": 1,
+                "EDITION_2_TEST_ONLY": 2,
+                "EDITION_99997_TEST_ONLY": 99997,
+                "EDITION_99998_TEST_ONLY": 99998,
+                "EDITION_99999_TEST_ONLY": 99999,
+                "EDITION_MAX": 2147483647
               }
             },
             "FileDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -7870,18 +9150,17 @@ export default {
                 "publicDependency": {
                   "rule": "repeated",
                   "type": "int32",
-                  "id": 10,
-                  "options": {
-                    "packed": false
-                  }
+                  "id": 10
                 },
                 "weakDependency": {
                   "rule": "repeated",
                   "type": "int32",
-                  "id": 11,
-                  "options": {
-                    "packed": false
-                  }
+                  "id": 11
+                },
+                "optionDependency": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 15
                 },
                 "messageType": {
                   "rule": "repeated",
@@ -7914,10 +9193,15 @@ export default {
                 "syntax": {
                   "type": "string",
                   "id": 12
+                },
+                "edition": {
+                  "type": "Edition",
+                  "id": 14
                 }
               }
             },
             "DescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -7966,6 +9250,10 @@ export default {
                   "rule": "repeated",
                   "type": "string",
                   "id": 10
+                },
+                "visibility": {
+                  "type": "SymbolVisibility",
+                  "id": 11
                 }
               },
               "nested": {
@@ -7978,6 +9266,10 @@ export default {
                     "end": {
                       "type": "int32",
                       "id": 2
+                    },
+                    "options": {
+                      "type": "ExtensionRangeOptions",
+                      "id": 3
                     }
                   }
                 },
@@ -7995,7 +9287,82 @@ export default {
                 }
               }
             },
+            "ExtensionRangeOptions": {
+              "edition": "proto2",
+              "fields": {
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                },
+                "declaration": {
+                  "rule": "repeated",
+                  "type": "Declaration",
+                  "id": 2,
+                  "options": {
+                    "retention": "RETENTION_SOURCE"
+                  }
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 50
+                },
+                "verification": {
+                  "type": "VerificationState",
+                  "id": 3,
+                  "options": {
+                    "default": "UNVERIFIED",
+                    "retention": "RETENTION_SOURCE"
+                  }
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "nested": {
+                "Declaration": {
+                  "fields": {
+                    "number": {
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "fullName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "reserved": {
+                      "type": "bool",
+                      "id": 5
+                    },
+                    "repeated": {
+                      "type": "bool",
+                      "id": 6
+                    }
+                  },
+                  "reserved": [
+                    [
+                      4,
+                      4
+                    ]
+                  ]
+                },
+                "VerificationState": {
+                  "values": {
+                    "DECLARATION": 0,
+                    "UNVERIFIED": 1
+                  }
+                }
+              }
+            },
             "FieldDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -8036,6 +9403,10 @@ export default {
                 "options": {
                   "type": "FieldOptions",
                   "id": 8
+                },
+                "proto3Optional": {
+                  "type": "bool",
+                  "id": 17
                 }
               },
               "nested": {
@@ -8064,13 +9435,14 @@ export default {
                 "Label": {
                   "values": {
                     "LABEL_OPTIONAL": 1,
-                    "LABEL_REQUIRED": 2,
-                    "LABEL_REPEATED": 3
+                    "LABEL_REPEATED": 3,
+                    "LABEL_REQUIRED": 2
                   }
                 }
               }
             },
             "OneofDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -8083,6 +9455,7 @@ export default {
               }
             },
             "EnumDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -8096,10 +9469,39 @@ export default {
                 "options": {
                   "type": "EnumOptions",
                   "id": 3
+                },
+                "reservedRange": {
+                  "rule": "repeated",
+                  "type": "EnumReservedRange",
+                  "id": 4
+                },
+                "reservedName": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 5
+                },
+                "visibility": {
+                  "type": "SymbolVisibility",
+                  "id": 6
+                }
+              },
+              "nested": {
+                "EnumReservedRange": {
+                  "fields": {
+                    "start": {
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "end": {
+                      "type": "int32",
+                      "id": 2
+                    }
+                  }
                 }
               }
             },
             "EnumValueDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -8116,6 +9518,7 @@ export default {
               }
             },
             "ServiceDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -8133,6 +9536,7 @@ export default {
               }
             },
             "MethodDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -8161,6 +9565,7 @@ export default {
               }
             },
             "FileOptions": {
+              "edition": "proto2",
               "fields": {
                 "javaPackage": {
                   "type": "string",
@@ -8214,7 +9619,10 @@ export default {
                 },
                 "ccEnableArenas": {
                   "type": "bool",
-                  "id": 31
+                  "id": 31,
+                  "options": {
+                    "default": true
+                  }
                 },
                 "objcClassPrefix": {
                   "type": "string",
@@ -8223,6 +9631,30 @@ export default {
                 "csharpNamespace": {
                   "type": "string",
                   "id": 37
+                },
+                "swiftPrefix": {
+                  "type": "string",
+                  "id": 39
+                },
+                "phpClassPrefix": {
+                  "type": "string",
+                  "id": 40
+                },
+                "phpNamespace": {
+                  "type": "string",
+                  "id": 41
+                },
+                "phpMetadataNamespace": {
+                  "type": "string",
+                  "id": 44
+                },
+                "rubyPackage": {
+                  "type": "string",
+                  "id": 45
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 50
                 },
                 "uninterpretedOption": {
                   "rule": "repeated",
@@ -8238,9 +9670,14 @@ export default {
               ],
               "reserved": [
                 [
+                  42,
+                  42
+                ],
+                [
                   38,
                   38
-                ]
+                ],
+                "php_generic_services"
               ],
               "nested": {
                 "OptimizeMode": {
@@ -8253,6 +9690,7 @@ export default {
               }
             },
             "MessageOptions": {
+              "edition": "proto2",
               "fields": {
                 "messageSetWireFormat": {
                   "type": "bool",
@@ -8270,6 +9708,17 @@ export default {
                   "type": "bool",
                   "id": 7
                 },
+                "deprecatedLegacyJsonFieldConflicts": {
+                  "type": "bool",
+                  "id": 11,
+                  "options": {
+                    "deprecated": true
+                  }
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 12
+                },
                 "uninterpretedOption": {
                   "rule": "repeated",
                   "type": "UninterpretedOption",
@@ -8284,12 +9733,29 @@ export default {
               ],
               "reserved": [
                 [
+                  4,
+                  4
+                ],
+                [
+                  5,
+                  5
+                ],
+                [
+                  6,
+                  6
+                ],
+                [
                   8,
                   8
+                ],
+                [
+                  9,
+                  9
                 ]
               ]
             },
             "FieldOptions": {
+              "edition": "proto2",
               "fields": {
                 "ctype": {
                   "type": "CType",
@@ -8313,13 +9779,46 @@ export default {
                   "type": "bool",
                   "id": 5
                 },
+                "unverifiedLazy": {
+                  "type": "bool",
+                  "id": 15
+                },
                 "deprecated": {
                   "type": "bool",
                   "id": 3
                 },
                 "weak": {
                   "type": "bool",
-                  "id": 10
+                  "id": 10,
+                  "options": {
+                    "deprecated": true
+                  }
+                },
+                "debugRedact": {
+                  "type": "bool",
+                  "id": 16
+                },
+                "retention": {
+                  "type": "OptionRetention",
+                  "id": 17
+                },
+                "targets": {
+                  "rule": "repeated",
+                  "type": "OptionTargetType",
+                  "id": 19
+                },
+                "editionDefaults": {
+                  "rule": "repeated",
+                  "type": "EditionDefault",
+                  "id": 20
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 21
+                },
+                "featureSupport": {
+                  "type": "FeatureSupport",
+                  "id": 22
                 },
                 "uninterpretedOption": {
                   "rule": "repeated",
@@ -8337,6 +9836,10 @@ export default {
                 [
                   4,
                   4
+                ],
+                [
+                  18,
+                  18
                 ]
               ],
               "nested": {
@@ -8353,51 +9856,67 @@ export default {
                     "JS_STRING": 1,
                     "JS_NUMBER": 2
                   }
+                },
+                "OptionRetention": {
+                  "values": {
+                    "RETENTION_UNKNOWN": 0,
+                    "RETENTION_RUNTIME": 1,
+                    "RETENTION_SOURCE": 2
+                  }
+                },
+                "OptionTargetType": {
+                  "values": {
+                    "TARGET_TYPE_UNKNOWN": 0,
+                    "TARGET_TYPE_FILE": 1,
+                    "TARGET_TYPE_EXTENSION_RANGE": 2,
+                    "TARGET_TYPE_MESSAGE": 3,
+                    "TARGET_TYPE_FIELD": 4,
+                    "TARGET_TYPE_ONEOF": 5,
+                    "TARGET_TYPE_ENUM": 6,
+                    "TARGET_TYPE_ENUM_ENTRY": 7,
+                    "TARGET_TYPE_SERVICE": 8,
+                    "TARGET_TYPE_METHOD": 9
+                  }
+                },
+                "EditionDefault": {
+                  "fields": {
+                    "edition": {
+                      "type": "Edition",
+                      "id": 3
+                    },
+                    "value": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                },
+                "FeatureSupport": {
+                  "fields": {
+                    "editionIntroduced": {
+                      "type": "Edition",
+                      "id": 1
+                    },
+                    "editionDeprecated": {
+                      "type": "Edition",
+                      "id": 2
+                    },
+                    "deprecationWarning": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "editionRemoved": {
+                      "type": "Edition",
+                      "id": 4
+                    }
+                  }
                 }
               }
             },
             "OneofOptions": {
+              "edition": "proto2",
               "fields": {
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ]
-            },
-            "EnumOptions": {
-              "fields": {
-                "allowAlias": {
-                  "type": "bool",
-                  "id": 2
-                },
-                "deprecated": {
-                  "type": "bool",
-                  "id": 3
-                },
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ]
-            },
-            "EnumValueOptions": {
-              "fields": {
-                "deprecated": {
-                  "type": "bool",
+                "features": {
+                  "type": "FeatureSet",
                   "id": 1
                 },
                 "uninterpretedOption": {
@@ -8413,8 +9932,86 @@ export default {
                 ]
               ]
             },
-            "ServiceOptions": {
+            "EnumOptions": {
+              "edition": "proto2",
               "fields": {
+                "allowAlias": {
+                  "type": "bool",
+                  "id": 2
+                },
+                "deprecated": {
+                  "type": "bool",
+                  "id": 3
+                },
+                "deprecatedLegacyJsonFieldConflicts": {
+                  "type": "bool",
+                  "id": 6,
+                  "options": {
+                    "deprecated": true
+                  }
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 7
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "reserved": [
+                [
+                  5,
+                  5
+                ]
+              ]
+            },
+            "EnumValueOptions": {
+              "edition": "proto2",
+              "fields": {
+                "deprecated": {
+                  "type": "bool",
+                  "id": 1
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 2
+                },
+                "debugRedact": {
+                  "type": "bool",
+                  "id": 3
+                },
+                "featureSupport": {
+                  "type": "FieldOptions.FeatureSupport",
+                  "id": 4
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ]
+            },
+            "ServiceOptions": {
+              "edition": "proto2",
+              "fields": {
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 34
+                },
                 "deprecated": {
                   "type": "bool",
                   "id": 33
@@ -8433,10 +10030,22 @@ export default {
               ]
             },
             "MethodOptions": {
+              "edition": "proto2",
               "fields": {
                 "deprecated": {
                   "type": "bool",
                   "id": 33
+                },
+                "idempotencyLevel": {
+                  "type": "IdempotencyLevel",
+                  "id": 34,
+                  "options": {
+                    "default": "IDEMPOTENCY_UNKNOWN"
+                  }
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 35
                 },
                 "uninterpretedOption": {
                   "rule": "repeated",
@@ -8449,9 +10058,19 @@ export default {
                   1000,
                   536870911
                 ]
-              ]
+              ],
+              "nested": {
+                "IdempotencyLevel": {
+                  "values": {
+                    "IDEMPOTENCY_UNKNOWN": 0,
+                    "NO_SIDE_EFFECTS": 1,
+                    "IDEMPOTENT": 2
+                  }
+                }
+              }
             },
             "UninterpretedOption": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "rule": "repeated",
@@ -8500,7 +10119,240 @@ export default {
                 }
               }
             },
+            "FeatureSet": {
+              "edition": "proto2",
+              "fields": {
+                "fieldPresence": {
+                  "type": "FieldPresence",
+                  "id": 1,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_2023",
+                    "edition_defaults.value": "EXPLICIT"
+                  }
+                },
+                "enumType": {
+                  "type": "EnumType",
+                  "id": 2,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_PROTO3",
+                    "edition_defaults.value": "OPEN"
+                  }
+                },
+                "repeatedFieldEncoding": {
+                  "type": "RepeatedFieldEncoding",
+                  "id": 3,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_PROTO3",
+                    "edition_defaults.value": "PACKED"
+                  }
+                },
+                "utf8Validation": {
+                  "type": "Utf8Validation",
+                  "id": 4,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_PROTO3",
+                    "edition_defaults.value": "VERIFY"
+                  }
+                },
+                "messageEncoding": {
+                  "type": "MessageEncoding",
+                  "id": 5,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_LEGACY",
+                    "edition_defaults.value": "LENGTH_PREFIXED"
+                  }
+                },
+                "jsonFormat": {
+                  "type": "JsonFormat",
+                  "id": 6,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_PROTO3",
+                    "edition_defaults.value": "ALLOW"
+                  }
+                },
+                "enforceNamingStyle": {
+                  "type": "EnforceNamingStyle",
+                  "id": 7,
+                  "options": {
+                    "retention": "RETENTION_SOURCE",
+                    "targets": "TARGET_TYPE_METHOD",
+                    "feature_support.edition_introduced": "EDITION_2024",
+                    "edition_defaults.edition": "EDITION_2024",
+                    "edition_defaults.value": "STYLE2024"
+                  }
+                },
+                "defaultSymbolVisibility": {
+                  "type": "VisibilityFeature.DefaultSymbolVisibility",
+                  "id": 8,
+                  "options": {
+                    "retention": "RETENTION_SOURCE",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2024",
+                    "edition_defaults.edition": "EDITION_2024",
+                    "edition_defaults.value": "EXPORT_TOP_LEVEL"
+                  }
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  9994
+                ],
+                [
+                  9995,
+                  9999
+                ],
+                [
+                  10000,
+                  10000
+                ]
+              ],
+              "reserved": [
+                [
+                  999,
+                  999
+                ]
+              ],
+              "nested": {
+                "FieldPresence": {
+                  "values": {
+                    "FIELD_PRESENCE_UNKNOWN": 0,
+                    "EXPLICIT": 1,
+                    "IMPLICIT": 2,
+                    "LEGACY_REQUIRED": 3
+                  }
+                },
+                "EnumType": {
+                  "values": {
+                    "ENUM_TYPE_UNKNOWN": 0,
+                    "OPEN": 1,
+                    "CLOSED": 2
+                  }
+                },
+                "RepeatedFieldEncoding": {
+                  "values": {
+                    "REPEATED_FIELD_ENCODING_UNKNOWN": 0,
+                    "PACKED": 1,
+                    "EXPANDED": 2
+                  }
+                },
+                "Utf8Validation": {
+                  "values": {
+                    "UTF8_VALIDATION_UNKNOWN": 0,
+                    "VERIFY": 2,
+                    "NONE": 3
+                  }
+                },
+                "MessageEncoding": {
+                  "values": {
+                    "MESSAGE_ENCODING_UNKNOWN": 0,
+                    "LENGTH_PREFIXED": 1,
+                    "DELIMITED": 2
+                  }
+                },
+                "JsonFormat": {
+                  "values": {
+                    "JSON_FORMAT_UNKNOWN": 0,
+                    "ALLOW": 1,
+                    "LEGACY_BEST_EFFORT": 2
+                  }
+                },
+                "EnforceNamingStyle": {
+                  "values": {
+                    "ENFORCE_NAMING_STYLE_UNKNOWN": 0,
+                    "STYLE2024": 1,
+                    "STYLE_LEGACY": 2
+                  }
+                },
+                "VisibilityFeature": {
+                  "fields": {},
+                  "reserved": [
+                    [
+                      1,
+                      536870911
+                    ]
+                  ],
+                  "nested": {
+                    "DefaultSymbolVisibility": {
+                      "values": {
+                        "DEFAULT_SYMBOL_VISIBILITY_UNKNOWN": 0,
+                        "EXPORT_ALL": 1,
+                        "EXPORT_TOP_LEVEL": 2,
+                        "LOCAL_ALL": 3,
+                        "STRICT": 4
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "FeatureSetDefaults": {
+              "edition": "proto2",
+              "fields": {
+                "defaults": {
+                  "rule": "repeated",
+                  "type": "FeatureSetEditionDefault",
+                  "id": 1
+                },
+                "minimumEdition": {
+                  "type": "Edition",
+                  "id": 4
+                },
+                "maximumEdition": {
+                  "type": "Edition",
+                  "id": 5
+                }
+              },
+              "nested": {
+                "FeatureSetEditionDefault": {
+                  "fields": {
+                    "edition": {
+                      "type": "Edition",
+                      "id": 3
+                    },
+                    "overridableFeatures": {
+                      "type": "FeatureSet",
+                      "id": 4
+                    },
+                    "fixedFeatures": {
+                      "type": "FeatureSet",
+                      "id": 5
+                    }
+                  },
+                  "reserved": [
+                    [
+                      1,
+                      1
+                    ],
+                    [
+                      2,
+                      2
+                    ],
+                    "features"
+                  ]
+                }
+              }
+            },
             "SourceCodeInfo": {
+              "edition": "proto2",
               "fields": {
                 "location": {
                   "rule": "repeated",
@@ -8508,18 +10360,30 @@ export default {
                   "id": 1
                 }
               },
+              "extensions": [
+                [
+                  536000000,
+                  536000000
+                ]
+              ],
               "nested": {
                 "Location": {
                   "fields": {
                     "path": {
                       "rule": "repeated",
                       "type": "int32",
-                      "id": 1
+                      "id": 1,
+                      "options": {
+                        "packed": true
+                      }
                     },
                     "span": {
                       "rule": "repeated",
                       "type": "int32",
-                      "id": 2
+                      "id": 2,
+                      "options": {
+                        "packed": true
+                      }
                     },
                     "leadingComments": {
                       "type": "string",
@@ -8539,6 +10403,7 @@ export default {
               }
             },
             "GeneratedCodeInfo": {
+              "edition": "proto2",
               "fields": {
                 "annotation": {
                   "rule": "repeated",
@@ -8552,7 +10417,10 @@ export default {
                     "path": {
                       "rule": "repeated",
                       "type": "int32",
-                      "id": 1
+                      "id": 1,
+                      "options": {
+                        "packed": true
+                      }
                     },
                     "sourceFile": {
                       "type": "string",
@@ -8565,9 +10433,30 @@ export default {
                     "end": {
                       "type": "int32",
                       "id": 4
+                    },
+                    "semantic": {
+                      "type": "Semantic",
+                      "id": 5
+                    }
+                  },
+                  "nested": {
+                    "Semantic": {
+                      "values": {
+                        "NONE": 0,
+                        "SET": 1,
+                        "ALIAS": 2
+                      }
                     }
                   }
                 }
+              }
+            },
+            "SymbolVisibility": {
+              "edition": "proto2",
+              "values": {
+                "VISIBILITY_UNSET": 0,
+                "VISIBILITY_LOCAL": 1,
+                "VISIBILITY_EXPORT": 2
               }
             }
           }

--- a/milvus/proto-json/milvus.ts
+++ b/milvus/proto-json/milvus.ts
@@ -6,7 +6,7 @@ export default {
           "nested": {
             "milvus": {
               "options": {
-                "go_package": "github.com/milvus-io/milvus-proto/go-api/v2/milvuspb",
+                "go_package": "github.com/milvus-io/milvus-proto/go-api/v3/milvuspb",
                 "java_multiple_files": true,
                 "java_package": "io.milvus.grpc",
                 "java_outer_classname": "MilvusProto",
@@ -406,7 +406,15 @@ export default {
                     },
                     "ReplicateMessage": {
                       "requestType": "ReplicateMessageRequest",
-                      "responseType": "ReplicateMessageResponse"
+                      "responseType": "ReplicateMessageResponse",
+                      "options": {
+                        "deprecated": true
+                      },
+                      "parsedOptions": [
+                        {
+                          "deprecated": true
+                        }
+                      ]
                     },
                     "BackupRBAC": {
                       "requestType": "BackupRBACMetaRequest",
@@ -493,6 +501,91 @@ export default {
                       "requestStream": true,
                       "responseType": "ReplicateResponse",
                       "responseStream": true
+                    },
+                    "DumpMessages": {
+                      "requestType": "DumpMessagesRequest",
+                      "responseType": "DumpMessagesResponse",
+                      "responseStream": true
+                    },
+                    "ComputePhraseMatchSlop": {
+                      "requestType": "ComputePhraseMatchSlopRequest",
+                      "responseType": "ComputePhraseMatchSlopResponse"
+                    },
+                    "CreateSnapshot": {
+                      "requestType": "CreateSnapshotRequest",
+                      "responseType": "common.Status"
+                    },
+                    "DropSnapshot": {
+                      "requestType": "DropSnapshotRequest",
+                      "responseType": "common.Status"
+                    },
+                    "ListSnapshots": {
+                      "requestType": "ListSnapshotsRequest",
+                      "responseType": "ListSnapshotsResponse"
+                    },
+                    "DescribeSnapshot": {
+                      "requestType": "DescribeSnapshotRequest",
+                      "responseType": "DescribeSnapshotResponse"
+                    },
+                    "RestoreSnapshot": {
+                      "requestType": "RestoreSnapshotRequest",
+                      "responseType": "RestoreSnapshotResponse"
+                    },
+                    "GetRestoreSnapshotState": {
+                      "requestType": "GetRestoreSnapshotStateRequest",
+                      "responseType": "GetRestoreSnapshotStateResponse"
+                    },
+                    "ListRestoreSnapshotJobs": {
+                      "requestType": "ListRestoreSnapshotJobsRequest",
+                      "responseType": "ListRestoreSnapshotJobsResponse"
+                    },
+                    "PinSnapshotData": {
+                      "requestType": "PinSnapshotDataRequest",
+                      "responseType": "PinSnapshotDataResponse"
+                    },
+                    "UnpinSnapshotData": {
+                      "requestType": "UnpinSnapshotDataRequest",
+                      "responseType": "common.Status"
+                    },
+                    "AlterCollectionSchema": {
+                      "requestType": "AlterCollectionSchemaRequest",
+                      "responseType": "AlterCollectionSchemaResponse"
+                    },
+                    "BatchUpdateManifest": {
+                      "requestType": "BatchUpdateManifestRequest",
+                      "responseType": "common.Status"
+                    },
+                    "RefreshExternalCollection": {
+                      "requestType": "RefreshExternalCollectionRequest",
+                      "responseType": "RefreshExternalCollectionResponse"
+                    },
+                    "GetRefreshExternalCollectionProgress": {
+                      "requestType": "GetRefreshExternalCollectionProgressRequest",
+                      "responseType": "GetRefreshExternalCollectionProgressResponse"
+                    },
+                    "ListRefreshExternalCollectionJobs": {
+                      "requestType": "ListRefreshExternalCollectionJobsRequest",
+                      "responseType": "ListRefreshExternalCollectionJobsResponse"
+                    }
+                  }
+                },
+                "ClientTelemetryService": {
+                  "methods": {
+                    "ClientHeartbeat": {
+                      "requestType": "ClientHeartbeatRequest",
+                      "responseType": "ClientHeartbeatResponse"
+                    },
+                    "GetClientTelemetry": {
+                      "requestType": "GetClientTelemetryRequest",
+                      "responseType": "GetClientTelemetryResponse"
+                    },
+                    "PushClientCommand": {
+                      "requestType": "PushClientCommandRequest",
+                      "responseType": "PushClientCommandResponse"
+                    },
+                    "DeleteClientCommand": {
+                      "requestType": "DeleteClientCommandRequest",
+                      "responseType": "DeleteClientCommandResponse"
                     }
                   }
                 },
@@ -2053,6 +2146,11 @@ export default {
                       "options": {
                         "proto3_optional": true
                       }
+                    },
+                    "field_ops": {
+                      "rule": "repeated",
+                      "type": "schema.FieldPartialUpdateOp",
+                      "id": 11
                     }
                   }
                 },
@@ -2562,6 +2660,14 @@ export default {
                     }
                   }
                 },
+                "ElementIndices": {
+                  "fields": {
+                    "indices": {
+                      "type": "schema.LongArray",
+                      "id": 1
+                    }
+                  }
+                },
                 "QueryResults": {
                   "fields": {
                     "status": {
@@ -2589,6 +2695,11 @@ export default {
                     "primary_field_name": {
                       "type": "string",
                       "id": 6
+                    },
+                    "element_indices": {
+                      "rule": "repeated",
+                      "type": "ElementIndices",
+                      "id": 7
                     }
                   }
                 },
@@ -4857,6 +4968,9 @@ export default {
                   }
                 },
                 "ReplicateMessageRequest": {
+                  "options": {
+                    "deprecated": true
+                  },
                   "fields": {
                     "base": {
                       "type": "common.MsgBase",
@@ -4892,6 +5006,9 @@ export default {
                   }
                 },
                 "ReplicateMessageResponse": {
+                  "options": {
+                    "deprecated": true
+                  },
                   "fields": {
                     "status": {
                       "type": "common.Status",
@@ -5445,6 +5562,10 @@ export default {
                     "checkpoint": {
                       "type": "common.ReplicateCheckpoint",
                       "id": 1
+                    },
+                    "salvage_checkpoint": {
+                      "type": "common.ReplicateCheckpoint",
+                      "id": 2
                     }
                   }
                 },
@@ -5498,6 +5619,46 @@ export default {
                     }
                   }
                 },
+                "DumpMessagesRequest": {
+                  "fields": {
+                    "pchannel": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "start_message_id": {
+                      "type": "common.MessageID",
+                      "id": 2
+                    },
+                    "start_timetick": {
+                      "type": "uint64",
+                      "id": 3
+                    },
+                    "end_timetick": {
+                      "type": "uint64",
+                      "id": 4
+                    }
+                  }
+                },
+                "DumpMessagesResponse": {
+                  "oneofs": {
+                    "response": {
+                      "oneof": [
+                        "status",
+                        "message"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "message": {
+                      "type": "common.ImmutableMessage",
+                      "id": 2
+                    }
+                  }
+                },
                 "TruncateCollectionRequest": {
                   "options": {
                     "(common.privilege_ext_obj).object_type": "Global",
@@ -5526,12 +5687,881 @@ export default {
                       "id": 1
                     }
                   }
+                },
+                "ComputePhraseMatchSlopRequest": {
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "analyzer_params": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "query_text": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "data_texts": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 4
+                    }
+                  }
+                },
+                "ComputePhraseMatchSlopResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "is_match": {
+                      "rule": "repeated",
+                      "type": "bool",
+                      "id": 2
+                    },
+                    "slops": {
+                      "rule": "repeated",
+                      "type": "int64",
+                      "id": 3
+                    }
+                  }
+                },
+                "CreateSnapshotRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeCreateSnapshot",
+                    "(common.privilege_ext_obj).object_name_index": 5
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "description": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "db_name": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "collection_name": {
+                      "type": "string",
+                      "id": 5
+                    },
+                    "compaction_protection_seconds": {
+                      "type": "int64",
+                      "id": 6
+                    }
+                  }
+                },
+                "DropSnapshotRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeDropSnapshot",
+                    "(common.privilege_ext_obj).object_name_index": 4
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "db_name": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collection_name": {
+                      "type": "string",
+                      "id": 4
+                    }
+                  }
+                },
+                "ListSnapshotsRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeListSnapshots",
+                    "(common.privilege_ext_obj).object_name_index": 3
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "db_name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "collection_name": {
+                      "type": "string",
+                      "id": 3
+                    }
+                  }
+                },
+                "ListSnapshotsResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "snapshots": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                },
+                "DescribeSnapshotRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeDescribeSnapshot",
+                    "(common.privilege_ext_obj).object_name_index": 4
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "db_name": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collection_name": {
+                      "type": "string",
+                      "id": 4
+                    }
+                  }
+                },
+                "DescribeSnapshotResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "description": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collection_name": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "partition_names": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 5
+                    },
+                    "create_ts": {
+                      "type": "int64",
+                      "id": 6
+                    },
+                    "s3_location": {
+                      "type": "string",
+                      "id": 7
+                    }
+                  }
+                },
+                "RestoreSnapshotRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeRestoreSnapshot",
+                    "(common.privilege_ext_obj).object_name_index": 4
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "db_name": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collection_name": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "rewrite_data": {
+                      "type": "bool",
+                      "id": 5
+                    },
+                    "target_db_name": {
+                      "type": "string",
+                      "id": 6
+                    },
+                    "target_collection_name": {
+                      "type": "string",
+                      "id": 7
+                    }
+                  }
+                },
+                "RestoreSnapshotResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "job_id": {
+                      "type": "int64",
+                      "id": 2
+                    }
+                  }
+                },
+                "RestoreSnapshotState": {
+                  "values": {
+                    "RestoreSnapshotNone": 0,
+                    "RestoreSnapshotPending": 1,
+                    "RestoreSnapshotExecuting": 2,
+                    "RestoreSnapshotCompleted": 3,
+                    "RestoreSnapshotFailed": 4
+                  }
+                },
+                "RestoreSnapshotInfo": {
+                  "fields": {
+                    "job_id": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "snapshot_name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "db_name": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collection_name": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "state": {
+                      "type": "RestoreSnapshotState",
+                      "id": 5
+                    },
+                    "progress": {
+                      "type": "int32",
+                      "id": 6
+                    },
+                    "reason": {
+                      "type": "string",
+                      "id": 7
+                    },
+                    "start_time": {
+                      "type": "uint64",
+                      "id": 8
+                    },
+                    "time_cost": {
+                      "type": "uint64",
+                      "id": 9
+                    }
+                  }
+                },
+                "GetRestoreSnapshotStateRequest": {
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "job_id": {
+                      "type": "int64",
+                      "id": 2
+                    }
+                  }
+                },
+                "GetRestoreSnapshotStateResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "info": {
+                      "type": "RestoreSnapshotInfo",
+                      "id": 2
+                    }
+                  }
+                },
+                "ListRestoreSnapshotJobsRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeRestoreSnapshot",
+                    "(common.privilege_ext_obj).object_name_index": 3
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "db_name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "collection_name": {
+                      "type": "string",
+                      "id": 3
+                    }
+                  }
+                },
+                "ListRestoreSnapshotJobsResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "jobs": {
+                      "rule": "repeated",
+                      "type": "RestoreSnapshotInfo",
+                      "id": 2
+                    }
+                  }
+                },
+                "PinSnapshotDataRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Global",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegePinSnapshotData",
+                    "(common.privilege_ext_obj).object_name_index": -1
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "db_name": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collection_name": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "ttl_seconds": {
+                      "type": "int64",
+                      "id": 5
+                    }
+                  }
+                },
+                "PinSnapshotDataResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "pin_id": {
+                      "type": "int64",
+                      "id": 2
+                    }
+                  }
+                },
+                "UnpinSnapshotDataRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Global",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeUnpinSnapshotData",
+                    "(common.privilege_ext_obj).object_name_index": -1
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "pin_id": {
+                      "type": "int64",
+                      "id": 2
+                    }
+                  }
+                },
+                "AlterCollectionSchemaRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeAlterCollectionSchema",
+                    "(common.privilege_ext_obj).object_name_index": 3
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "db_name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "collection_name": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collectionID": {
+                      "type": "int64",
+                      "id": 4
+                    },
+                    "action": {
+                      "type": "Action",
+                      "id": 5
+                    }
+                  },
+                  "nested": {
+                    "FieldInfo": {
+                      "fields": {
+                        "field_schema": {
+                          "type": "schema.FieldSchema",
+                          "id": 1
+                        },
+                        "index_name": {
+                          "type": "string",
+                          "id": 2
+                        },
+                        "extra_params": {
+                          "rule": "repeated",
+                          "type": "common.KeyValuePair",
+                          "id": 3
+                        }
+                      }
+                    },
+                    "AddRequest": {
+                      "fields": {
+                        "field_infos": {
+                          "rule": "repeated",
+                          "type": "FieldInfo",
+                          "id": 1
+                        },
+                        "func_schema": {
+                          "rule": "repeated",
+                          "type": "schema.FunctionSchema",
+                          "id": 2
+                        },
+                        "do_physical_backfill": {
+                          "type": "bool",
+                          "id": 3
+                        }
+                      }
+                    },
+                    "DropRequest": {
+                      "oneofs": {
+                        "identifier": {
+                          "oneof": [
+                            "field_name",
+                            "field_id",
+                            "function_name"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "field_name": {
+                          "type": "string",
+                          "id": 1
+                        },
+                        "field_id": {
+                          "type": "int64",
+                          "id": 2
+                        },
+                        "function_name": {
+                          "type": "string",
+                          "id": 3
+                        }
+                      }
+                    },
+                    "Action": {
+                      "oneofs": {
+                        "op": {
+                          "oneof": [
+                            "add_request",
+                            "drop_request"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "add_request": {
+                          "type": "AddRequest",
+                          "id": 1
+                        },
+                        "drop_request": {
+                          "type": "DropRequest",
+                          "id": 2
+                        }
+                      }
+                    }
+                  }
+                },
+                "AlterCollectionSchemaResponse": {
+                  "fields": {
+                    "alter_status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "index_status": {
+                      "type": "common.Status",
+                      "id": 2
+                    }
+                  }
+                },
+                "BatchUpdateManifestRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeInsert",
+                    "(common.privilege_ext_obj).object_name_index": 3
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "db_name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "collection_name": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "field_names": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 4
+                    },
+                    "items": {
+                      "rule": "repeated",
+                      "type": "BatchUpdateManifestItem",
+                      "id": 5
+                    }
+                  }
+                },
+                "BatchUpdateManifestItem": {
+                  "fields": {
+                    "segment_id": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "manifest_version": {
+                      "type": "int64",
+                      "id": 2
+                    }
+                  }
+                },
+                "ClientHeartbeatRequest": {
+                  "fields": {
+                    "client_info": {
+                      "type": "common.ClientInfo",
+                      "id": 1
+                    },
+                    "report_timestamp": {
+                      "type": "int64",
+                      "id": 2
+                    },
+                    "metrics": {
+                      "rule": "repeated",
+                      "type": "common.OperationMetrics",
+                      "id": 3
+                    },
+                    "command_replies": {
+                      "rule": "repeated",
+                      "type": "common.CommandReply",
+                      "id": 4
+                    },
+                    "config_hash": {
+                      "type": "string",
+                      "id": 5
+                    },
+                    "last_command_timestamp": {
+                      "type": "int64",
+                      "id": 6
+                    }
+                  }
+                },
+                "ClientHeartbeatResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "server_timestamp": {
+                      "type": "int64",
+                      "id": 2
+                    },
+                    "commands": {
+                      "rule": "repeated",
+                      "type": "common.ClientCommand",
+                      "id": 3
+                    }
+                  }
+                },
+                "GetClientTelemetryRequest": {
+                  "fields": {
+                    "database": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "client_id": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "include_metrics": {
+                      "type": "bool",
+                      "id": 3
+                    }
+                  }
+                },
+                "ClientTelemetry": {
+                  "fields": {
+                    "client_info": {
+                      "type": "common.ClientInfo",
+                      "id": 1
+                    },
+                    "last_heartbeat_time": {
+                      "type": "int64",
+                      "id": 2
+                    },
+                    "status": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "databases": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 4
+                    },
+                    "metrics": {
+                      "rule": "repeated",
+                      "type": "common.OperationMetrics",
+                      "id": 5
+                    }
+                  }
+                },
+                "GetClientTelemetryResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "clients": {
+                      "rule": "repeated",
+                      "type": "ClientTelemetry",
+                      "id": 2
+                    },
+                    "aggregated": {
+                      "type": "common.Metrics",
+                      "id": 3
+                    }
+                  }
+                },
+                "PushClientCommandRequest": {
+                  "fields": {
+                    "command_type": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "payload": {
+                      "type": "bytes",
+                      "id": 2
+                    },
+                    "target_client_id": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "target_database": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "ttl_seconds": {
+                      "type": "int64",
+                      "id": 5
+                    },
+                    "persistent": {
+                      "type": "bool",
+                      "id": 6
+                    }
+                  }
+                },
+                "PushClientCommandResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "command_id": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                },
+                "DeleteClientCommandRequest": {
+                  "fields": {
+                    "command_id": {
+                      "type": "string",
+                      "id": 1
+                    }
+                  }
+                },
+                "DeleteClientCommandResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    }
+                  }
+                },
+                "RefreshExternalCollectionState": {
+                  "values": {
+                    "RefreshPending": 0,
+                    "RefreshInProgress": 1,
+                    "RefreshCompleted": 2,
+                    "RefreshFailed": 3
+                  }
+                },
+                "RefreshExternalCollectionRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeRefreshExternalCollection",
+                    "(common.privilege_ext_obj).object_name_index": 3
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "db_name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "collection_name": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "external_source": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "external_spec": {
+                      "type": "string",
+                      "id": 5
+                    }
+                  }
+                },
+                "RefreshExternalCollectionResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "job_id": {
+                      "type": "int64",
+                      "id": 2
+                    }
+                  }
+                },
+                "GetRefreshExternalCollectionProgressRequest": {
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "job_id": {
+                      "type": "int64",
+                      "id": 2
+                    }
+                  }
+                },
+                "RefreshExternalCollectionJobInfo": {
+                  "fields": {
+                    "job_id": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "collection_name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "state": {
+                      "type": "RefreshExternalCollectionState",
+                      "id": 3
+                    },
+                    "progress": {
+                      "type": "int64",
+                      "id": 4
+                    },
+                    "reason": {
+                      "type": "string",
+                      "id": 5
+                    },
+                    "external_source": {
+                      "type": "string",
+                      "id": 6
+                    },
+                    "start_time": {
+                      "type": "int64",
+                      "id": 7
+                    },
+                    "end_time": {
+                      "type": "int64",
+                      "id": 8
+                    }
+                  }
+                },
+                "GetRefreshExternalCollectionProgressResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "job_info": {
+                      "type": "RefreshExternalCollectionJobInfo",
+                      "id": 2
+                    }
+                  }
+                },
+                "ListRefreshExternalCollectionJobsRequest": {
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "db_name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "collection_name": {
+                      "type": "string",
+                      "id": 3
+                    }
+                  }
+                },
+                "ListRefreshExternalCollectionJobsResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "jobs": {
+                      "rule": "repeated",
+                      "type": "RefreshExternalCollectionJobInfo",
+                      "id": 2
+                    }
+                  }
                 }
               }
             },
             "common": {
               "options": {
-                "go_package": "github.com/milvus-io/milvus-proto/go-api/v2/commonpb",
+                "go_package": "github.com/milvus-io/milvus-proto/go-api/v3/commonpb",
                 "java_multiple_files": true,
                 "java_package": "io.milvus.grpc",
                 "java_outer_classname": "CommonProto",
@@ -5737,6 +6767,10 @@ export default {
                       "rule": "repeated",
                       "type": "bytes",
                       "id": 3
+                    },
+                    "element_level": {
+                      "type": "bool",
+                      "id": 4
                     }
                   }
                 },
@@ -5762,6 +6796,11 @@ export default {
                   }
                 },
                 "MsgType": {
+                  "valuesOptions": {
+                    "Replicate": {
+                      "deprecated": true
+                    }
+                  },
                   "values": {
                     "Undefined": 0,
                     "CreateCollection": 100,
@@ -5885,7 +6924,20 @@ export default {
                     "AlterDatabase": 1804,
                     "DescribeDatabase": 1805,
                     "AddCollectionField": 1900,
-                    "AlterWAL": 2000
+                    "AlterWAL": 2000,
+                    "CreateSnapshot": 2100,
+                    "DropSnapshot": 2101,
+                    "ListSnapshots": 2102,
+                    "DescribeSnapshot": 2103,
+                    "RestoreSnapshot": 2104,
+                    "GetRestoreSnapshotState": 2105,
+                    "ListRestoreSnapshotJobs": 2106,
+                    "PinSnapshotData": 2107,
+                    "UnpinSnapshotData": 2108,
+                    "AlterCollectionSchema": 2200,
+                    "RefreshExternalCollection": 2300,
+                    "GetRefreshExternalCollectionProgress": 2301,
+                    "ListRefreshExternalCollectionJobs": 2302
                   }
                 },
                 "MsgBase": {
@@ -5917,11 +6969,17 @@ export default {
                     },
                     "replicateInfo": {
                       "type": "ReplicateInfo",
-                      "id": 7
+                      "id": 7,
+                      "options": {
+                        "deprecated": true
+                      }
                     }
                   }
                 },
                 "ReplicateInfo": {
+                  "options": {
+                    "deprecated": true
+                  },
                   "fields": {
                     "isReplicate": {
                       "type": "bool",
@@ -6075,7 +7133,16 @@ export default {
                     "PrivilegeRemoveFileResource": 73,
                     "PrivilegeListFileResources": 74,
                     "PrivilegeUpdateReplicateConfiguration": 78,
-                    "PrivilegeGetReplicateConfiguration": 85
+                    "PrivilegeCreateSnapshot": 79,
+                    "PrivilegeDropSnapshot": 80,
+                    "PrivilegeDescribeSnapshot": 81,
+                    "PrivilegeListSnapshots": 82,
+                    "PrivilegeRestoreSnapshot": 83,
+                    "PrivilegeAlterCollectionSchema": 84,
+                    "PrivilegeGetReplicateConfiguration": 85,
+                    "PrivilegeRefreshExternalCollection": 86,
+                    "PrivilegePinSnapshotData": 87,
+                    "PrivilegeUnpinSnapshotData": 88
                   }
                 },
                 "PrivilegeExt": {
@@ -6158,6 +7225,99 @@ export default {
                       "keyType": "string",
                       "type": "string",
                       "id": 6
+                    }
+                  }
+                },
+                "Metrics": {
+                  "fields": {
+                    "request_count": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "success_count": {
+                      "type": "int64",
+                      "id": 2
+                    },
+                    "error_count": {
+                      "type": "int64",
+                      "id": 3
+                    },
+                    "avg_latency_ms": {
+                      "type": "double",
+                      "id": 4
+                    },
+                    "p99_latency_ms": {
+                      "type": "double",
+                      "id": 5
+                    },
+                    "max_latency_ms": {
+                      "type": "double",
+                      "id": 6
+                    }
+                  }
+                },
+                "OperationMetrics": {
+                  "fields": {
+                    "operation": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "global": {
+                      "type": "Metrics",
+                      "id": 2
+                    },
+                    "collection_metrics": {
+                      "keyType": "string",
+                      "type": "Metrics",
+                      "id": 3
+                    }
+                  }
+                },
+                "ClientCommand": {
+                  "fields": {
+                    "command_id": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "command_type": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "payload": {
+                      "type": "bytes",
+                      "id": 3
+                    },
+                    "create_time": {
+                      "type": "int64",
+                      "id": 4
+                    },
+                    "persistent": {
+                      "type": "bool",
+                      "id": 5
+                    },
+                    "target_scope": {
+                      "type": "string",
+                      "id": 6
+                    }
+                  }
+                },
+                "CommandReply": {
+                  "fields": {
+                    "command_id": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "success": {
+                      "type": "bool",
+                      "id": 2
+                    },
+                    "error_message": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "payload": {
+                      "type": "bytes",
+                      "id": 4
                     }
                   }
                 },
@@ -6376,7 +7536,7 @@ export default {
             },
             "rg": {
               "options": {
-                "go_package": "github.com/milvus-io/milvus-proto/go-api/v2/rgpb",
+                "go_package": "github.com/milvus-io/milvus-proto/go-api/v3/rgpb",
                 "java_multiple_files": true,
                 "java_package": "io.milvus.grpc",
                 "java_outer_classname": "ResourceGroupProto",
@@ -6439,7 +7599,7 @@ export default {
             },
             "schema": {
               "options": {
-                "go_package": "github.com/milvus-io/milvus-proto/go-api/v2/schemapb",
+                "go_package": "github.com/milvus-io/milvus-proto/go-api/v3/schemapb",
                 "java_multiple_files": true,
                 "java_package": "io.milvus.grpc",
                 "java_outer_classname": "SchemaProto",
@@ -6464,6 +7624,7 @@ export default {
                     "Geometry": 24,
                     "Text": 25,
                     "Timestamptz": 26,
+                    "Mol": 27,
                     "BinaryVector": 100,
                     "FloatVector": 101,
                     "Float16Vector": 102,
@@ -6480,7 +7641,9 @@ export default {
                     "Unknown": 0,
                     "BM25": 1,
                     "TextEmbedding": 2,
-                    "Rerank": 3
+                    "Rerank": 3,
+                    "MinHash": 4,
+                    "MolFingerprint": 5
                   }
                 },
                 "FieldState": {
@@ -6558,6 +7721,10 @@ export default {
                     "is_function_output": {
                       "type": "bool",
                       "id": 16
+                    },
+                    "external_field": {
+                      "type": "string",
+                      "id": 17
                     }
                   }
                 },
@@ -6669,6 +7836,23 @@ export default {
                       "type": "int32",
                       "id": 10
                     },
+                    "external_source": {
+                      "type": "string",
+                      "id": 11
+                    },
+                    "external_spec": {
+                      "type": "string",
+                      "id": 12
+                    },
+                    "do_physical_backfill": {
+                      "type": "bool",
+                      "id": 13
+                    },
+                    "file_resource_ids": {
+                      "rule": "repeated",
+                      "type": "int64",
+                      "id": 14
+                    },
                     "enable_namespace": {
                       "type": "bool",
                       "id": 15
@@ -6698,6 +7882,10 @@ export default {
                       "rule": "repeated",
                       "type": "common.KeyValuePair",
                       "id": 5
+                    },
+                    "nullable": {
+                      "type": "bool",
+                      "id": 6
                     }
                   }
                 },
@@ -6813,6 +8001,24 @@ export default {
                     }
                   }
                 },
+                "MolArray": {
+                  "fields": {
+                    "data": {
+                      "rule": "repeated",
+                      "type": "bytes",
+                      "id": 1
+                    }
+                  }
+                },
+                "MolSmilesArray": {
+                  "fields": {
+                    "data": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 1
+                    }
+                  }
+                },
                 "ValueField": {
                   "oneofs": {
                     "data": {
@@ -6878,7 +8084,9 @@ export default {
                         "json_data",
                         "geometry_data",
                         "timestamptz_data",
-                        "geometry_wkt_data"
+                        "geometry_wkt_data",
+                        "mol_data",
+                        "mol_smiles_data"
                       ]
                     }
                   },
@@ -6930,6 +8138,14 @@ export default {
                     "geometry_wkt_data": {
                       "type": "GeometryWktArray",
                       "id": 12
+                    },
+                    "mol_data": {
+                      "type": "MolArray",
+                      "id": 13
+                    },
+                    "mol_smiles_data": {
+                      "type": "MolSmilesArray",
+                      "id": 14
                     }
                   }
                 },
@@ -7018,6 +8234,27 @@ export default {
                       "rule": "repeated",
                       "type": "FieldData",
                       "id": 1
+                    }
+                  }
+                },
+                "FieldPartialUpdateOp": {
+                  "fields": {
+                    "field_name": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "op": {
+                      "type": "OpType",
+                      "id": 2
+                    }
+                  },
+                  "nested": {
+                    "OpType": {
+                      "values": {
+                        "REPLACE": 0,
+                        "ARRAY_APPEND": 1,
+                        "ARRAY_REMOVE": 2
+                      }
                     }
                   }
                 },
@@ -7173,8 +8410,23 @@ export default {
                       "rule": "repeated",
                       "type": "common.HighlightResult",
                       "id": 14
+                    },
+                    "element_indices": {
+                      "type": "LongArray",
+                      "id": 15
+                    },
+                    "group_by_field_values": {
+                      "rule": "repeated",
+                      "type": "FieldData",
+                      "id": 17
                     }
-                  }
+                  },
+                  "reserved": [
+                    [
+                      16,
+                      16
+                    ]
+                  ]
                 },
                 "VectorClusteringInfo": {
                   "fields": {
@@ -7298,7 +8550,7 @@ export default {
             },
             "feder": {
               "options": {
-                "go_package": "github.com/milvus-io/milvus-proto/go-api/v2/federpb"
+                "go_package": "github.com/milvus-io/milvus-proto/go-api/v3/federpb"
               },
               "nested": {
                 "SegmentIndexData": {
@@ -7397,7 +8649,7 @@ export default {
             },
             "msg": {
               "options": {
-                "go_package": "github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+                "go_package": "github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
               },
               "nested": {
                 "InsertDataVersion": {
@@ -7754,6 +9006,9 @@ export default {
                   }
                 },
                 "ReplicateMsg": {
+                  "options": {
+                    "deprecated": true
+                  },
                   "fields": {
                     "base": {
                       "type": "common.MsgBase",
@@ -7844,15 +9099,40 @@ export default {
         "protobuf": {
           "nested": {
             "FileDescriptorSet": {
+              "edition": "proto2",
               "fields": {
                 "file": {
                   "rule": "repeated",
                   "type": "FileDescriptorProto",
                   "id": 1
                 }
+              },
+              "extensions": [
+                [
+                  536000000,
+                  536000000
+                ]
+              ]
+            },
+            "Edition": {
+              "edition": "proto2",
+              "values": {
+                "EDITION_UNKNOWN": 0,
+                "EDITION_LEGACY": 900,
+                "EDITION_PROTO2": 998,
+                "EDITION_PROTO3": 999,
+                "EDITION_2023": 1000,
+                "EDITION_2024": 1001,
+                "EDITION_1_TEST_ONLY": 1,
+                "EDITION_2_TEST_ONLY": 2,
+                "EDITION_99997_TEST_ONLY": 99997,
+                "EDITION_99998_TEST_ONLY": 99998,
+                "EDITION_99999_TEST_ONLY": 99999,
+                "EDITION_MAX": 2147483647
               }
             },
             "FileDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -7870,18 +9150,17 @@ export default {
                 "publicDependency": {
                   "rule": "repeated",
                   "type": "int32",
-                  "id": 10,
-                  "options": {
-                    "packed": false
-                  }
+                  "id": 10
                 },
                 "weakDependency": {
                   "rule": "repeated",
                   "type": "int32",
-                  "id": 11,
-                  "options": {
-                    "packed": false
-                  }
+                  "id": 11
+                },
+                "optionDependency": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 15
                 },
                 "messageType": {
                   "rule": "repeated",
@@ -7914,10 +9193,15 @@ export default {
                 "syntax": {
                   "type": "string",
                   "id": 12
+                },
+                "edition": {
+                  "type": "Edition",
+                  "id": 14
                 }
               }
             },
             "DescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -7966,6 +9250,10 @@ export default {
                   "rule": "repeated",
                   "type": "string",
                   "id": 10
+                },
+                "visibility": {
+                  "type": "SymbolVisibility",
+                  "id": 11
                 }
               },
               "nested": {
@@ -7978,6 +9266,10 @@ export default {
                     "end": {
                       "type": "int32",
                       "id": 2
+                    },
+                    "options": {
+                      "type": "ExtensionRangeOptions",
+                      "id": 3
                     }
                   }
                 },
@@ -7995,7 +9287,82 @@ export default {
                 }
               }
             },
+            "ExtensionRangeOptions": {
+              "edition": "proto2",
+              "fields": {
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                },
+                "declaration": {
+                  "rule": "repeated",
+                  "type": "Declaration",
+                  "id": 2,
+                  "options": {
+                    "retention": "RETENTION_SOURCE"
+                  }
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 50
+                },
+                "verification": {
+                  "type": "VerificationState",
+                  "id": 3,
+                  "options": {
+                    "default": "UNVERIFIED",
+                    "retention": "RETENTION_SOURCE"
+                  }
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "nested": {
+                "Declaration": {
+                  "fields": {
+                    "number": {
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "fullName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "reserved": {
+                      "type": "bool",
+                      "id": 5
+                    },
+                    "repeated": {
+                      "type": "bool",
+                      "id": 6
+                    }
+                  },
+                  "reserved": [
+                    [
+                      4,
+                      4
+                    ]
+                  ]
+                },
+                "VerificationState": {
+                  "values": {
+                    "DECLARATION": 0,
+                    "UNVERIFIED": 1
+                  }
+                }
+              }
+            },
             "FieldDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -8036,6 +9403,10 @@ export default {
                 "options": {
                   "type": "FieldOptions",
                   "id": 8
+                },
+                "proto3Optional": {
+                  "type": "bool",
+                  "id": 17
                 }
               },
               "nested": {
@@ -8064,13 +9435,14 @@ export default {
                 "Label": {
                   "values": {
                     "LABEL_OPTIONAL": 1,
-                    "LABEL_REQUIRED": 2,
-                    "LABEL_REPEATED": 3
+                    "LABEL_REPEATED": 3,
+                    "LABEL_REQUIRED": 2
                   }
                 }
               }
             },
             "OneofDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -8083,6 +9455,7 @@ export default {
               }
             },
             "EnumDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -8096,10 +9469,39 @@ export default {
                 "options": {
                   "type": "EnumOptions",
                   "id": 3
+                },
+                "reservedRange": {
+                  "rule": "repeated",
+                  "type": "EnumReservedRange",
+                  "id": 4
+                },
+                "reservedName": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 5
+                },
+                "visibility": {
+                  "type": "SymbolVisibility",
+                  "id": 6
+                }
+              },
+              "nested": {
+                "EnumReservedRange": {
+                  "fields": {
+                    "start": {
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "end": {
+                      "type": "int32",
+                      "id": 2
+                    }
+                  }
                 }
               }
             },
             "EnumValueDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -8116,6 +9518,7 @@ export default {
               }
             },
             "ServiceDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -8133,6 +9536,7 @@ export default {
               }
             },
             "MethodDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -8161,6 +9565,7 @@ export default {
               }
             },
             "FileOptions": {
+              "edition": "proto2",
               "fields": {
                 "javaPackage": {
                   "type": "string",
@@ -8214,7 +9619,10 @@ export default {
                 },
                 "ccEnableArenas": {
                   "type": "bool",
-                  "id": 31
+                  "id": 31,
+                  "options": {
+                    "default": true
+                  }
                 },
                 "objcClassPrefix": {
                   "type": "string",
@@ -8223,6 +9631,30 @@ export default {
                 "csharpNamespace": {
                   "type": "string",
                   "id": 37
+                },
+                "swiftPrefix": {
+                  "type": "string",
+                  "id": 39
+                },
+                "phpClassPrefix": {
+                  "type": "string",
+                  "id": 40
+                },
+                "phpNamespace": {
+                  "type": "string",
+                  "id": 41
+                },
+                "phpMetadataNamespace": {
+                  "type": "string",
+                  "id": 44
+                },
+                "rubyPackage": {
+                  "type": "string",
+                  "id": 45
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 50
                 },
                 "uninterpretedOption": {
                   "rule": "repeated",
@@ -8238,9 +9670,14 @@ export default {
               ],
               "reserved": [
                 [
+                  42,
+                  42
+                ],
+                [
                   38,
                   38
-                ]
+                ],
+                "php_generic_services"
               ],
               "nested": {
                 "OptimizeMode": {
@@ -8253,6 +9690,7 @@ export default {
               }
             },
             "MessageOptions": {
+              "edition": "proto2",
               "fields": {
                 "messageSetWireFormat": {
                   "type": "bool",
@@ -8270,6 +9708,17 @@ export default {
                   "type": "bool",
                   "id": 7
                 },
+                "deprecatedLegacyJsonFieldConflicts": {
+                  "type": "bool",
+                  "id": 11,
+                  "options": {
+                    "deprecated": true
+                  }
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 12
+                },
                 "uninterpretedOption": {
                   "rule": "repeated",
                   "type": "UninterpretedOption",
@@ -8284,12 +9733,29 @@ export default {
               ],
               "reserved": [
                 [
+                  4,
+                  4
+                ],
+                [
+                  5,
+                  5
+                ],
+                [
+                  6,
+                  6
+                ],
+                [
                   8,
                   8
+                ],
+                [
+                  9,
+                  9
                 ]
               ]
             },
             "FieldOptions": {
+              "edition": "proto2",
               "fields": {
                 "ctype": {
                   "type": "CType",
@@ -8313,13 +9779,46 @@ export default {
                   "type": "bool",
                   "id": 5
                 },
+                "unverifiedLazy": {
+                  "type": "bool",
+                  "id": 15
+                },
                 "deprecated": {
                   "type": "bool",
                   "id": 3
                 },
                 "weak": {
                   "type": "bool",
-                  "id": 10
+                  "id": 10,
+                  "options": {
+                    "deprecated": true
+                  }
+                },
+                "debugRedact": {
+                  "type": "bool",
+                  "id": 16
+                },
+                "retention": {
+                  "type": "OptionRetention",
+                  "id": 17
+                },
+                "targets": {
+                  "rule": "repeated",
+                  "type": "OptionTargetType",
+                  "id": 19
+                },
+                "editionDefaults": {
+                  "rule": "repeated",
+                  "type": "EditionDefault",
+                  "id": 20
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 21
+                },
+                "featureSupport": {
+                  "type": "FeatureSupport",
+                  "id": 22
                 },
                 "uninterpretedOption": {
                   "rule": "repeated",
@@ -8337,6 +9836,10 @@ export default {
                 [
                   4,
                   4
+                ],
+                [
+                  18,
+                  18
                 ]
               ],
               "nested": {
@@ -8353,51 +9856,67 @@ export default {
                     "JS_STRING": 1,
                     "JS_NUMBER": 2
                   }
+                },
+                "OptionRetention": {
+                  "values": {
+                    "RETENTION_UNKNOWN": 0,
+                    "RETENTION_RUNTIME": 1,
+                    "RETENTION_SOURCE": 2
+                  }
+                },
+                "OptionTargetType": {
+                  "values": {
+                    "TARGET_TYPE_UNKNOWN": 0,
+                    "TARGET_TYPE_FILE": 1,
+                    "TARGET_TYPE_EXTENSION_RANGE": 2,
+                    "TARGET_TYPE_MESSAGE": 3,
+                    "TARGET_TYPE_FIELD": 4,
+                    "TARGET_TYPE_ONEOF": 5,
+                    "TARGET_TYPE_ENUM": 6,
+                    "TARGET_TYPE_ENUM_ENTRY": 7,
+                    "TARGET_TYPE_SERVICE": 8,
+                    "TARGET_TYPE_METHOD": 9
+                  }
+                },
+                "EditionDefault": {
+                  "fields": {
+                    "edition": {
+                      "type": "Edition",
+                      "id": 3
+                    },
+                    "value": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                },
+                "FeatureSupport": {
+                  "fields": {
+                    "editionIntroduced": {
+                      "type": "Edition",
+                      "id": 1
+                    },
+                    "editionDeprecated": {
+                      "type": "Edition",
+                      "id": 2
+                    },
+                    "deprecationWarning": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "editionRemoved": {
+                      "type": "Edition",
+                      "id": 4
+                    }
+                  }
                 }
               }
             },
             "OneofOptions": {
+              "edition": "proto2",
               "fields": {
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ]
-            },
-            "EnumOptions": {
-              "fields": {
-                "allowAlias": {
-                  "type": "bool",
-                  "id": 2
-                },
-                "deprecated": {
-                  "type": "bool",
-                  "id": 3
-                },
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ]
-            },
-            "EnumValueOptions": {
-              "fields": {
-                "deprecated": {
-                  "type": "bool",
+                "features": {
+                  "type": "FeatureSet",
                   "id": 1
                 },
                 "uninterpretedOption": {
@@ -8413,8 +9932,86 @@ export default {
                 ]
               ]
             },
-            "ServiceOptions": {
+            "EnumOptions": {
+              "edition": "proto2",
               "fields": {
+                "allowAlias": {
+                  "type": "bool",
+                  "id": 2
+                },
+                "deprecated": {
+                  "type": "bool",
+                  "id": 3
+                },
+                "deprecatedLegacyJsonFieldConflicts": {
+                  "type": "bool",
+                  "id": 6,
+                  "options": {
+                    "deprecated": true
+                  }
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 7
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "reserved": [
+                [
+                  5,
+                  5
+                ]
+              ]
+            },
+            "EnumValueOptions": {
+              "edition": "proto2",
+              "fields": {
+                "deprecated": {
+                  "type": "bool",
+                  "id": 1
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 2
+                },
+                "debugRedact": {
+                  "type": "bool",
+                  "id": 3
+                },
+                "featureSupport": {
+                  "type": "FieldOptions.FeatureSupport",
+                  "id": 4
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ]
+            },
+            "ServiceOptions": {
+              "edition": "proto2",
+              "fields": {
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 34
+                },
                 "deprecated": {
                   "type": "bool",
                   "id": 33
@@ -8433,10 +10030,22 @@ export default {
               ]
             },
             "MethodOptions": {
+              "edition": "proto2",
               "fields": {
                 "deprecated": {
                   "type": "bool",
                   "id": 33
+                },
+                "idempotencyLevel": {
+                  "type": "IdempotencyLevel",
+                  "id": 34,
+                  "options": {
+                    "default": "IDEMPOTENCY_UNKNOWN"
+                  }
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 35
                 },
                 "uninterpretedOption": {
                   "rule": "repeated",
@@ -8449,9 +10058,19 @@ export default {
                   1000,
                   536870911
                 ]
-              ]
+              ],
+              "nested": {
+                "IdempotencyLevel": {
+                  "values": {
+                    "IDEMPOTENCY_UNKNOWN": 0,
+                    "NO_SIDE_EFFECTS": 1,
+                    "IDEMPOTENT": 2
+                  }
+                }
+              }
             },
             "UninterpretedOption": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "rule": "repeated",
@@ -8500,7 +10119,240 @@ export default {
                 }
               }
             },
+            "FeatureSet": {
+              "edition": "proto2",
+              "fields": {
+                "fieldPresence": {
+                  "type": "FieldPresence",
+                  "id": 1,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_2023",
+                    "edition_defaults.value": "EXPLICIT"
+                  }
+                },
+                "enumType": {
+                  "type": "EnumType",
+                  "id": 2,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_PROTO3",
+                    "edition_defaults.value": "OPEN"
+                  }
+                },
+                "repeatedFieldEncoding": {
+                  "type": "RepeatedFieldEncoding",
+                  "id": 3,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_PROTO3",
+                    "edition_defaults.value": "PACKED"
+                  }
+                },
+                "utf8Validation": {
+                  "type": "Utf8Validation",
+                  "id": 4,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_PROTO3",
+                    "edition_defaults.value": "VERIFY"
+                  }
+                },
+                "messageEncoding": {
+                  "type": "MessageEncoding",
+                  "id": 5,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_LEGACY",
+                    "edition_defaults.value": "LENGTH_PREFIXED"
+                  }
+                },
+                "jsonFormat": {
+                  "type": "JsonFormat",
+                  "id": 6,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_PROTO3",
+                    "edition_defaults.value": "ALLOW"
+                  }
+                },
+                "enforceNamingStyle": {
+                  "type": "EnforceNamingStyle",
+                  "id": 7,
+                  "options": {
+                    "retention": "RETENTION_SOURCE",
+                    "targets": "TARGET_TYPE_METHOD",
+                    "feature_support.edition_introduced": "EDITION_2024",
+                    "edition_defaults.edition": "EDITION_2024",
+                    "edition_defaults.value": "STYLE2024"
+                  }
+                },
+                "defaultSymbolVisibility": {
+                  "type": "VisibilityFeature.DefaultSymbolVisibility",
+                  "id": 8,
+                  "options": {
+                    "retention": "RETENTION_SOURCE",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2024",
+                    "edition_defaults.edition": "EDITION_2024",
+                    "edition_defaults.value": "EXPORT_TOP_LEVEL"
+                  }
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  9994
+                ],
+                [
+                  9995,
+                  9999
+                ],
+                [
+                  10000,
+                  10000
+                ]
+              ],
+              "reserved": [
+                [
+                  999,
+                  999
+                ]
+              ],
+              "nested": {
+                "FieldPresence": {
+                  "values": {
+                    "FIELD_PRESENCE_UNKNOWN": 0,
+                    "EXPLICIT": 1,
+                    "IMPLICIT": 2,
+                    "LEGACY_REQUIRED": 3
+                  }
+                },
+                "EnumType": {
+                  "values": {
+                    "ENUM_TYPE_UNKNOWN": 0,
+                    "OPEN": 1,
+                    "CLOSED": 2
+                  }
+                },
+                "RepeatedFieldEncoding": {
+                  "values": {
+                    "REPEATED_FIELD_ENCODING_UNKNOWN": 0,
+                    "PACKED": 1,
+                    "EXPANDED": 2
+                  }
+                },
+                "Utf8Validation": {
+                  "values": {
+                    "UTF8_VALIDATION_UNKNOWN": 0,
+                    "VERIFY": 2,
+                    "NONE": 3
+                  }
+                },
+                "MessageEncoding": {
+                  "values": {
+                    "MESSAGE_ENCODING_UNKNOWN": 0,
+                    "LENGTH_PREFIXED": 1,
+                    "DELIMITED": 2
+                  }
+                },
+                "JsonFormat": {
+                  "values": {
+                    "JSON_FORMAT_UNKNOWN": 0,
+                    "ALLOW": 1,
+                    "LEGACY_BEST_EFFORT": 2
+                  }
+                },
+                "EnforceNamingStyle": {
+                  "values": {
+                    "ENFORCE_NAMING_STYLE_UNKNOWN": 0,
+                    "STYLE2024": 1,
+                    "STYLE_LEGACY": 2
+                  }
+                },
+                "VisibilityFeature": {
+                  "fields": {},
+                  "reserved": [
+                    [
+                      1,
+                      536870911
+                    ]
+                  ],
+                  "nested": {
+                    "DefaultSymbolVisibility": {
+                      "values": {
+                        "DEFAULT_SYMBOL_VISIBILITY_UNKNOWN": 0,
+                        "EXPORT_ALL": 1,
+                        "EXPORT_TOP_LEVEL": 2,
+                        "LOCAL_ALL": 3,
+                        "STRICT": 4
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "FeatureSetDefaults": {
+              "edition": "proto2",
+              "fields": {
+                "defaults": {
+                  "rule": "repeated",
+                  "type": "FeatureSetEditionDefault",
+                  "id": 1
+                },
+                "minimumEdition": {
+                  "type": "Edition",
+                  "id": 4
+                },
+                "maximumEdition": {
+                  "type": "Edition",
+                  "id": 5
+                }
+              },
+              "nested": {
+                "FeatureSetEditionDefault": {
+                  "fields": {
+                    "edition": {
+                      "type": "Edition",
+                      "id": 3
+                    },
+                    "overridableFeatures": {
+                      "type": "FeatureSet",
+                      "id": 4
+                    },
+                    "fixedFeatures": {
+                      "type": "FeatureSet",
+                      "id": 5
+                    }
+                  },
+                  "reserved": [
+                    [
+                      1,
+                      1
+                    ],
+                    [
+                      2,
+                      2
+                    ],
+                    "features"
+                  ]
+                }
+              }
+            },
             "SourceCodeInfo": {
+              "edition": "proto2",
               "fields": {
                 "location": {
                   "rule": "repeated",
@@ -8508,18 +10360,30 @@ export default {
                   "id": 1
                 }
               },
+              "extensions": [
+                [
+                  536000000,
+                  536000000
+                ]
+              ],
               "nested": {
                 "Location": {
                   "fields": {
                     "path": {
                       "rule": "repeated",
                       "type": "int32",
-                      "id": 1
+                      "id": 1,
+                      "options": {
+                        "packed": true
+                      }
                     },
                     "span": {
                       "rule": "repeated",
                       "type": "int32",
-                      "id": 2
+                      "id": 2,
+                      "options": {
+                        "packed": true
+                      }
                     },
                     "leadingComments": {
                       "type": "string",
@@ -8539,6 +10403,7 @@ export default {
               }
             },
             "GeneratedCodeInfo": {
+              "edition": "proto2",
               "fields": {
                 "annotation": {
                   "rule": "repeated",
@@ -8552,7 +10417,10 @@ export default {
                     "path": {
                       "rule": "repeated",
                       "type": "int32",
-                      "id": 1
+                      "id": 1,
+                      "options": {
+                        "packed": true
+                      }
                     },
                     "sourceFile": {
                       "type": "string",
@@ -8565,9 +10433,30 @@ export default {
                     "end": {
                       "type": "int32",
                       "id": 4
+                    },
+                    "semantic": {
+                      "type": "Semantic",
+                      "id": 5
+                    }
+                  },
+                  "nested": {
+                    "Semantic": {
+                      "values": {
+                        "NONE": 0,
+                        "SET": 1,
+                        "ALIAS": 2
+                      }
                     }
                   }
                 }
+              }
+            },
+            "SymbolVisibility": {
+              "edition": "proto2",
+              "values": {
+                "VISIBILITY_UNSET": 0,
+                "VISIBILITY_LOCAL": 1,
+                "VISIBILITY_EXPORT": 2
               }
             }
           }

--- a/milvus/proto-json/schema.base.ts
+++ b/milvus/proto-json/schema.base.ts
@@ -6,7 +6,7 @@ export default {
           "nested": {
             "schema": {
               "options": {
-                "go_package": "github.com/milvus-io/milvus-proto/go-api/v2/schemapb",
+                "go_package": "github.com/milvus-io/milvus-proto/go-api/v3/schemapb",
                 "java_multiple_files": true,
                 "java_package": "io.milvus.grpc",
                 "java_outer_classname": "SchemaProto",
@@ -31,6 +31,7 @@ export default {
                     "Geometry": 24,
                     "Text": 25,
                     "Timestamptz": 26,
+                    "Mol": 27,
                     "BinaryVector": 100,
                     "FloatVector": 101,
                     "Float16Vector": 102,
@@ -47,7 +48,9 @@ export default {
                     "Unknown": 0,
                     "BM25": 1,
                     "TextEmbedding": 2,
-                    "Rerank": 3
+                    "Rerank": 3,
+                    "MinHash": 4,
+                    "MolFingerprint": 5
                   }
                 },
                 "FieldState": {
@@ -125,6 +128,10 @@ export default {
                     "isFunctionOutput": {
                       "type": "bool",
                       "id": 16
+                    },
+                    "externalField": {
+                      "type": "string",
+                      "id": 17
                     }
                   }
                 },
@@ -236,6 +243,23 @@ export default {
                       "type": "int32",
                       "id": 10
                     },
+                    "externalSource": {
+                      "type": "string",
+                      "id": 11
+                    },
+                    "externalSpec": {
+                      "type": "string",
+                      "id": 12
+                    },
+                    "doPhysicalBackfill": {
+                      "type": "bool",
+                      "id": 13
+                    },
+                    "fileResourceIds": {
+                      "rule": "repeated",
+                      "type": "int64",
+                      "id": 14
+                    },
                     "enableNamespace": {
                       "type": "bool",
                       "id": 15
@@ -265,6 +289,10 @@ export default {
                       "rule": "repeated",
                       "type": "common.KeyValuePair",
                       "id": 5
+                    },
+                    "nullable": {
+                      "type": "bool",
+                      "id": 6
                     }
                   }
                 },
@@ -380,6 +408,24 @@ export default {
                     }
                   }
                 },
+                "MolArray": {
+                  "fields": {
+                    "data": {
+                      "rule": "repeated",
+                      "type": "bytes",
+                      "id": 1
+                    }
+                  }
+                },
+                "MolSmilesArray": {
+                  "fields": {
+                    "data": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 1
+                    }
+                  }
+                },
                 "ValueField": {
                   "oneofs": {
                     "data": {
@@ -445,7 +491,9 @@ export default {
                         "jsonData",
                         "geometryData",
                         "timestamptzData",
-                        "geometryWktData"
+                        "geometryWktData",
+                        "molData",
+                        "molSmilesData"
                       ]
                     }
                   },
@@ -497,6 +545,14 @@ export default {
                     "geometryWktData": {
                       "type": "GeometryWktArray",
                       "id": 12
+                    },
+                    "molData": {
+                      "type": "MolArray",
+                      "id": 13
+                    },
+                    "molSmilesData": {
+                      "type": "MolSmilesArray",
+                      "id": 14
                     }
                   }
                 },
@@ -585,6 +641,27 @@ export default {
                       "rule": "repeated",
                       "type": "FieldData",
                       "id": 1
+                    }
+                  }
+                },
+                "FieldPartialUpdateOp": {
+                  "fields": {
+                    "fieldName": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "op": {
+                      "type": "OpType",
+                      "id": 2
+                    }
+                  },
+                  "nested": {
+                    "OpType": {
+                      "values": {
+                        "REPLACE": 0,
+                        "ARRAY_APPEND": 1,
+                        "ARRAY_REMOVE": 2
+                      }
                     }
                   }
                 },
@@ -740,8 +817,23 @@ export default {
                       "rule": "repeated",
                       "type": "common.HighlightResult",
                       "id": 14
+                    },
+                    "elementIndices": {
+                      "type": "LongArray",
+                      "id": 15
+                    },
+                    "groupByFieldValues": {
+                      "rule": "repeated",
+                      "type": "FieldData",
+                      "id": 17
                     }
-                  }
+                  },
+                  "reserved": [
+                    [
+                      16,
+                      16
+                    ]
+                  ]
                 },
                 "VectorClusteringInfo": {
                   "fields": {
@@ -865,7 +957,7 @@ export default {
             },
             "common": {
               "options": {
-                "go_package": "github.com/milvus-io/milvus-proto/go-api/v2/commonpb",
+                "go_package": "github.com/milvus-io/milvus-proto/go-api/v3/commonpb",
                 "java_multiple_files": true,
                 "java_package": "io.milvus.grpc",
                 "java_outer_classname": "CommonProto",
@@ -1071,6 +1163,10 @@ export default {
                       "rule": "repeated",
                       "type": "bytes",
                       "id": 3
+                    },
+                    "elementLevel": {
+                      "type": "bool",
+                      "id": 4
                     }
                   }
                 },
@@ -1096,6 +1192,11 @@ export default {
                   }
                 },
                 "MsgType": {
+                  "valuesOptions": {
+                    "Replicate": {
+                      "deprecated": true
+                    }
+                  },
                   "values": {
                     "Undefined": 0,
                     "CreateCollection": 100,
@@ -1219,7 +1320,20 @@ export default {
                     "AlterDatabase": 1804,
                     "DescribeDatabase": 1805,
                     "AddCollectionField": 1900,
-                    "AlterWAL": 2000
+                    "AlterWAL": 2000,
+                    "CreateSnapshot": 2100,
+                    "DropSnapshot": 2101,
+                    "ListSnapshots": 2102,
+                    "DescribeSnapshot": 2103,
+                    "RestoreSnapshot": 2104,
+                    "GetRestoreSnapshotState": 2105,
+                    "ListRestoreSnapshotJobs": 2106,
+                    "PinSnapshotData": 2107,
+                    "UnpinSnapshotData": 2108,
+                    "AlterCollectionSchema": 2200,
+                    "RefreshExternalCollection": 2300,
+                    "GetRefreshExternalCollectionProgress": 2301,
+                    "ListRefreshExternalCollectionJobs": 2302
                   }
                 },
                 "MsgBase": {
@@ -1251,11 +1365,17 @@ export default {
                     },
                     "replicateInfo": {
                       "type": "ReplicateInfo",
-                      "id": 7
+                      "id": 7,
+                      "options": {
+                        "deprecated": true
+                      }
                     }
                   }
                 },
                 "ReplicateInfo": {
+                  "options": {
+                    "deprecated": true
+                  },
                   "fields": {
                     "isReplicate": {
                       "type": "bool",
@@ -1409,7 +1529,16 @@ export default {
                     "PrivilegeRemoveFileResource": 73,
                     "PrivilegeListFileResources": 74,
                     "PrivilegeUpdateReplicateConfiguration": 78,
-                    "PrivilegeGetReplicateConfiguration": 85
+                    "PrivilegeCreateSnapshot": 79,
+                    "PrivilegeDropSnapshot": 80,
+                    "PrivilegeDescribeSnapshot": 81,
+                    "PrivilegeListSnapshots": 82,
+                    "PrivilegeRestoreSnapshot": 83,
+                    "PrivilegeAlterCollectionSchema": 84,
+                    "PrivilegeGetReplicateConfiguration": 85,
+                    "PrivilegeRefreshExternalCollection": 86,
+                    "PrivilegePinSnapshotData": 87,
+                    "PrivilegeUnpinSnapshotData": 88
                   }
                 },
                 "PrivilegeExt": {
@@ -1492,6 +1621,99 @@ export default {
                       "keyType": "string",
                       "type": "string",
                       "id": 6
+                    }
+                  }
+                },
+                "Metrics": {
+                  "fields": {
+                    "requestCount": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "successCount": {
+                      "type": "int64",
+                      "id": 2
+                    },
+                    "errorCount": {
+                      "type": "int64",
+                      "id": 3
+                    },
+                    "avgLatencyMs": {
+                      "type": "double",
+                      "id": 4
+                    },
+                    "p99LatencyMs": {
+                      "type": "double",
+                      "id": 5
+                    },
+                    "maxLatencyMs": {
+                      "type": "double",
+                      "id": 6
+                    }
+                  }
+                },
+                "OperationMetrics": {
+                  "fields": {
+                    "operation": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "global": {
+                      "type": "Metrics",
+                      "id": 2
+                    },
+                    "collectionMetrics": {
+                      "keyType": "string",
+                      "type": "Metrics",
+                      "id": 3
+                    }
+                  }
+                },
+                "ClientCommand": {
+                  "fields": {
+                    "commandId": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "commandType": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "payload": {
+                      "type": "bytes",
+                      "id": 3
+                    },
+                    "createTime": {
+                      "type": "int64",
+                      "id": 4
+                    },
+                    "persistent": {
+                      "type": "bool",
+                      "id": 5
+                    },
+                    "targetScope": {
+                      "type": "string",
+                      "id": 6
+                    }
+                  }
+                },
+                "CommandReply": {
+                  "fields": {
+                    "commandId": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "success": {
+                      "type": "bool",
+                      "id": 2
+                    },
+                    "errorMessage": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "payload": {
+                      "type": "bytes",
+                      "id": 4
                     }
                   }
                 },
@@ -1717,15 +1939,40 @@ export default {
         "protobuf": {
           "nested": {
             "FileDescriptorSet": {
+              "edition": "proto2",
               "fields": {
                 "file": {
                   "rule": "repeated",
                   "type": "FileDescriptorProto",
                   "id": 1
                 }
+              },
+              "extensions": [
+                [
+                  536000000,
+                  536000000
+                ]
+              ]
+            },
+            "Edition": {
+              "edition": "proto2",
+              "values": {
+                "EDITION_UNKNOWN": 0,
+                "EDITION_LEGACY": 900,
+                "EDITION_PROTO2": 998,
+                "EDITION_PROTO3": 999,
+                "EDITION_2023": 1000,
+                "EDITION_2024": 1001,
+                "EDITION_1_TEST_ONLY": 1,
+                "EDITION_2_TEST_ONLY": 2,
+                "EDITION_99997_TEST_ONLY": 99997,
+                "EDITION_99998_TEST_ONLY": 99998,
+                "EDITION_99999_TEST_ONLY": 99999,
+                "EDITION_MAX": 2147483647
               }
             },
             "FileDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -1743,18 +1990,17 @@ export default {
                 "publicDependency": {
                   "rule": "repeated",
                   "type": "int32",
-                  "id": 10,
-                  "options": {
-                    "packed": false
-                  }
+                  "id": 10
                 },
                 "weakDependency": {
                   "rule": "repeated",
                   "type": "int32",
-                  "id": 11,
-                  "options": {
-                    "packed": false
-                  }
+                  "id": 11
+                },
+                "optionDependency": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 15
                 },
                 "messageType": {
                   "rule": "repeated",
@@ -1787,10 +2033,15 @@ export default {
                 "syntax": {
                   "type": "string",
                   "id": 12
+                },
+                "edition": {
+                  "type": "Edition",
+                  "id": 14
                 }
               }
             },
             "DescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -1839,6 +2090,10 @@ export default {
                   "rule": "repeated",
                   "type": "string",
                   "id": 10
+                },
+                "visibility": {
+                  "type": "SymbolVisibility",
+                  "id": 11
                 }
               },
               "nested": {
@@ -1851,6 +2106,10 @@ export default {
                     "end": {
                       "type": "int32",
                       "id": 2
+                    },
+                    "options": {
+                      "type": "ExtensionRangeOptions",
+                      "id": 3
                     }
                   }
                 },
@@ -1868,7 +2127,82 @@ export default {
                 }
               }
             },
+            "ExtensionRangeOptions": {
+              "edition": "proto2",
+              "fields": {
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                },
+                "declaration": {
+                  "rule": "repeated",
+                  "type": "Declaration",
+                  "id": 2,
+                  "options": {
+                    "retention": "RETENTION_SOURCE"
+                  }
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 50
+                },
+                "verification": {
+                  "type": "VerificationState",
+                  "id": 3,
+                  "options": {
+                    "default": "UNVERIFIED",
+                    "retention": "RETENTION_SOURCE"
+                  }
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "nested": {
+                "Declaration": {
+                  "fields": {
+                    "number": {
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "fullName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "type": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "reserved": {
+                      "type": "bool",
+                      "id": 5
+                    },
+                    "repeated": {
+                      "type": "bool",
+                      "id": 6
+                    }
+                  },
+                  "reserved": [
+                    [
+                      4,
+                      4
+                    ]
+                  ]
+                },
+                "VerificationState": {
+                  "values": {
+                    "DECLARATION": 0,
+                    "UNVERIFIED": 1
+                  }
+                }
+              }
+            },
             "FieldDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -1909,6 +2243,10 @@ export default {
                 "options": {
                   "type": "FieldOptions",
                   "id": 8
+                },
+                "proto3Optional": {
+                  "type": "bool",
+                  "id": 17
                 }
               },
               "nested": {
@@ -1937,13 +2275,14 @@ export default {
                 "Label": {
                   "values": {
                     "LABEL_OPTIONAL": 1,
-                    "LABEL_REQUIRED": 2,
-                    "LABEL_REPEATED": 3
+                    "LABEL_REPEATED": 3,
+                    "LABEL_REQUIRED": 2
                   }
                 }
               }
             },
             "OneofDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -1956,6 +2295,7 @@ export default {
               }
             },
             "EnumDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -1969,10 +2309,39 @@ export default {
                 "options": {
                   "type": "EnumOptions",
                   "id": 3
+                },
+                "reservedRange": {
+                  "rule": "repeated",
+                  "type": "EnumReservedRange",
+                  "id": 4
+                },
+                "reservedName": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 5
+                },
+                "visibility": {
+                  "type": "SymbolVisibility",
+                  "id": 6
+                }
+              },
+              "nested": {
+                "EnumReservedRange": {
+                  "fields": {
+                    "start": {
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "end": {
+                      "type": "int32",
+                      "id": 2
+                    }
+                  }
                 }
               }
             },
             "EnumValueDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -1989,6 +2358,7 @@ export default {
               }
             },
             "ServiceDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -2006,6 +2376,7 @@ export default {
               }
             },
             "MethodDescriptorProto": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "type": "string",
@@ -2034,6 +2405,7 @@ export default {
               }
             },
             "FileOptions": {
+              "edition": "proto2",
               "fields": {
                 "javaPackage": {
                   "type": "string",
@@ -2087,7 +2459,10 @@ export default {
                 },
                 "ccEnableArenas": {
                   "type": "bool",
-                  "id": 31
+                  "id": 31,
+                  "options": {
+                    "default": true
+                  }
                 },
                 "objcClassPrefix": {
                   "type": "string",
@@ -2096,6 +2471,30 @@ export default {
                 "csharpNamespace": {
                   "type": "string",
                   "id": 37
+                },
+                "swiftPrefix": {
+                  "type": "string",
+                  "id": 39
+                },
+                "phpClassPrefix": {
+                  "type": "string",
+                  "id": 40
+                },
+                "phpNamespace": {
+                  "type": "string",
+                  "id": 41
+                },
+                "phpMetadataNamespace": {
+                  "type": "string",
+                  "id": 44
+                },
+                "rubyPackage": {
+                  "type": "string",
+                  "id": 45
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 50
                 },
                 "uninterpretedOption": {
                   "rule": "repeated",
@@ -2111,9 +2510,14 @@ export default {
               ],
               "reserved": [
                 [
+                  42,
+                  42
+                ],
+                [
                   38,
                   38
-                ]
+                ],
+                "php_generic_services"
               ],
               "nested": {
                 "OptimizeMode": {
@@ -2126,6 +2530,7 @@ export default {
               }
             },
             "MessageOptions": {
+              "edition": "proto2",
               "fields": {
                 "messageSetWireFormat": {
                   "type": "bool",
@@ -2143,6 +2548,17 @@ export default {
                   "type": "bool",
                   "id": 7
                 },
+                "deprecatedLegacyJsonFieldConflicts": {
+                  "type": "bool",
+                  "id": 11,
+                  "options": {
+                    "deprecated": true
+                  }
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 12
+                },
                 "uninterpretedOption": {
                   "rule": "repeated",
                   "type": "UninterpretedOption",
@@ -2157,12 +2573,29 @@ export default {
               ],
               "reserved": [
                 [
+                  4,
+                  4
+                ],
+                [
+                  5,
+                  5
+                ],
+                [
+                  6,
+                  6
+                ],
+                [
                   8,
                   8
+                ],
+                [
+                  9,
+                  9
                 ]
               ]
             },
             "FieldOptions": {
+              "edition": "proto2",
               "fields": {
                 "ctype": {
                   "type": "CType",
@@ -2186,13 +2619,46 @@ export default {
                   "type": "bool",
                   "id": 5
                 },
+                "unverifiedLazy": {
+                  "type": "bool",
+                  "id": 15
+                },
                 "deprecated": {
                   "type": "bool",
                   "id": 3
                 },
                 "weak": {
                   "type": "bool",
-                  "id": 10
+                  "id": 10,
+                  "options": {
+                    "deprecated": true
+                  }
+                },
+                "debugRedact": {
+                  "type": "bool",
+                  "id": 16
+                },
+                "retention": {
+                  "type": "OptionRetention",
+                  "id": 17
+                },
+                "targets": {
+                  "rule": "repeated",
+                  "type": "OptionTargetType",
+                  "id": 19
+                },
+                "editionDefaults": {
+                  "rule": "repeated",
+                  "type": "EditionDefault",
+                  "id": 20
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 21
+                },
+                "featureSupport": {
+                  "type": "FeatureSupport",
+                  "id": 22
                 },
                 "uninterpretedOption": {
                   "rule": "repeated",
@@ -2210,6 +2676,10 @@ export default {
                 [
                   4,
                   4
+                ],
+                [
+                  18,
+                  18
                 ]
               ],
               "nested": {
@@ -2226,51 +2696,67 @@ export default {
                     "JS_STRING": 1,
                     "JS_NUMBER": 2
                   }
+                },
+                "OptionRetention": {
+                  "values": {
+                    "RETENTION_UNKNOWN": 0,
+                    "RETENTION_RUNTIME": 1,
+                    "RETENTION_SOURCE": 2
+                  }
+                },
+                "OptionTargetType": {
+                  "values": {
+                    "TARGET_TYPE_UNKNOWN": 0,
+                    "TARGET_TYPE_FILE": 1,
+                    "TARGET_TYPE_EXTENSION_RANGE": 2,
+                    "TARGET_TYPE_MESSAGE": 3,
+                    "TARGET_TYPE_FIELD": 4,
+                    "TARGET_TYPE_ONEOF": 5,
+                    "TARGET_TYPE_ENUM": 6,
+                    "TARGET_TYPE_ENUM_ENTRY": 7,
+                    "TARGET_TYPE_SERVICE": 8,
+                    "TARGET_TYPE_METHOD": 9
+                  }
+                },
+                "EditionDefault": {
+                  "fields": {
+                    "edition": {
+                      "type": "Edition",
+                      "id": 3
+                    },
+                    "value": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                },
+                "FeatureSupport": {
+                  "fields": {
+                    "editionIntroduced": {
+                      "type": "Edition",
+                      "id": 1
+                    },
+                    "editionDeprecated": {
+                      "type": "Edition",
+                      "id": 2
+                    },
+                    "deprecationWarning": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "editionRemoved": {
+                      "type": "Edition",
+                      "id": 4
+                    }
+                  }
                 }
               }
             },
             "OneofOptions": {
+              "edition": "proto2",
               "fields": {
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ]
-            },
-            "EnumOptions": {
-              "fields": {
-                "allowAlias": {
-                  "type": "bool",
-                  "id": 2
-                },
-                "deprecated": {
-                  "type": "bool",
-                  "id": 3
-                },
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ]
-            },
-            "EnumValueOptions": {
-              "fields": {
-                "deprecated": {
-                  "type": "bool",
+                "features": {
+                  "type": "FeatureSet",
                   "id": 1
                 },
                 "uninterpretedOption": {
@@ -2286,8 +2772,86 @@ export default {
                 ]
               ]
             },
-            "ServiceOptions": {
+            "EnumOptions": {
+              "edition": "proto2",
               "fields": {
+                "allowAlias": {
+                  "type": "bool",
+                  "id": 2
+                },
+                "deprecated": {
+                  "type": "bool",
+                  "id": 3
+                },
+                "deprecatedLegacyJsonFieldConflicts": {
+                  "type": "bool",
+                  "id": 6,
+                  "options": {
+                    "deprecated": true
+                  }
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 7
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "reserved": [
+                [
+                  5,
+                  5
+                ]
+              ]
+            },
+            "EnumValueOptions": {
+              "edition": "proto2",
+              "fields": {
+                "deprecated": {
+                  "type": "bool",
+                  "id": 1
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 2
+                },
+                "debugRedact": {
+                  "type": "bool",
+                  "id": 3
+                },
+                "featureSupport": {
+                  "type": "FieldOptions.FeatureSupport",
+                  "id": 4
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ]
+            },
+            "ServiceOptions": {
+              "edition": "proto2",
+              "fields": {
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 34
+                },
                 "deprecated": {
                   "type": "bool",
                   "id": 33
@@ -2306,10 +2870,22 @@ export default {
               ]
             },
             "MethodOptions": {
+              "edition": "proto2",
               "fields": {
                 "deprecated": {
                   "type": "bool",
                   "id": 33
+                },
+                "idempotencyLevel": {
+                  "type": "IdempotencyLevel",
+                  "id": 34,
+                  "options": {
+                    "default": "IDEMPOTENCY_UNKNOWN"
+                  }
+                },
+                "features": {
+                  "type": "FeatureSet",
+                  "id": 35
                 },
                 "uninterpretedOption": {
                   "rule": "repeated",
@@ -2322,9 +2898,19 @@ export default {
                   1000,
                   536870911
                 ]
-              ]
+              ],
+              "nested": {
+                "IdempotencyLevel": {
+                  "values": {
+                    "IDEMPOTENCY_UNKNOWN": 0,
+                    "NO_SIDE_EFFECTS": 1,
+                    "IDEMPOTENT": 2
+                  }
+                }
+              }
             },
             "UninterpretedOption": {
+              "edition": "proto2",
               "fields": {
                 "name": {
                   "rule": "repeated",
@@ -2373,7 +2959,240 @@ export default {
                 }
               }
             },
+            "FeatureSet": {
+              "edition": "proto2",
+              "fields": {
+                "fieldPresence": {
+                  "type": "FieldPresence",
+                  "id": 1,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_2023",
+                    "edition_defaults.value": "EXPLICIT"
+                  }
+                },
+                "enumType": {
+                  "type": "EnumType",
+                  "id": 2,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_PROTO3",
+                    "edition_defaults.value": "OPEN"
+                  }
+                },
+                "repeatedFieldEncoding": {
+                  "type": "RepeatedFieldEncoding",
+                  "id": 3,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_PROTO3",
+                    "edition_defaults.value": "PACKED"
+                  }
+                },
+                "utf8Validation": {
+                  "type": "Utf8Validation",
+                  "id": 4,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_PROTO3",
+                    "edition_defaults.value": "VERIFY"
+                  }
+                },
+                "messageEncoding": {
+                  "type": "MessageEncoding",
+                  "id": 5,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_LEGACY",
+                    "edition_defaults.value": "LENGTH_PREFIXED"
+                  }
+                },
+                "jsonFormat": {
+                  "type": "JsonFormat",
+                  "id": 6,
+                  "options": {
+                    "retention": "RETENTION_RUNTIME",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2023",
+                    "edition_defaults.edition": "EDITION_PROTO3",
+                    "edition_defaults.value": "ALLOW"
+                  }
+                },
+                "enforceNamingStyle": {
+                  "type": "EnforceNamingStyle",
+                  "id": 7,
+                  "options": {
+                    "retention": "RETENTION_SOURCE",
+                    "targets": "TARGET_TYPE_METHOD",
+                    "feature_support.edition_introduced": "EDITION_2024",
+                    "edition_defaults.edition": "EDITION_2024",
+                    "edition_defaults.value": "STYLE2024"
+                  }
+                },
+                "defaultSymbolVisibility": {
+                  "type": "VisibilityFeature.DefaultSymbolVisibility",
+                  "id": 8,
+                  "options": {
+                    "retention": "RETENTION_SOURCE",
+                    "targets": "TARGET_TYPE_FILE",
+                    "feature_support.edition_introduced": "EDITION_2024",
+                    "edition_defaults.edition": "EDITION_2024",
+                    "edition_defaults.value": "EXPORT_TOP_LEVEL"
+                  }
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  9994
+                ],
+                [
+                  9995,
+                  9999
+                ],
+                [
+                  10000,
+                  10000
+                ]
+              ],
+              "reserved": [
+                [
+                  999,
+                  999
+                ]
+              ],
+              "nested": {
+                "FieldPresence": {
+                  "values": {
+                    "FIELD_PRESENCE_UNKNOWN": 0,
+                    "EXPLICIT": 1,
+                    "IMPLICIT": 2,
+                    "LEGACY_REQUIRED": 3
+                  }
+                },
+                "EnumType": {
+                  "values": {
+                    "ENUM_TYPE_UNKNOWN": 0,
+                    "OPEN": 1,
+                    "CLOSED": 2
+                  }
+                },
+                "RepeatedFieldEncoding": {
+                  "values": {
+                    "REPEATED_FIELD_ENCODING_UNKNOWN": 0,
+                    "PACKED": 1,
+                    "EXPANDED": 2
+                  }
+                },
+                "Utf8Validation": {
+                  "values": {
+                    "UTF8_VALIDATION_UNKNOWN": 0,
+                    "VERIFY": 2,
+                    "NONE": 3
+                  }
+                },
+                "MessageEncoding": {
+                  "values": {
+                    "MESSAGE_ENCODING_UNKNOWN": 0,
+                    "LENGTH_PREFIXED": 1,
+                    "DELIMITED": 2
+                  }
+                },
+                "JsonFormat": {
+                  "values": {
+                    "JSON_FORMAT_UNKNOWN": 0,
+                    "ALLOW": 1,
+                    "LEGACY_BEST_EFFORT": 2
+                  }
+                },
+                "EnforceNamingStyle": {
+                  "values": {
+                    "ENFORCE_NAMING_STYLE_UNKNOWN": 0,
+                    "STYLE2024": 1,
+                    "STYLE_LEGACY": 2
+                  }
+                },
+                "VisibilityFeature": {
+                  "fields": {},
+                  "reserved": [
+                    [
+                      1,
+                      536870911
+                    ]
+                  ],
+                  "nested": {
+                    "DefaultSymbolVisibility": {
+                      "values": {
+                        "DEFAULT_SYMBOL_VISIBILITY_UNKNOWN": 0,
+                        "EXPORT_ALL": 1,
+                        "EXPORT_TOP_LEVEL": 2,
+                        "LOCAL_ALL": 3,
+                        "STRICT": 4
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "FeatureSetDefaults": {
+              "edition": "proto2",
+              "fields": {
+                "defaults": {
+                  "rule": "repeated",
+                  "type": "FeatureSetEditionDefault",
+                  "id": 1
+                },
+                "minimumEdition": {
+                  "type": "Edition",
+                  "id": 4
+                },
+                "maximumEdition": {
+                  "type": "Edition",
+                  "id": 5
+                }
+              },
+              "nested": {
+                "FeatureSetEditionDefault": {
+                  "fields": {
+                    "edition": {
+                      "type": "Edition",
+                      "id": 3
+                    },
+                    "overridableFeatures": {
+                      "type": "FeatureSet",
+                      "id": 4
+                    },
+                    "fixedFeatures": {
+                      "type": "FeatureSet",
+                      "id": 5
+                    }
+                  },
+                  "reserved": [
+                    [
+                      1,
+                      1
+                    ],
+                    [
+                      2,
+                      2
+                    ],
+                    "features"
+                  ]
+                }
+              }
+            },
             "SourceCodeInfo": {
+              "edition": "proto2",
               "fields": {
                 "location": {
                   "rule": "repeated",
@@ -2381,18 +3200,30 @@ export default {
                   "id": 1
                 }
               },
+              "extensions": [
+                [
+                  536000000,
+                  536000000
+                ]
+              ],
               "nested": {
                 "Location": {
                   "fields": {
                     "path": {
                       "rule": "repeated",
                       "type": "int32",
-                      "id": 1
+                      "id": 1,
+                      "options": {
+                        "packed": true
+                      }
                     },
                     "span": {
                       "rule": "repeated",
                       "type": "int32",
-                      "id": 2
+                      "id": 2,
+                      "options": {
+                        "packed": true
+                      }
                     },
                     "leadingComments": {
                       "type": "string",
@@ -2412,6 +3243,7 @@ export default {
               }
             },
             "GeneratedCodeInfo": {
+              "edition": "proto2",
               "fields": {
                 "annotation": {
                   "rule": "repeated",
@@ -2425,7 +3257,10 @@ export default {
                     "path": {
                       "rule": "repeated",
                       "type": "int32",
-                      "id": 1
+                      "id": 1,
+                      "options": {
+                        "packed": true
+                      }
                     },
                     "sourceFile": {
                       "type": "string",
@@ -2438,9 +3273,30 @@ export default {
                     "end": {
                       "type": "int32",
                       "id": 4
+                    },
+                    "semantic": {
+                      "type": "Semantic",
+                      "id": 5
+                    }
+                  },
+                  "nested": {
+                    "Semantic": {
+                      "values": {
+                        "NONE": 0,
+                        "SET": 1,
+                        "ALIAS": 2
+                      }
                     }
                   }
                 }
+              }
+            },
+            "SymbolVisibility": {
+              "edition": "proto2",
+              "values": {
+                "VISIBILITY_UNSET": 0,
+                "VISIBILITY_LOCAL": 1,
+                "VISIBILITY_EXPORT": 2
               }
             }
           }

--- a/milvus/types/Collection.ts
+++ b/milvus/types/Collection.ts
@@ -70,6 +70,7 @@ export type FieldSchema = {
   is_clustering_key?: boolean;
   nullable?: boolean;
   is_function_output: boolean;
+  external_field?: string;
   fields?: FieldSchema[];
 } & Partial<Record<TypeParamKey, TypeParam>>;
 
@@ -87,6 +88,7 @@ export type FieldType = {
   autoID?: boolean;
   default_value?: number | string;
   nullable?: boolean;
+  external_field?: string;
   fields?: FieldType[];
 } & Partial<Record<TypeParamKey, TypeParam>>;
 
@@ -120,6 +122,10 @@ export interface BaseCreateCollectionReq extends GrpcTimeOut {
   properties?: Properties; // optional, collection properties
   db_name?: string; // optional, db name
   functions?: FunctionObject[]; // optionals, doc-in/doc-out functions
+  external_source?: string; // optional, external collection source path
+  external_spec?: string; // optional, external collection spec configuration
+  do_physical_backfill?: boolean; // optional, whether to physically backfill external data
+  file_resource_ids?: Array<number | string>; // optional, external file resource ids
 }
 
 export interface CreateCollectionWithFieldsReq extends BaseCreateCollectionReq {
@@ -234,6 +240,10 @@ export interface CollectionSchema {
   fields: FieldSchema[];
   functions: FunctionObject[];
   struct_array_fields: FieldSchema[];
+  external_source?: string;
+  external_spec?: string;
+  do_physical_backfill?: boolean;
+  file_resource_ids?: string[];
 }
 
 export interface DescribeCollectionResponse extends TimeStamp {
@@ -335,6 +345,52 @@ export interface DropCollectionFunctionReq extends collectionNameReq {
   collection_name: string; // required, collection name
   db_name?: string; // optional, db name
   function_name: string; // required, function name
+}
+
+export enum RefreshExternalCollectionState {
+  RefreshPending = 'RefreshPending',
+  RefreshInProgress = 'RefreshInProgress',
+  RefreshCompleted = 'RefreshCompleted',
+  RefreshFailed = 'RefreshFailed',
+}
+
+export interface RefreshExternalCollectionReq extends collectionNameReq {
+  external_source?: string; // optional, new external source path
+  external_spec?: string; // optional, new external spec configuration
+}
+
+export interface RefreshExternalCollectionResponse extends resStatusResponse {
+  job_id: string;
+}
+
+export interface GetRefreshExternalCollectionProgressReq extends GrpcTimeOut {
+  job_id: number | string;
+}
+
+export interface RefreshExternalCollectionJobInfo {
+  job_id: string;
+  collection_name: string;
+  state:
+    | RefreshExternalCollectionState
+    | keyof typeof RefreshExternalCollectionState;
+  progress: string;
+  reason: string;
+  external_source: string;
+  start_time: string;
+  end_time: string;
+}
+
+export interface GetRefreshExternalCollectionProgressResponse extends resStatusResponse {
+  job_info: RefreshExternalCollectionJobInfo;
+}
+
+export interface ListRefreshExternalCollectionJobsReq extends GrpcTimeOut {
+  db_name?: string;
+  collection_name?: string;
+}
+
+export interface ListRefreshExternalCollectionJobsResponse extends resStatusResponse {
+  jobs: RefreshExternalCollectionJobInfo[];
 }
 
 export interface DescribeAliasResponse extends resStatusResponse {

--- a/milvus/utils/Schema.ts
+++ b/milvus/utils/Schema.ts
@@ -207,6 +207,7 @@ export const formatFieldSchema = (
     is_function_output,
     is_partition_key,
     is_primary_key,
+    external_field,
     ...rest
   } = assignTypeParams(field);
   const dataType = convertToDataType(field.data_type);
@@ -222,6 +223,10 @@ export const formatFieldSchema = (
     isClusteringKey:
       !!field.is_clustering_key || field.name === clustering_key_field,
   };
+
+  if (external_field) {
+    createObj.externalField = external_field;
+  }
 
   // if element type exist and
   if (
@@ -269,14 +274,16 @@ export const formatFieldSchema = (
  * @param {FunctionObject} func - The function object to format.
  * @returns {Object} The formatted function schema payload (plain object).
  */
-export const formatFunctionSchema = (func: FunctionObject): { [k: string]: any } => {
+export const formatFunctionSchema = (
+  func: FunctionObject
+): { [k: string]: any } => {
   const { input_field_names, output_field_names, type, ...rest } = func;
 
   // Ensure type is a number (enum value), not a string
   const typeValue =
     typeof type === 'number'
       ? type
-      : FunctionType[type as keyof typeof FunctionType] ?? type;
+      : (FunctionType[type as keyof typeof FunctionType] ?? type);
 
   // Return a plain object with snake_case field names for gRPC
   // The @grpc/proto-loader uses milvus.ts which has snake_case field names
@@ -336,6 +343,10 @@ export const formatCollectionSchema = (
     partition_key_field,
     functions,
     clustering_key_field,
+    external_source,
+    external_spec,
+    do_physical_backfill,
+    file_resource_ids,
   } = data;
 
   let fields = (data as CreateCollectionWithFieldsReq).fields;
@@ -400,6 +411,22 @@ export const formatCollectionSchema = (
     ),
     ...payload,
   };
+
+  if (external_source) {
+    payload.externalSource = external_source;
+  }
+
+  if (external_spec) {
+    payload.externalSpec = external_spec;
+  }
+
+  if (typeof do_physical_backfill !== 'undefined') {
+    payload.doPhysicalBackfill = do_physical_backfill;
+  }
+
+  if (file_resource_ids) {
+    payload.fileResourceIds = file_resource_ids;
+  }
 
   return payload;
 };

--- a/milvus/utils/Validate.ts
+++ b/milvus/utils/Validate.ts
@@ -100,6 +100,13 @@ const checkFieldsRecursive = (
  * @param fields
  */
 export const checkCollectionFields = (fields: FieldType[]) => {
+  return checkCollectionFieldsWithOptions(fields);
+};
+
+export const checkCollectionFieldsWithOptions = (
+  fields: FieldType[],
+  options: { isExternalCollection?: boolean } = {}
+) => {
   const result = {
     hasPrimaryKey: false,
     hasVectorField: false,
@@ -107,6 +114,10 @@ export const checkCollectionFields = (fields: FieldType[]) => {
   };
 
   checkFieldsRecursive(fields, result);
+
+  if (options.isExternalCollection) {
+    return true;
+  }
 
   // if no primary key field is found, throw error
   if (!result.hasPrimaryKey) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zilliz/milvus2-sdk-node",
   "author": "Zilliz",
-  "milvusVersion": "v2.6.15",
+  "milvusVersion": "3.0-20260427-a363a438-arm64",
   "version": "2.6.14",
   "main": "dist/milvus",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zilliz/milvus2-sdk-node",
   "author": "Zilliz",
-  "milvusVersion": "3.0-20260427-a363a438-arm64",
+  "milvusVersion": "3.0-20260427-a363a438-amd64",
   "version": "2.6.14",
   "main": "dist/milvus",
   "files": [

--- a/test/grpc/Basic.spec.ts
+++ b/test/grpc/Basic.spec.ts
@@ -6,6 +6,44 @@ const milvusClient = new MilvusClient({
   logLevel: 'info',
   logPrefix: 'Basic API',
 });
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+const hasField = async (fieldName: string) => {
+  const describe = await milvusClient.describeCollection({
+    collection_name: COLLECTION_NAME,
+  });
+
+  return describe.schema.fields.some(field => field.name === fieldName);
+};
+
+const addCollectionFieldAndWait = async (field: FieldType) => {
+  let res = await milvusClient.addCollectionField({
+    collection_name: COLLECTION_NAME,
+    field,
+  });
+
+  for (let i = 0; i < 10; i++) {
+    if (res.error_code === ErrorCode.SUCCESS) {
+      return res;
+    }
+
+    if (
+      (res.error_code === 'NotReadyServe' ||
+        res.reason?.includes('duplicated field name')) &&
+      (await hasField(field.name))
+    ) {
+      return { error_code: ErrorCode.SUCCESS, reason: '' };
+    }
+
+    await sleep(1000);
+    res = await milvusClient.addCollectionField({
+      collection_name: COLLECTION_NAME,
+      field,
+    });
+  }
+
+  return res;
+};
 const COLLECTION_NAME = GENERATE_NAME();
 const schema: FieldType[] = [
   {
@@ -305,11 +343,16 @@ describe(`Basic API without database`, () => {
   });
 
   it(`add fields should be successful`, async () => {
-    const addVarChar = await milvusClient.addCollectionFields({
+    const release = await milvusClient.releaseCollection({
       collection_name: COLLECTION_NAME,
-      fields: fieldsToAdd,
     });
+    expect(release.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const addVarChar = await addCollectionFieldAndWait(fieldsToAdd[0]);
     expect(addVarChar.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const addArray = await addCollectionFieldAndWait(fieldsToAdd[1]);
+    expect(addArray.error_code).toEqual(ErrorCode.SUCCESS);
 
     const describe = await milvusClient.describeCollection({
       collection_name: COLLECTION_NAME,
@@ -319,14 +362,42 @@ describe(`Basic API without database`, () => {
     );
     expect(describe.schema.fields[6].name).toEqual('new_varChar2');
     expect(describe.schema.fields[7].name).toEqual('new_array2');
+
+    const load = await milvusClient.loadCollectionSync({
+      collection_name: COLLECTION_NAME,
+    });
+    expect(load.error_code).toEqual(ErrorCode.SUCCESS);
   });
 
   it('add wrong fields should be failed', async () => {
-    const addWrongFields = await milvusClient.addCollectionFields({
+    const release = await milvusClient.releaseCollection({
+      collection_name: COLLECTION_NAME,
+    });
+    expect(release.error_code).toEqual(ErrorCode.SUCCESS);
+
+    let addWrongFields = await milvusClient.addCollectionFields({
       collection_name: COLLECTION_NAME,
       fields: wrongFieldsToAdd,
     });
+
+    for (
+      let i = 0;
+      addWrongFields.error_code === 'NotReadyServe' && i < 10;
+      i++
+    ) {
+      await sleep(1000);
+      addWrongFields = await milvusClient.addCollectionFields({
+        collection_name: COLLECTION_NAME,
+        fields: wrongFieldsToAdd,
+      });
+    }
+
     expect(addWrongFields.error_code).toEqual(ErrorCode.IllegalArgument);
+
+    const load = await milvusClient.loadCollectionSync({
+      collection_name: COLLECTION_NAME,
+    });
+    expect(load.error_code).toEqual(ErrorCode.SUCCESS);
   });
 
   it(`search with ids should be successful`, async () => {
@@ -432,7 +503,9 @@ describe('Search by String IDs API testing', () => {
   });
 
   afterAll(async () => {
-    await milvusClient.dropCollection({ collection_name: COLLECTION_NAME_STRING });
+    await milvusClient.dropCollection({
+      collection_name: COLLECTION_NAME_STRING,
+    });
   });
 
   it(`search with string ids should be successful`, async () => {

--- a/test/grpc/ExternalCollection.spec.ts
+++ b/test/grpc/ExternalCollection.spec.ts
@@ -1,0 +1,102 @@
+import { DataType, ErrorCode, MilvusClient } from '../../milvus';
+import { GENERATE_NAME, IP } from '../tools';
+
+const milvusClient = new MilvusClient({
+  address: IP,
+  username: process.env.MILVUS_USERNAME || 'root',
+  password: process.env.MILVUS_PASSWORD || 'Milvus',
+  logLevel: 'info',
+});
+
+const DEFAULT_EXTERNAL_SOURCE = 's3://test-bucket/data/';
+const DEFAULT_EXTERNAL_SPEC = JSON.stringify({
+  format: 'parquet',
+  extfs: {
+    access_key_id: 'dummy',
+    access_key_value: 'dummy',
+    region: 'us-east-1',
+    cloud_provider: 'aws',
+  },
+});
+
+describe('External Collection API', () => {
+  const collectionName = GENERATE_NAME();
+
+  afterAll(async () => {
+    await milvusClient.dropCollection({ collection_name: collectionName });
+  });
+
+  it('creates, describes, and refreshes an external collection with external field mappings', async () => {
+    const create = await milvusClient.createCollection({
+      collection_name: collectionName,
+      external_source:
+        process.env.EXTERNAL_COLLECTION_SOURCE || DEFAULT_EXTERNAL_SOURCE,
+      external_spec:
+        process.env.EXTERNAL_COLLECTION_SPEC || DEFAULT_EXTERNAL_SPEC,
+      fields: [
+        {
+          name: 'product_id',
+          data_type: DataType.Int64,
+          external_field: 'id',
+        },
+        {
+          name: 'name',
+          data_type: DataType.VarChar,
+          max_length: 256,
+          external_field: 'name',
+        },
+        {
+          name: 'vec',
+          data_type: DataType.FloatVector,
+          dim: 4,
+          external_field: 'vector',
+        },
+      ],
+    });
+
+    expect(create.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const describe = await milvusClient.describeCollection({
+      collection_name: collectionName,
+    });
+
+    expect(describe.schema.external_source).toBe(
+      process.env.EXTERNAL_COLLECTION_SOURCE || DEFAULT_EXTERNAL_SOURCE
+    );
+    expect(describe.schema.external_spec).toBeTruthy();
+    const externalSpec = JSON.parse(describe.schema.external_spec!);
+    expect(externalSpec.format).toBe('parquet');
+    const virtualPk = describe.schema.fields.find(
+      field => field.name === '__virtual_pk__'
+    );
+    const productId = describe.schema.fields.find(
+      field => field.name === 'product_id'
+    );
+    const name = describe.schema.fields.find(field => field.name === 'name');
+    const vector = describe.schema.fields.find(field => field.name === 'vec');
+
+    expect(virtualPk?.is_primary_key).toBe(true);
+    expect(virtualPk?.autoID).toBe(true);
+    expect(productId?.external_field).toBe('id');
+    expect(name?.external_field).toBe('name');
+    expect(vector?.external_field).toBe('vector');
+
+    const refresh = await milvusClient.refreshExternalCollection({
+      collection_name: collectionName,
+    });
+    expect(refresh.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(refresh.job_id).toBeTruthy();
+
+    const progress = await milvusClient.getRefreshExternalCollectionProgress({
+      job_id: refresh.job_id,
+    });
+    expect(progress.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(progress.job_info.collection_name).toBe(collectionName);
+
+    const jobs = await milvusClient.listRefreshExternalCollectionJobs({
+      collection_name: collectionName,
+    });
+    expect(jobs.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(Array.isArray(jobs.jobs)).toBe(true);
+  });
+});

--- a/test/http/test.ts
+++ b/test/http/test.ts
@@ -449,7 +449,7 @@ export function generateTests(
       expect(typeof search.data[0].distance).toEqual('number');
     });
 
-    it('should query data and get data and delete successfully', async () => {
+    it('should query data and get data successfully', async () => {
       const query = await client.query({
         collectionName: createParams.collectionName,
         outputFields: ['id'],
@@ -468,12 +468,6 @@ export function generateTests(
       });
       expect(get.code).toEqual(0);
       expect(get.data.length).toEqual(ids.length);
-
-      const del = await client.delete({
-        collectionName: createParams.collectionName,
-        filter: `id in [${ids.join(',')}]`,
-      });
-      expect(del.code).toEqual(0);
     });
 
     it('should search data successfully', async () => {
@@ -560,11 +554,12 @@ export function generateTests(
       expect(describe.code).toEqual(0);
       expect(describe.data.collectionName).toEqual(newCollectionName);
 
-      await client.renameCollection({
+      const renameBack = await client.renameCollection({
         dbName: config.database,
         collectionName: newCollectionName,
         newCollectionName: createParams.collectionName,
       });
+      expect(renameBack.code).toEqual(0);
     });
 
     it('should release collection successfully', async () => {
@@ -592,7 +587,7 @@ export function generateTests(
       });
 
       expect(statistics.code).toEqual(0);
-      expect(statistics.data.rowCount).toEqual(101);
+      expect(statistics.data.rowCount).toBeGreaterThanOrEqual(101);
     });
 
     it('should getCollectionLoadState successfully', async () => {

--- a/test/utils/Schema.spec.ts
+++ b/test/utils/Schema.spec.ts
@@ -8,9 +8,11 @@ import {
   convertToDataType,
   DataType,
   formatFieldSchema,
+  formatFunctionSchema,
   formatCollectionSchema,
   formatDescribedCol,
   CreateCollectionReq,
+  FunctionType,
 } from '../../milvus';
 
 describe('utils/Schema', () => {
@@ -431,6 +433,24 @@ describe('utils/Schema', () => {
       { defaults: true }
     );
     expect(decoded.externalField).toBe('name');
+  });
+
+  it('formats function schema when function type is a string enum key', () => {
+    const payload = formatFunctionSchema({
+      name: 'bm25_func',
+      type: 'BM25' as unknown as FunctionType,
+      input_field_names: ['text'],
+      output_field_names: ['sparse'],
+      params: { enable_match: true },
+    });
+
+    expect(payload).toMatchObject({
+      name: 'bm25_func',
+      type: FunctionType.BM25,
+      input_field_names: ['text'],
+      output_field_names: ['sparse'],
+      params: [{ key: 'enable_match', value: 'true' }],
+    });
   });
 
   it('adds a dataType property to each field object in the schema', () => {

--- a/test/utils/Schema.spec.ts
+++ b/test/utils/Schema.spec.ts
@@ -7,6 +7,7 @@ import {
   assignTypeParams,
   convertToDataType,
   DataType,
+  formatFieldSchema,
   formatCollectionSchema,
   formatDescribedCol,
   CreateCollectionReq,
@@ -153,6 +154,7 @@ describe('utils/Schema', () => {
           data_type: DataType.Int64,
           is_primary_key: true,
           description: 'Test PRIMARY KEY field',
+          external_field: 'external_id',
         },
         {
           name: 'testField2',
@@ -189,6 +191,10 @@ describe('utils/Schema', () => {
           ],
         },
       ],
+      external_source: 's3://bucket/path',
+      external_spec: '{"format":"parquet"}',
+      do_physical_backfill: true,
+      file_resource_ids: [1, '2'],
       functions: [
         {
           name: 'bm25f1',
@@ -214,98 +220,58 @@ describe('utils/Schema', () => {
       'milvus.proto.schema.FunctionSchema'
     );
 
-    const expectedResult = {
-      name: 'testCollection',
-      description: 'Test Collection for Jest',
-      enableDynamicField: false,
-      fields: [
-        {
-          typeParams: [],
-          indexParams: [],
-          name: 'testField1',
-          description: 'Test PRIMARY KEY field',
-          data_type: 5,
-          dataType: 5,
-          isPrimaryKey: true,
-          isPartitionKey: false,
-          isFunctionOutput: false,
-          isClusteringKey: false,
-        },
-        {
-          typeParams: [{ key: 'dim', value: '64' }],
-          indexParams: [],
-          name: 'testField2',
-          description: 'Test VECTOR field',
-          data_type: 'FloatVector',
-          dataType: 101,
-          isPrimaryKey: false,
-          isPartitionKey: false,
-          isFunctionOutput: false,
-          isClusteringKey: false,
-        },
-        {
-          typeParams: [{ key: 'max_capacity', value: '64' }],
-          indexParams: [],
-          name: 'arrayField',
-          description: 'Test Array field',
-          data_type: 22,
-          dataType: 22,
-          isPrimaryKey: false,
-          isPartitionKey: false,
-          isFunctionOutput: false,
-          isClusteringKey: false,
-          elementType: 5,
-          element_type: 5,
-        },
-        {
-          typeParams: [],
-          indexParams: [],
-          name: 'sparse',
-          description: 'sparse field',
-          data_type: 104,
-          dataType: 104,
-          isPrimaryKey: false,
-          isPartitionKey: false,
-          isFunctionOutput: true,
-          isClusteringKey: false,
-        },
-        {
-          typeParams: [],
-          indexParams: [],
-          name: 'struct',
-          fields: [
-            { name: 'field1', data_type: 5 },
-            { name: 'field1', data_type: 101, dim: 128 },
-          ],
-          data_type: 201,
-          dataType: 201,
-          isPrimaryKey: false,
-          isPartitionKey: false,
-          isFunctionOutput: false,
-          isClusteringKey: false,
-        },
-      ],
-      structArrayFields: [],
-      functions: [
-        {
-          inputFieldNames: ['testField1'],
-          inputFieldIds: [],
-          outputFieldNames: ['sparse'],
-          outputFieldIds: [],
-          params: [{ key: 'a', value: '1' }],
-          name: 'bm25f1',
-          description: 'bm25 function',
-          type: 1,
-        },
-      ],
-    };
-
     const payload = formatCollectionSchema(data, {
       fieldSchemaType,
       functionSchemaType,
     });
 
-    expect(payload).toEqual(expectedResult);
+    expect(payload).toMatchObject({
+      name: 'testCollection',
+      description: 'Test Collection for Jest',
+      enableDynamicField: false,
+      externalSource: 's3://bucket/path',
+      externalSpec: '{"format":"parquet"}',
+      doPhysicalBackfill: true,
+      fileResourceIds: [1, '2'],
+    });
+    expect(payload.fields[0]).toMatchObject({
+      name: 'testField1',
+      description: 'Test PRIMARY KEY field',
+      dataType: DataType.Int64,
+      isPrimaryKey: true,
+      isPartitionKey: false,
+      isFunctionOutput: false,
+      isClusteringKey: false,
+      externalField: 'external_id',
+    });
+    expect(payload.fields[1]).toMatchObject({
+      name: 'testField2',
+      typeParams: [{ key: 'dim', value: '64' }],
+      dataType: DataType.FloatVector,
+    });
+    expect(payload.fields[2]).toMatchObject({
+      name: 'arrayField',
+      typeParams: [{ key: 'max_capacity', value: '64' }],
+      dataType: DataType.Array,
+      elementType: DataType.Int64,
+    });
+    expect(payload.fields[3]).toMatchObject({
+      name: 'sparse',
+      dataType: DataType.SparseFloatVector,
+      isFunctionOutput: true,
+    });
+    expect(payload.fields[4]).toMatchObject({
+      name: 'struct',
+      dataType: DataType.Struct,
+    });
+    expect(payload.functions[0]).toMatchObject({
+      inputFieldNames: ['testField1'],
+      outputFieldNames: ['sparse'],
+      params: [{ key: 'a', value: '1' }],
+      name: 'bm25f1',
+      description: 'bm25 function',
+      type: 1,
+    });
   });
 
   it('converts TIMESTAMPTZ default_value correctly', () => {
@@ -393,6 +359,80 @@ describe('utils/Schema', () => {
     });
   });
 
+  it('formats external collection when schema is used instead of fields', () => {
+    const schemaProtoPath = path.resolve(
+      __dirname,
+      '../../proto/proto/schema.proto'
+    );
+    const schemaProto = protobuf.loadSync(schemaProtoPath);
+
+    const fieldSchemaType = schemaProto.lookupType(
+      'milvus.proto.schema.FieldSchema'
+    );
+
+    const data = {
+      collection_name: 'externalCollection',
+      external_source: 's3://bucket/path',
+      schema: [
+        {
+          name: 'external_id',
+          data_type: DataType.Int64,
+          external_field: 'row_id',
+        },
+      ],
+    } as CreateCollectionReq;
+
+    const payload = formatCollectionSchema(data, { fieldSchemaType });
+
+    expect(payload.externalSource).toBe('s3://bucket/path');
+    expect(payload.fields[0]).toHaveProperty('externalField', 'row_id');
+
+    const collectionSchemaType = schemaProto.lookupType(
+      'milvus.proto.schema.CollectionSchema'
+    );
+    const decoded = collectionSchemaType.toObject(
+      collectionSchemaType.decode(
+        collectionSchemaType
+          .encode(collectionSchemaType.create(payload))
+          .finish()
+      ),
+      { defaults: true }
+    );
+    expect(decoded.externalSource).toBe('s3://bucket/path');
+    expect(decoded.fields[0]).toHaveProperty('externalField', 'row_id');
+  });
+
+  it('formats external field for add collection field APIs', () => {
+    const schemaProtoPath = path.resolve(
+      __dirname,
+      '../../proto/proto/schema.proto'
+    );
+    const schemaProto = protobuf.loadSync(schemaProtoPath);
+
+    const fieldSchemaType = schemaProto.lookupType(
+      'milvus.proto.schema.FieldSchema'
+    );
+
+    const payload = formatFieldSchema(
+      {
+        name: 'product_name',
+        data_type: DataType.VarChar,
+        max_length: 256,
+        external_field: 'name',
+      },
+      { fieldSchemaType }
+    );
+    expect(payload.externalField).toBe('name');
+
+    const decoded = fieldSchemaType.toObject(
+      fieldSchemaType.decode(
+        fieldSchemaType.encode(fieldSchemaType.create(payload)).finish()
+      ),
+      { defaults: true }
+    );
+    expect(decoded.externalField).toBe('name');
+  });
+
   it('adds a dataType property to each field object in the schema', () => {
     const response: any = {
       virtual_channel_names: ['by-dev-rootcoord-dml_14_461525722618459440v0'],
@@ -427,6 +467,7 @@ describe('utils/Schema', () => {
             is_clustering_key: false,
             nullable: false,
             is_function_output: false,
+            external_field: 'row_id',
           },
           {
             type_params: [{ key: 'dim', value: '4' }],
@@ -583,6 +624,10 @@ describe('utils/Schema', () => {
         description: '',
         autoID: false,
         enable_dynamic_field: false,
+        external_source: 's3://bucket/path',
+        external_spec: '{"format":"parquet"}',
+        do_physical_backfill: true,
+        file_resource_ids: ['1', '2'],
         dbName: '',
       },
       collectionID: '461525722618459440',
@@ -603,6 +648,10 @@ describe('utils/Schema', () => {
 
     // Test that dataType property is added to each field
     expect(formatted.schema.fields[0]).toHaveProperty('dataType', 5); // Int64
+    expect(formatted.schema.fields[0]).toHaveProperty(
+      'external_field',
+      'row_id'
+    );
     expect(formatted.schema.fields[1]).toHaveProperty('dataType', 101); // FloatVector
     expect(formatted.schema.fields[1]).toHaveProperty('_placeholderType', 101); // EmbListFloatVector
     expect(formatted.schema.fields[2]).toHaveProperty('dataType', 21); // VarChar
@@ -703,6 +752,16 @@ describe('utils/Schema', () => {
     expect(formatted).toHaveProperty('collectionID', '461525722618459440');
     expect(formatted).toHaveProperty('schema');
     expect(formatted.schema).toHaveProperty('name', 'collection_qaw552nb');
+    expect(formatted.schema).toHaveProperty(
+      'external_source',
+      's3://bucket/path'
+    );
+    expect(formatted.schema).toHaveProperty(
+      'external_spec',
+      '{"format":"parquet"}'
+    );
+    expect(formatted.schema).toHaveProperty('do_physical_backfill', true);
+    expect(formatted.schema).toHaveProperty('file_resource_ids', ['1', '2']);
     expect(formatted.schema).toHaveProperty('properties');
     expect(formatted.schema).toHaveProperty('functions');
 

--- a/test/utils/Schema.spec.ts
+++ b/test/utils/Schema.spec.ts
@@ -5,6 +5,7 @@ import {
   _Field,
   FieldType,
   assignTypeParams,
+  buildDefaultSchema,
   convertToDataType,
   DataType,
   formatFieldSchema,
@@ -16,6 +17,30 @@ import {
 } from '../../milvus';
 
 describe('utils/Schema', () => {
+  it('builds the default schema from shorthand create collection params', () => {
+    expect(
+      buildDefaultSchema({
+        dimension: 8,
+        primary_field_name: 'id',
+        id_type: DataType.Int64,
+        vector_field_name: 'vector',
+        auto_id: true,
+      })
+    ).toEqual([
+      {
+        name: 'id',
+        data_type: DataType.Int64,
+        is_primary_key: true,
+        autoID: true,
+      },
+      {
+        name: 'vector',
+        data_type: DataType.FloatVector,
+        dim: 8,
+      },
+    ]);
+  });
+
   it('should assign properties with keys `dim` or `max_length` to the `type_params`, `enable_match`, `analyzer_params`, `enable_analyzer` object and delete them from the `field` object', () => {
     const field = {
       name: 'vector',
@@ -450,6 +475,75 @@ describe('utils/Schema', () => {
       input_field_names: ['text'],
       output_field_names: ['sparse'],
       params: [{ key: 'enable_match', value: 'true' }],
+    });
+  });
+
+  it('formats struct array fields in create collection schema', () => {
+    const schemaProtoPath = path.resolve(
+      __dirname,
+      '../../proto/proto/schema.proto'
+    );
+    const schemaProto = protobuf.loadSync(schemaProtoPath);
+
+    const fieldSchemaType = schemaProto.lookupType(
+      'milvus.proto.schema.FieldSchema'
+    );
+    const structArrayFieldSchemaType = schemaProto.lookupType(
+      'milvus.proto.schema.StructArrayFieldSchema'
+    );
+
+    const payload = formatCollectionSchema(
+      {
+        collection_name: 'structCollection',
+        fields: [
+          {
+            name: 'id',
+            data_type: DataType.Int64,
+            is_primary_key: true,
+          },
+          {
+            name: 'vector',
+            data_type: DataType.FloatVector,
+            dim: 4,
+          },
+          {
+            name: 'metadata',
+            data_type: DataType.Array,
+            element_type: DataType.Struct,
+            max_capacity: 2,
+            fields: [
+              {
+                name: 'score',
+                data_type: DataType.Float,
+              },
+              {
+                name: 'embedding',
+                data_type: DataType.FloatVector,
+                dim: 4,
+              },
+            ],
+          },
+        ],
+      } as CreateCollectionReq,
+      { fieldSchemaType, structArrayFieldSchemaType }
+    );
+
+    expect(payload.fields).toHaveLength(2);
+    expect(payload.structArrayFields).toHaveLength(1);
+    expect(payload.structArrayFields[0].name).toBe('metadata');
+    expect(payload.structArrayFields[0].fields[0]).toMatchObject({
+      name: 'score',
+      dataType: DataType.Array,
+      elementType: DataType.Float,
+    });
+    expect(payload.structArrayFields[0].fields[1]).toMatchObject({
+      name: 'embedding',
+      dataType: 106,
+      elementType: DataType.FloatVector,
+      typeParams: [
+        { key: 'dim', value: '4' },
+        { key: 'max_capacity', value: '2' },
+      ],
     });
   });
 

--- a/test/utils/Validate.spec.ts
+++ b/test/utils/Validate.spec.ts
@@ -5,12 +5,14 @@ import {
   isInvalidMessage,
   ERROR_REASONS,
   checkCollectionFields,
+  checkCollectionFieldsWithOptions,
   checkTimeParam,
   DataType,
   FieldType,
   checkCreateCollectionCompatibility,
   CreateCollectionReq,
   isVectorType,
+  MilvusClient,
 } from '../../milvus';
 
 describe('utils/validate', () => {
@@ -418,6 +420,201 @@ describe('utils/validate', () => {
       ERROR_REASONS.CREATE_COLLECTION_CHECK_VECTOR_FIELD_EXIST
     );
   });
+
+  it('should allow external collection fields without primary key or vector field', () => {
+    const fields: FieldType[] = [
+      {
+        name: 'external_id',
+        data_type: DataType.Int64,
+        external_field: 'row_id',
+      },
+      {
+        name: 'title',
+        data_type: DataType.VarChar,
+        max_length: 100,
+        external_field: 'title',
+      },
+    ];
+
+    expect(
+      checkCollectionFieldsWithOptions(fields, { isExternalCollection: true })
+    ).toBe(true);
+  });
+
+  it('should still validate external collection field type parameters', () => {
+    const fields: FieldType[] = [
+      {
+        name: 'title',
+        data_type: DataType.VarChar,
+        external_field: 'title',
+      },
+    ];
+
+    expect(() =>
+      checkCollectionFieldsWithOptions(fields, { isExternalCollection: true })
+    ).toThrowError(ERROR_REASONS.CREATE_COLLECTION_CHECK_MISS_MAX_LENGTH);
+  });
+
+  it('should throw an error if external collection enables auto id', async () => {
+    const milvusClient = new MilvusClient({
+      address: 'localhost:19530',
+      __SKIP_CONNECT__: true,
+    });
+
+    await expect(
+      milvusClient._createCollection({
+        collection_name: 'external_collection',
+        external_source: 's3://bucket/path',
+        auto_id: true,
+        fields: [
+          {
+            name: 'external_id',
+            data_type: DataType.Int64,
+            external_field: 'row_id',
+          },
+        ],
+      } as any)
+    ).rejects.toThrowError(ERROR_REASONS.CREATE_EXTERNAL_COLLECTION_AUTO_ID);
+
+    await expect(
+      milvusClient._createCollection({
+        collection_name: 'external_collection',
+        external_source: 's3://bucket/path',
+        fields: [
+          {
+            name: 'external_id',
+            data_type: DataType.Int64,
+            external_field: 'row_id',
+            autoID: true,
+          },
+        ],
+      })
+    ).rejects.toThrowError(ERROR_REASONS.CREATE_EXTERNAL_COLLECTION_AUTO_ID);
+  });
+
+  it('should throw an error if external collection defines primary key', async () => {
+    const milvusClient = new MilvusClient({
+      address: 'localhost:19530',
+      __SKIP_CONNECT__: true,
+    });
+
+    await expect(
+      milvusClient._createCollection({
+        collection_name: 'external_collection',
+        external_source: 's3://bucket/path',
+        fields: [
+          {
+            name: 'external_id',
+            data_type: DataType.Int64,
+            is_primary_key: true,
+            external_field: 'row_id',
+          },
+          {
+            name: 'vector',
+            data_type: DataType.FloatVector,
+            dim: 4,
+            external_field: 'vector',
+          },
+        ],
+      })
+    ).rejects.toThrowError(
+      ERROR_REASONS.CREATE_EXTERNAL_COLLECTION_PRIMARY_KEY
+    );
+  });
+
+  it('should call refresh external collection APIs with expected requests', async () => {
+    const grpcClient = {
+      RefreshExternalCollection: jest.fn((params, options, callback) =>
+        callback(null, {
+          status: { error_code: 'Success', reason: '' },
+          job_id: '42',
+        })
+      ),
+      GetRefreshExternalCollectionProgress: jest.fn(
+        (params, options, callback) =>
+          callback(null, {
+            status: { error_code: 'Success', reason: '' },
+            job_info: {
+              job_id: '42',
+              collection_name: 'external_collection',
+              state: 'RefreshCompleted',
+              progress: '100',
+              reason: '',
+              external_source: 's3://bucket/path',
+              start_time: '1',
+              end_time: '2',
+            },
+          })
+      ),
+      ListRefreshExternalCollectionJobs: jest.fn((params, options, callback) =>
+        callback(null, {
+          status: { error_code: 'Success', reason: '' },
+          jobs: [],
+        })
+      ),
+    };
+    const channelPool = {
+      acquire: jest.fn().mockResolvedValue(grpcClient),
+      release: jest.fn(),
+    };
+    const milvusClient = new MilvusClient({
+      address: 'localhost:19530',
+      __SKIP_CONNECT__: true,
+    });
+    (milvusClient as any).channelPool = channelPool;
+
+    await expect(
+      milvusClient.refreshExternalCollection({} as any)
+    ).rejects.toThrowError(ERROR_REASONS.COLLECTION_NAME_IS_REQUIRED);
+
+    const refresh = await milvusClient.refreshExternalCollection({
+      db_name: 'default',
+      collection_name: 'external_collection',
+      external_source: 's3://bucket/path',
+      external_spec: '{"format":"parquet"}',
+    });
+    expect(refresh.job_id).toBe('42');
+    expect(grpcClient.RefreshExternalCollection).toHaveBeenCalledWith(
+      {
+        db_name: 'default',
+        collection_name: 'external_collection',
+        external_source: 's3://bucket/path',
+        external_spec: '{"format":"parquet"}',
+      },
+      expect.any(Object),
+      expect.any(Function)
+    );
+
+    await expect(
+      milvusClient.getRefreshExternalCollectionProgress({} as any)
+    ).rejects.toThrowError('The `job_id` property is missing.');
+
+    const progress = await milvusClient.getRefreshExternalCollectionProgress({
+      job_id: 42,
+    });
+    expect(progress.job_info.collection_name).toBe('external_collection');
+    expect(
+      grpcClient.GetRefreshExternalCollectionProgress
+    ).toHaveBeenCalledWith(
+      { job_id: 42 },
+      expect.any(Object),
+      expect.any(Function)
+    );
+
+    await milvusClient.listRefreshExternalCollectionJobs({
+      db_name: 'default',
+      collection_name: 'external_collection',
+    });
+    expect(grpcClient.ListRefreshExternalCollectionJobs).toHaveBeenCalledWith(
+      {
+        db_name: 'default',
+        collection_name: 'external_collection',
+      },
+      expect.any(Object),
+      expect.any(Function)
+    );
+  });
+
   it(`should return true for a bigint input`, () => {
     expect(checkTimeParam(BigInt(123))).toBe(true);
   });


### PR DESCRIPTION
## Summary
- Add external collection schema fields and validation, including external field mappings and primary-key/auto-id restrictions.
- Add refresh external collection APIs and response types.
- Add unit coverage plus a gRPC external collection integration test against Milvus 3.0.

## Tests
- NODE_ENV=dev npx jest test/utils/Schema.spec.ts test/utils/Validate.spec.ts test/grpc/ExternalCollection.spec.ts --runInBand
- npm run build