### PR TITLE
feat: add snapshot APIs

### DIFF
--- a/milvus/grpc/Collection.ts
+++ b/milvus/grpc/Collection.ts
@@ -73,6 +73,21 @@ import {
   GetRefreshExternalCollectionProgressResponse,
   ListRefreshExternalCollectionJobsReq,
   ListRefreshExternalCollectionJobsResponse,
+  CreateSnapshotReq,
+  DropSnapshotReq,
+  ListSnapshotsReq,
+  ListSnapshotsResponse,
+  DescribeSnapshotReq,
+  DescribeSnapshotResponse,
+  RestoreSnapshotReq,
+  RestoreSnapshotResponse,
+  GetRestoreSnapshotStateReq,
+  GetRestoreSnapshotStateResponse,
+  ListRestoreSnapshotJobsReq,
+  ListRestoreSnapshotJobsResponse,
+  PinSnapshotDataReq,
+  PinSnapshotDataResponse,
+  UnpinSnapshotDataReq,
 } from '../';
 
 /**
@@ -1745,6 +1760,273 @@ export class Collection extends Database {
     return await promisify(
       this.channelPool,
       'ListRefreshExternalCollectionJobs',
+      data,
+      data.timeout || this.timeout
+    );
+  }
+
+  /**
+   * Create a snapshot for a collection.
+   *
+   * @param {CreateSnapshotReq} data - The request parameters.
+   * @param {string} data.snapshot_name - The snapshot name.
+   * @param {string} data.collection_name - The collection to snapshot.
+   * @param {string} [data.db_name] - The database name.
+   * @param {string} [data.description] - Optional snapshot description.
+   * @param {number|string} [data.compaction_protection_seconds] - Duration to protect referenced segments from compaction.
+   * @param {number} [data.timeout] - An optional duration of time in milliseconds to allow for the RPC.
+   *
+   * @returns {Promise<ResStatus>} The response status of the operation.
+   */
+  async createSnapshot(data: CreateSnapshotReq): Promise<ResStatus> {
+    checkCollectionName(data);
+    if (!data.snapshot_name) {
+      throw new Error('The `snapshot_name` property is missing.');
+    }
+
+    const { snapshot_name, timeout, ...rest } = data;
+    const req = {
+      ...rest,
+      name: snapshot_name,
+    };
+
+    return await promisify(
+      this.channelPool,
+      'CreateSnapshot',
+      req,
+      timeout || this.timeout
+    );
+  }
+
+  /**
+   * Drop a snapshot.
+   *
+   * @param {DropSnapshotReq} data - The request parameters.
+   * @param {string} data.snapshot_name - The snapshot name.
+   * @param {string} data.collection_name - The collection the snapshot belongs to.
+   * @param {string} [data.db_name] - The database name.
+   * @param {number} [data.timeout] - An optional duration of time in milliseconds to allow for the RPC.
+   *
+   * @returns {Promise<ResStatus>} The response status of the operation.
+   */
+  async dropSnapshot(data: DropSnapshotReq): Promise<ResStatus> {
+    checkCollectionName(data);
+    if (!data.snapshot_name) {
+      throw new Error('The `snapshot_name` property is missing.');
+    }
+
+    const { snapshot_name, timeout, ...rest } = data;
+    const req = {
+      ...rest,
+      name: snapshot_name,
+    };
+
+    return await promisify(
+      this.channelPool,
+      'DropSnapshot',
+      req,
+      timeout || this.timeout
+    );
+  }
+
+  /**
+   * List snapshots for a collection.
+   *
+   * @param {ListSnapshotsReq} data - The request parameters.
+   * @param {string} data.collection_name - The collection name.
+   * @param {string} [data.db_name] - The database name.
+   * @param {number} [data.timeout] - An optional duration of time in milliseconds to allow for the RPC.
+   *
+   * @returns {Promise<ListSnapshotsResponse>} The list snapshots response.
+   */
+  async listSnapshots(data: ListSnapshotsReq): Promise<ListSnapshotsResponse> {
+    checkCollectionName(data);
+
+    return await promisify(
+      this.channelPool,
+      'ListSnapshots',
+      data,
+      data.timeout || this.timeout
+    );
+  }
+
+  /**
+   * Describe a snapshot.
+   *
+   * @param {DescribeSnapshotReq} data - The request parameters.
+   * @param {string} data.snapshot_name - The snapshot name.
+   * @param {string} data.collection_name - The collection the snapshot belongs to.
+   * @param {string} [data.db_name] - The database name.
+   * @param {number} [data.timeout] - An optional duration of time in milliseconds to allow for the RPC.
+   *
+   * @returns {Promise<DescribeSnapshotResponse>} The snapshot description response.
+   */
+  async describeSnapshot(
+    data: DescribeSnapshotReq
+  ): Promise<DescribeSnapshotResponse> {
+    checkCollectionName(data);
+    if (!data.snapshot_name) {
+      throw new Error('The `snapshot_name` property is missing.');
+    }
+
+    const { snapshot_name, timeout, ...rest } = data;
+    const req = {
+      ...rest,
+      name: snapshot_name,
+    };
+
+    return await promisify(
+      this.channelPool,
+      'DescribeSnapshot',
+      req,
+      timeout || this.timeout
+    );
+  }
+
+  /**
+   * Restore a snapshot into a target collection.
+   *
+   * @param {RestoreSnapshotReq} data - The request parameters.
+   * @param {string} data.snapshot_name - The snapshot name.
+   * @param {string} data.source_collection_name - The source collection name.
+   * @param {string} data.target_collection_name - The target collection name.
+   * @param {string} [data.source_db_name] - The source database name.
+   * @param {string} [data.target_db_name] - The target database name.
+   * @param {number} [data.timeout] - An optional duration of time in milliseconds to allow for the RPC.
+   *
+   * @returns {Promise<RestoreSnapshotResponse>} The restore job response.
+   */
+  async restoreSnapshot(
+    data: RestoreSnapshotReq
+  ): Promise<RestoreSnapshotResponse> {
+    if (!data || !data.snapshot_name) {
+      throw new Error('The `snapshot_name` property is missing.');
+    }
+    if (!data.source_collection_name) {
+      throw new Error('The `source_collection_name` property is missing.');
+    }
+    if (!data.target_collection_name) {
+      throw new Error('The `target_collection_name` property is missing.');
+    }
+
+    const {
+      snapshot_name,
+      source_collection_name,
+      source_db_name,
+      timeout,
+      ...rest
+    } = data;
+    const req = {
+      ...rest,
+      name: snapshot_name,
+      db_name: source_db_name,
+      collection_name: source_collection_name,
+    };
+
+    return await promisify(
+      this.channelPool,
+      'RestoreSnapshot',
+      req,
+      timeout || this.timeout
+    );
+  }
+
+  /**
+   * Get the state of a restore snapshot job.
+   *
+   * @param {GetRestoreSnapshotStateReq} data - The request parameters.
+   * @param {number|string} data.job_id - The restore job ID.
+   * @param {number} [data.timeout] - An optional duration of time in milliseconds to allow for the RPC.
+   *
+   * @returns {Promise<GetRestoreSnapshotStateResponse>} The restore job state response.
+   */
+  async getRestoreSnapshotState(
+    data: GetRestoreSnapshotStateReq
+  ): Promise<GetRestoreSnapshotStateResponse> {
+    if (!data || typeof data.job_id === 'undefined') {
+      throw new Error('The `job_id` property is missing.');
+    }
+
+    return await promisify(
+      this.channelPool,
+      'GetRestoreSnapshotState',
+      data,
+      data.timeout || this.timeout
+    );
+  }
+
+  /**
+   * List restore snapshot jobs.
+   *
+   * @param {ListRestoreSnapshotJobsReq} data - The request parameters.
+   * @param {string} [data.collection_name] - Optional target collection name filter.
+   * @param {string} [data.db_name] - Optional database name filter.
+   * @param {number} [data.timeout] - An optional duration of time in milliseconds to allow for the RPC.
+   *
+   * @returns {Promise<ListRestoreSnapshotJobsResponse>} The restore jobs response.
+   */
+  async listRestoreSnapshotJobs(
+    data: ListRestoreSnapshotJobsReq = {}
+  ): Promise<ListRestoreSnapshotJobsResponse> {
+    return await promisify(
+      this.channelPool,
+      'ListRestoreSnapshotJobs',
+      data,
+      data.timeout || this.timeout
+    );
+  }
+
+  /**
+   * Pin snapshot data to prevent garbage collection while it is being copied out.
+   *
+   * @param {PinSnapshotDataReq} data - The request parameters.
+   * @param {string} data.snapshot_name - The snapshot name.
+   * @param {string} data.collection_name - The collection the snapshot belongs to.
+   * @param {string} [data.db_name] - The database name.
+   * @param {number|string} [data.ttl_seconds] - Optional pin TTL in seconds.
+   * @param {number} [data.timeout] - An optional duration of time in milliseconds to allow for the RPC.
+   *
+   * @returns {Promise<PinSnapshotDataResponse>} The pin response.
+   */
+  async pinSnapshotData(
+    data: PinSnapshotDataReq
+  ): Promise<PinSnapshotDataResponse> {
+    checkCollectionName(data);
+    if (!data.snapshot_name) {
+      throw new Error('The `snapshot_name` property is missing.');
+    }
+
+    const { snapshot_name, timeout, ...rest } = data;
+    const req = {
+      ...rest,
+      name: snapshot_name,
+    };
+
+    return await promisify(
+      this.channelPool,
+      'PinSnapshotData',
+      req,
+      timeout || this.timeout
+    );
+  }
+
+  /**
+   * Release a snapshot data pin.
+   *
+   * @param {UnpinSnapshotDataReq} data - The request parameters.
+   * @param {number|string} data.pin_id - The pin ID returned by pinSnapshotData().
+   * @param {number} [data.timeout] - An optional duration of time in milliseconds to allow for the RPC.
+   *
+   * @returns {Promise<ResStatus>} The response status of the operation.
+   */
+  async unpinSnapshotData(data: UnpinSnapshotDataReq): Promise<ResStatus> {
+    if (!data || typeof data.pin_id === 'undefined') {
+      throw new Error('The `pin_id` property is missing.');
+    }
+
+    return await promisify(
+      this.channelPool,
+      'UnpinSnapshotData',
       data,
       data.timeout || this.timeout
     );

--- a/milvus/types/Collection.ts
+++ b/milvus/types/Collection.ts
@@ -393,6 +393,97 @@ export interface ListRefreshExternalCollectionJobsResponse extends resStatusResp
   jobs: RefreshExternalCollectionJobInfo[];
 }
 
+export enum RestoreSnapshotState {
+  RestoreSnapshotNone = 'RestoreSnapshotNone',
+  RestoreSnapshotPending = 'RestoreSnapshotPending',
+  RestoreSnapshotExecuting = 'RestoreSnapshotExecuting',
+  RestoreSnapshotCompleted = 'RestoreSnapshotCompleted',
+  RestoreSnapshotFailed = 'RestoreSnapshotFailed',
+}
+
+export interface CreateSnapshotReq extends collectionNameReq {
+  snapshot_name: string;
+  description?: string;
+  compaction_protection_seconds?: number | string;
+}
+
+export interface DropSnapshotReq extends collectionNameReq {
+  snapshot_name: string;
+}
+
+export interface ListSnapshotsReq extends collectionNameReq {}
+
+export interface ListSnapshotsResponse extends resStatusResponse {
+  snapshots: string[];
+}
+
+export interface DescribeSnapshotReq extends collectionNameReq {
+  snapshot_name: string;
+}
+
+export interface DescribeSnapshotResponse extends resStatusResponse {
+  name: string;
+  description: string;
+  collection_name: string;
+  partition_names: string[];
+  create_ts: string;
+  s3_location: string;
+}
+
+export interface RestoreSnapshotReq extends GrpcTimeOut {
+  snapshot_name: string;
+  source_collection_name: string;
+  target_collection_name: string;
+  source_db_name?: string;
+  target_db_name?: string;
+}
+
+export interface RestoreSnapshotResponse extends resStatusResponse {
+  job_id: string;
+}
+
+export interface GetRestoreSnapshotStateReq extends GrpcTimeOut {
+  job_id: number | string;
+}
+
+export interface RestoreSnapshotJobInfo {
+  job_id: string;
+  snapshot_name: string;
+  db_name: string;
+  collection_name: string;
+  state: RestoreSnapshotState | keyof typeof RestoreSnapshotState;
+  progress: number;
+  reason: string;
+  start_time: string;
+  time_cost: string;
+}
+
+export interface GetRestoreSnapshotStateResponse extends resStatusResponse {
+  info: RestoreSnapshotJobInfo;
+}
+
+export interface ListRestoreSnapshotJobsReq extends GrpcTimeOut {
+  db_name?: string;
+  collection_name?: string;
+}
+
+export interface ListRestoreSnapshotJobsResponse extends resStatusResponse {
+  jobs: RestoreSnapshotJobInfo[];
+}
+
+export interface PinSnapshotDataReq extends collectionNameReq {
+  snapshot_name: string;
+  ttl_seconds?: number | string;
+}
+
+export interface PinSnapshotDataResponse extends resStatusResponse {
+  pin_id: string;
+}
+
+export interface UnpinSnapshotDataReq extends GrpcTimeOut {
+  pin_id: number | string;
+}
+
 export interface DescribeAliasResponse extends resStatusResponse {
   db_name: string;
   alias: string;

--- a/test/grpc/Snapshot.spec.ts
+++ b/test/grpc/Snapshot.spec.ts
@@ -1,0 +1,110 @@
+import { DataType, ErrorCode, MilvusClient } from '../../milvus';
+import { GENERATE_NAME, IP } from '../tools';
+
+const milvusClient = new MilvusClient({ address: IP, logLevel: 'info' });
+
+describe('Snapshot API', () => {
+  const collectionName = GENERATE_NAME('snapshot_collection');
+  const restoredCollectionName = GENERATE_NAME('snapshot_restored');
+  const snapshotName = GENERATE_NAME('snapshot');
+
+  beforeAll(async () => {
+    const create = await milvusClient.createCollection({
+      collection_name: collectionName,
+      fields: [
+        {
+          name: 'id',
+          data_type: DataType.Int64,
+          is_primary_key: true,
+        },
+        {
+          name: 'vector',
+          data_type: DataType.FloatVector,
+          dim: 4,
+        },
+      ],
+    });
+    expect(create.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const insert = await milvusClient.insert({
+      collection_name: collectionName,
+      data: [
+        { id: 1, vector: [0.1, 0.2, 0.3, 0.4] },
+        { id: 2, vector: [0.2, 0.3, 0.4, 0.5] },
+      ],
+    });
+    expect(insert.status.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const flush = await milvusClient.flush({
+      collection_names: [collectionName],
+    });
+    expect(flush.status.error_code).toEqual(ErrorCode.SUCCESS);
+  });
+
+  afterAll(async () => {
+    await milvusClient.dropSnapshot({
+      snapshot_name: snapshotName,
+      collection_name: collectionName,
+    });
+    await milvusClient.dropCollection({ collection_name: collectionName });
+    await milvusClient.dropCollection({
+      collection_name: restoredCollectionName,
+    });
+  });
+
+  it('creates, lists, describes, pins, unpins, restores, and tracks a snapshot', async () => {
+    const create = await milvusClient.createSnapshot({
+      snapshot_name: snapshotName,
+      collection_name: collectionName,
+      description: 'node sdk snapshot test',
+      compaction_protection_seconds: 0,
+    });
+    expect(create.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const snapshots = await milvusClient.listSnapshots({
+      collection_name: collectionName,
+    });
+    expect(snapshots.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(snapshots.snapshots).toContain(snapshotName);
+
+    const describe = await milvusClient.describeSnapshot({
+      snapshot_name: snapshotName,
+      collection_name: collectionName,
+    });
+    expect(describe.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(describe.name).toEqual(snapshotName);
+    expect(describe.collection_name).toEqual(collectionName);
+    expect(describe.description).toEqual('node sdk snapshot test');
+
+    const pin = await milvusClient.pinSnapshotData({
+      snapshot_name: snapshotName,
+      collection_name: collectionName,
+      ttl_seconds: 60,
+    });
+    expect(pin.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(pin.pin_id).toBeTruthy();
+
+    const unpin = await milvusClient.unpinSnapshotData({ pin_id: pin.pin_id });
+    expect(unpin.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const restore = await milvusClient.restoreSnapshot({
+      snapshot_name: snapshotName,
+      source_collection_name: collectionName,
+      target_collection_name: restoredCollectionName,
+    });
+    expect(restore.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(restore.job_id).toBeTruthy();
+
+    const state = await milvusClient.getRestoreSnapshotState({
+      job_id: restore.job_id,
+    });
+    expect(state.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(state.info.snapshot_name).toEqual(snapshotName);
+
+    const jobs = await milvusClient.listRestoreSnapshotJobs({
+      collection_name: restoredCollectionName,
+    });
+    expect(jobs.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(jobs.jobs.some(job => job.job_id === restore.job_id)).toBe(true);
+  });
+});

--- a/test/grpc/Snapshot.spec.ts
+++ b/test/grpc/Snapshot.spec.ts
@@ -52,6 +52,67 @@ describe('Snapshot API', () => {
     });
   });
 
+  it('validates required snapshot request fields before sending RPCs', async () => {
+    await expect(milvusClient.createSnapshot({} as any)).rejects.toThrow(
+      'The `collection_name` property is missing.'
+    );
+
+    await expect(
+      milvusClient.createSnapshot({ collection_name: collectionName } as any)
+    ).rejects.toThrow('The `snapshot_name` property is missing.');
+
+    await expect(milvusClient.dropSnapshot({} as any)).rejects.toThrow(
+      'The `collection_name` property is missing.'
+    );
+
+    await expect(
+      milvusClient.dropSnapshot({ collection_name: collectionName } as any)
+    ).rejects.toThrow('The `snapshot_name` property is missing.');
+
+    await expect(milvusClient.listSnapshots({} as any)).rejects.toThrow(
+      'The `collection_name` property is missing.'
+    );
+
+    await expect(milvusClient.describeSnapshot({} as any)).rejects.toThrow(
+      'The `collection_name` property is missing.'
+    );
+
+    await expect(
+      milvusClient.describeSnapshot({ collection_name: collectionName } as any)
+    ).rejects.toThrow('The `snapshot_name` property is missing.');
+
+    await expect(milvusClient.restoreSnapshot({} as any)).rejects.toThrow(
+      'The `snapshot_name` property is missing.'
+    );
+
+    await expect(
+      milvusClient.restoreSnapshot({ snapshot_name: snapshotName } as any)
+    ).rejects.toThrow('The `source_collection_name` property is missing.');
+
+    await expect(
+      milvusClient.restoreSnapshot({
+        snapshot_name: snapshotName,
+        source_collection_name: collectionName,
+      } as any)
+    ).rejects.toThrow('The `target_collection_name` property is missing.');
+
+    await expect(
+      milvusClient.getRestoreSnapshotState({} as any)
+    ).rejects.toThrow('The `job_id` property is missing.');
+
+    await expect(milvusClient.pinSnapshotData({} as any)).rejects.toThrow(
+      'The `collection_name` property is missing.'
+    );
+
+    await expect(
+      milvusClient.pinSnapshotData({ collection_name: collectionName } as any)
+    ).rejects.toThrow('The `snapshot_name` property is missing.');
+
+    await expect(milvusClient.unpinSnapshotData({} as any)).rejects.toThrow(
+      'The `pin_id` property is missing.'
+    );
+  });
+
   it('creates, lists, describes, pins, unpins, restores, and tracks a snapshot', async () => {
     const create = await milvusClient.createSnapshot({
       snapshot_name: snapshotName,
@@ -106,5 +167,9 @@ describe('Snapshot API', () => {
     });
     expect(jobs.status.error_code).toEqual(ErrorCode.SUCCESS);
     expect(jobs.jobs.some(job => job.job_id === restore.job_id)).toBe(true);
+
+    const allJobs = await milvusClient.listRestoreSnapshotJobs();
+    expect(allJobs.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(allJobs.jobs.some(job => job.job_id === restore.job_id)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Add TypeScript request and response types for Milvus snapshot operations.
- Expose snapshot management methods on the gRPC collection client, including create/drop/list/describe/restore, restore job tracking, and pin/unpin data.
- Add a local Milvus 3.0 integration test covering the snapshot lifecycle.

## Test
- `NODE_ENV=dev npx jest test/grpc/Snapshot.spec.ts`
- `npm run build`