### PR TITLE
feat: support element-level result offsets

### DIFF
--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -1140,6 +1140,21 @@ export class Data extends Collection {
       return acc;
     }, []);
 
+    if (promise.element_indices && promise.element_indices.length > 0) {
+      if (promise.element_indices.length !== results.length) {
+        throw new Error(
+          `element_indices length (${promise.element_indices.length}) != query result length (${results.length})`
+        );
+      }
+
+      results = promise.element_indices.flatMap((elementIndex, i) =>
+        elementIndex.indices.data.map(elementOffset => ({
+          ...results[i],
+          offset: elementOffset,
+        }))
+      );
+    }
+
     return {
       status: promise.status,
       data: results,

--- a/milvus/types/Data.ts
+++ b/milvus/types/Data.ts
@@ -64,6 +64,12 @@ export interface QueryResults extends resStatusResponse {
   data: Record<string, any>[];
 }
 
+export interface ElementIndices {
+  indices: {
+    data: number[] | string[];
+  };
+}
+
 export interface CountResult extends resStatusResponse {
   data: number;
 }
@@ -129,4 +135,5 @@ export interface QueryRes extends resStatusResponse {
   }[];
   output_fields: string[];
   collection_name: string;
+  element_indices?: ElementIndices[];
 }

--- a/milvus/types/Search.ts
+++ b/milvus/types/Search.ts
@@ -12,6 +12,7 @@ import {
   SparseVectorDic,
   SparseFloatVector,
   Int8Vector,
+  FieldData,
 } from '../';
 
 // Highlighter types
@@ -160,28 +161,30 @@ export type HybridSearchReq = Omit<
   rerank?: RerankerObj | FunctionObject | FunctionScore;
 };
 
+export interface SearchFieldData {
+  type: string;
+  field_name: string;
+  field_id: number;
+  field: 'vectors' | 'scalars';
+  vectors?: {
+    dim: string;
+    data: 'float_vector' | 'binary_vector';
+    float_vector?: {
+      data: number[];
+    };
+    binary_vector?: Buffer;
+  };
+  scalars: {
+    [x: string]: any;
+    data: string;
+  };
+}
+
 // search api response type
 export interface SearchRes extends resStatusResponse {
   results: {
     top_k: number;
-    fields_data: {
-      type: string;
-      field_name: string;
-      field_id: number;
-      field: 'vectors' | 'scalars';
-      vectors?: {
-        dim: string;
-        data: 'float_vector' | 'binary_vector';
-        float_vector?: {
-          data: number[];
-        };
-        binary_vector?: Buffer;
-      };
-      scalars: {
-        [x: string]: any;
-        data: string;
-      };
-    }[];
+    fields_data: SearchFieldData[];
     scores: number[];
     ids: {
       int_id?: {
@@ -195,7 +198,10 @@ export interface SearchRes extends resStatusResponse {
     num_queries: number;
     topks: number[];
     output_fields: string[];
-    group_by_field_value: string;
+    group_by_field_value?: SearchFieldData | null;
+    group_by_field_values?: SearchFieldData[];
+    element_indices?: { data: number[] | string[] };
+    primary_field_name?: string;
     recalls: number[];
     search_iterator_v2_results?: Record<string, any>;
     _search_iterator_v2_results?: string;
@@ -235,6 +241,8 @@ export interface SearchResultData {
   [x: string]: any;
   score: number;
   id: string;
+  offset?: number | string;
+  group_by_field_values?: Record<string, FieldData>;
   highlight?: HighlightResult;
 }
 

--- a/milvus/utils/Bytes.ts
+++ b/milvus/utils/Bytes.ts
@@ -13,6 +13,7 @@ import {
   FieldSchema,
   PlaceholderType,
   SearchData,
+  PlaceholderType as PlaceholderTypeEnum,
 } from '..';
 
 /**
@@ -291,9 +292,11 @@ export const bytesToSparseRow = (bufferData: Buffer): SparseFloatVector => {
 export const buildPlaceholderGroupBytes = (
   milvusProto: Root,
   data: [SearchData] | SearchData[],
-  field: FieldSchema
+  field: FieldSchema,
+  placeholderType?: PlaceholderTypeEnum
 ) => {
-  const { is_function_output, _placeholderType } = field as any;
+  const { is_function_output } = field as any;
+  const _placeholderType = placeholderType || (field as any)._placeholderType;
   // create placeholder_group value
   let bytes;
 

--- a/milvus/utils/Search.ts
+++ b/milvus/utils/Search.ts
@@ -352,9 +352,11 @@ export const buildSearchRequest = (
       !isPlainStructVectorMetric &&
       Array.isArray(data) &&
       Array.isArray((data as any)[0]);
-    const placeholderType = isEmbeddingListData
+    const placeholderType = (annsField as any).is_function_output
       ? (annsField as any)._placeholderType
-      : annsField.dataType || DataTypeMap[annsField.data_type];
+      : isEmbeddingListData
+        ? (annsField as any)._placeholderType
+        : annsField.dataType || DataTypeMap[annsField.data_type];
     const searchData =
       ids && ids.length > 0
         ? []

--- a/milvus/utils/Search.ts
+++ b/milvus/utils/Search.ts
@@ -334,8 +334,34 @@ export const buildSearchRequest = (
     if ((!ids || ids.length === 0) && !data) {
       throw new Error('Search data is required');
     }
+    const metricType = annsField.index_params?.find(
+      param => param.key === 'metric_type'
+    )?.value;
+    const isPlainStructVectorMetric =
+      metricType !== undefined && !String(metricType).startsWith('MAX_SIM');
+    const isEmbeddingListPlaceholder = [
+      PlaceholderType.EmbListFloatVector,
+      PlaceholderType.EmbListBinaryVector,
+      PlaceholderType.EmbListFloat16Vector,
+      PlaceholderType.EmbListBFloat16Vector,
+      PlaceholderType.EmbListSparseFloatVector,
+      PlaceholderType.EmbListInt8Vector,
+    ].includes((annsField as any)._placeholderType);
+    const isEmbeddingListData =
+      isEmbeddingListPlaceholder &&
+      !isPlainStructVectorMetric &&
+      Array.isArray(data) &&
+      Array.isArray((data as any)[0]);
+    const placeholderType = isEmbeddingListData
+      ? (annsField as any)._placeholderType
+      : annsField.dataType || DataTypeMap[annsField.data_type];
     const searchData =
-      ids && ids.length > 0 ? [] : formatSearchData(data!, annsField);
+      ids && ids.length > 0
+        ? []
+        : formatSearchData(data!, {
+          ...annsField,
+          _placeholderType: placeholderType,
+        } as FieldSchema);
 
     const request: FormatedSearchRequest = {
       collection_name: params.collection_name,
@@ -362,7 +388,8 @@ export const buildSearchRequest = (
       request.placeholder_group = buildPlaceholderGroupBytes(
         milvusProto,
         searchData,
-        annsField
+        annsField,
+        placeholderType
       );
     }
 
@@ -473,9 +500,20 @@ export const formatSearchResult = (
   const { round_decimal } = options;
   // build final results array
   const results: any[] = [];
-  const { topks, scores, fields_data, highlight_results } = searchRes.results;
+  const {
+    topks,
+    scores,
+    fields_data,
+    highlight_results,
+    element_indices,
+    group_by_field_values,
+  } = searchRes.results;
+  const elementOffsets = element_indices?.data;
   // build fields data map
   const fieldsDataMap = buildFieldDataMap(fields_data, options.transformers);
+  const groupByFieldValuesMap = group_by_field_values?.length
+    ? buildFieldDataMap(group_by_field_values, options.transformers)
+    : undefined;
   // build output name array
   const output_fields = [
     ...(!!searchRes.results.output_fields?.length
@@ -510,6 +548,17 @@ export const formatSearchResult = (
             : formatNumberPrecision(score, round_decimal);
 
         const result: any = { score: fixedScore };
+
+        if (elementOffsets && elementOffsets.length > 0) {
+          result.offset = elementOffsets[absoluteIndex];
+        }
+
+        if (groupByFieldValuesMap) {
+          result.group_by_field_values = {};
+          groupByFieldValuesMap.forEach((data, fieldName) => {
+            result.group_by_field_values[fieldName] = data[absoluteIndex];
+          });
+        }
 
         // Get ID - Assuming ID field name is known or included in output_fields
         // Example: const idFieldName = collectionInfo.schema.primary_field_name;

--- a/test/grpc/ElementLevel.spec.ts
+++ b/test/grpc/ElementLevel.spec.ts
@@ -100,6 +100,24 @@ describe('Element-level query/search', () => {
     await milvusClient.dropDatabase(dbParam);
   });
 
+  it('should return offsets for element-level query rows', async () => {
+    const query = await milvusClient.query({
+      collection_name: COLLECTION_NAME,
+      filter: 'element_filter(items, $[order] == 20)',
+      output_fields: ['id', 'items[label]', 'items[order]'],
+    });
+
+    expect(query.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(query.data).toHaveLength(1);
+    expect(query.data[0]).toMatchObject({
+      id: '1',
+      offset: '1',
+    });
+    const matchedElement = query.data[0].items[Number(query.data[0].offset)];
+    expect(matchedElement.label).toEqual('second');
+    expect(matchedElement.order).toEqual(20);
+  });
+
   it('should return offsets for element-level search hits', async () => {
     const search = await milvusClient.search({
       collection_name: COLLECTION_NAME,
@@ -108,8 +126,6 @@ describe('Element-level query/search', () => {
       output_fields: ['id', 'items[label]', 'items[order]'],
       limit: 3,
     });
-
-    console.dir(search, { depth: null });
 
     expect(search.status.error_code).toEqual(ErrorCode.SUCCESS);
     expect(search.results[0]).toMatchObject({

--- a/test/grpc/ElementLevel.spec.ts
+++ b/test/grpc/ElementLevel.spec.ts
@@ -1,0 +1,124 @@
+import {
+  MilvusClient,
+  DataType,
+  ErrorCode,
+  IndexType,
+  MetricType,
+} from '../../milvus';
+import { GENERATE_NAME, IP } from '../tools';
+
+const milvusClient = new MilvusClient({
+  address: IP,
+  logLevel: 'info',
+});
+const COLLECTION_NAME = GENERATE_NAME('element_level');
+const dbParam = { db_name: 'element_level_DB' };
+
+const vectors = {
+  first: [1, 0, 0, 0],
+  second: [0, 1, 0, 0],
+  third: [0, 0, 1, 0],
+  fourth: [0, 0, 0, 1],
+  fifth: [-1, 0, 0, 0],
+};
+
+describe('Element-level query/search', () => {
+  beforeAll(async () => {
+    await milvusClient.createDatabase(dbParam);
+    await milvusClient.use(dbParam);
+    await milvusClient.createCollection({
+      collection_name: COLLECTION_NAME,
+      consistency_level: 'Strong',
+      fields: [
+        {
+          name: 'id',
+          data_type: DataType.Int64,
+          is_primary_key: true,
+          autoID: false,
+        },
+        {
+          name: 'items',
+          data_type: DataType.Array,
+          element_type: DataType.Struct,
+          max_capacity: 3,
+          fields: [
+            {
+              name: 'label',
+              data_type: DataType.VarChar,
+              max_length: 16,
+            },
+            {
+              name: 'order',
+              data_type: DataType.Int32,
+            },
+            {
+              name: 'embedding',
+              data_type: DataType.FloatVector,
+              dim: 4,
+            },
+          ],
+        },
+      ],
+    });
+    await milvusClient.insert({
+      collection_name: COLLECTION_NAME,
+      data: [
+        {
+          id: 1,
+          items: [
+            { label: 'first', order: 10, embedding: vectors.first },
+            { label: 'second', order: 20, embedding: vectors.second },
+            { label: 'third', order: 30, embedding: vectors.third },
+          ],
+        },
+        {
+          id: 2,
+          items: [
+            { label: 'fourth', order: 40, embedding: vectors.fourth },
+            { label: 'fifth', order: 50, embedding: vectors.fifth },
+          ],
+        },
+      ],
+    });
+    await milvusClient.flush({ collection_names: [COLLECTION_NAME] });
+    const index = await milvusClient.createIndex({
+      collection_name: COLLECTION_NAME,
+      field_name: 'items[embedding]',
+      index_name: 'items_embedding_cosine',
+      metric_type: MetricType.COSINE,
+      index_type: IndexType.AUTOINDEX,
+    });
+    expect(index.error_code).toEqual(ErrorCode.SUCCESS);
+    const load = await milvusClient.loadCollection({
+      collection_name: COLLECTION_NAME,
+    });
+    expect(load.error_code).toEqual(ErrorCode.SUCCESS);
+  });
+
+  afterAll(async () => {
+    await milvusClient.dropCollection({ collection_name: COLLECTION_NAME });
+    await milvusClient.dropDatabase(dbParam);
+  });
+
+  it('should return offsets for element-level search hits', async () => {
+    const search = await milvusClient.search({
+      collection_name: COLLECTION_NAME,
+      data: vectors.second,
+      anns_field: 'items[embedding]',
+      output_fields: ['id', 'items[label]', 'items[order]'],
+      limit: 3,
+    });
+
+    console.dir(search, { depth: null });
+
+    expect(search.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(search.results[0]).toMatchObject({
+      id: '1',
+      offset: '1',
+    });
+    const matchedElement =
+      search.results[0].items[Number(search.results[0].offset)];
+    expect(matchedElement.label).toEqual('second');
+    expect(matchedElement.order).toEqual(20);
+  });
+});

--- a/test/utils/Data.spec.ts
+++ b/test/utils/Data.spec.ts
@@ -4,9 +4,142 @@ import {
   buildFieldData,
   DataType,
   ERROR_REASONS,
+  MilvusClient,
 } from '../../milvus';
 
 describe('utils/Data', () => {
+  it('should expand query rows with element indices into offset rows', async () => {
+    const client = new MilvusClient({
+      address: 'localhost:19530',
+      __SKIP_CONNECT__: true,
+    });
+    const response: any = {
+      status: { error_code: 'Success', reason: '' },
+      fields_data: [
+        {
+          type: 'Int64',
+          field_name: 'id',
+          field_id: '101',
+          is_dynamic: false,
+          scalars: {
+            long_data: { data: ['1', '2'] },
+            data: 'long_data',
+          },
+          field: 'scalars',
+        },
+        {
+          type: 'VarChar',
+          field_name: 'name',
+          field_id: '102',
+          is_dynamic: false,
+          scalars: {
+            string_data: { data: ['first', 'second'] },
+            data: 'string_data',
+          },
+          field: 'scalars',
+        },
+      ],
+      element_indices: [
+        { indices: { data: ['0', '2'] } },
+        { indices: { data: ['1'] } },
+      ],
+    };
+    (client as any).channelPool = {
+      acquire: jest.fn().mockResolvedValue({
+        Query: (_params: any, _options: any, cb: any) => cb(null, response),
+      }),
+      release: jest.fn(),
+    };
+
+    const result = await client.query({
+      collection_name: 'test_collection',
+      expr: 'id > 0',
+      output_fields: ['id', 'name'],
+    });
+
+    expect(result.data).toEqual([
+      { id: '1', name: 'first', offset: '0' },
+      { id: '1', name: 'first', offset: '2' },
+      { id: '2', name: 'second', offset: '1' },
+    ]);
+  });
+
+  it('should return query rows unchanged when element indices are empty', async () => {
+    const client = new MilvusClient({
+      address: 'localhost:19530',
+      __SKIP_CONNECT__: true,
+    });
+    const response: any = {
+      status: { error_code: 'Success', reason: '' },
+      fields_data: [
+        {
+          type: 'Int64',
+          field_name: 'id',
+          field_id: '101',
+          is_dynamic: false,
+          scalars: {
+            long_data: { data: ['1', '2'] },
+            data: 'long_data',
+          },
+          field: 'scalars',
+        },
+      ],
+      element_indices: [],
+    };
+    (client as any).channelPool = {
+      acquire: jest.fn().mockResolvedValue({
+        Query: (_params: any, _options: any, cb: any) => cb(null, response),
+      }),
+      release: jest.fn(),
+    };
+
+    const result = await client.query({
+      collection_name: 'test_collection',
+      expr: 'id > 0',
+      output_fields: ['id'],
+    });
+
+    expect(result.data).toEqual([{ id: '1' }, { id: '2' }]);
+  });
+
+  it('should reject query element indices that do not match row count', async () => {
+    const client = new MilvusClient({
+      address: 'localhost:19530',
+      __SKIP_CONNECT__: true,
+    });
+    const response: any = {
+      status: { error_code: 'Success', reason: '' },
+      fields_data: [
+        {
+          type: 'Int64',
+          field_name: 'id',
+          field_id: '101',
+          is_dynamic: false,
+          scalars: {
+            long_data: { data: ['1', '2'] },
+            data: 'long_data',
+          },
+          field: 'scalars',
+        },
+      ],
+      element_indices: [{ indices: { data: ['0'] } }],
+    };
+    (client as any).channelPool = {
+      acquire: jest.fn().mockResolvedValue({
+        Query: (_params: any, _options: any, cb: any) => cb(null, response),
+      }),
+      release: jest.fn(),
+    };
+
+    await expect(
+      client.query({
+        collection_name: 'test_collection',
+        expr: 'id > 0',
+        output_fields: ['id'],
+      })
+    ).rejects.toThrow('element_indices length (1) != query result length (2)');
+  });
+
   it('should return an empty object when data is empty', () => {
     const data = {};
     const fieldsDataMap = new Map();

--- a/test/utils/Search.spec.ts
+++ b/test/utils/Search.spec.ts
@@ -13,6 +13,7 @@ import {
   FunctionType,
   buildSearchParams,
   PlaceholderType,
+  buildPlaceholderGroupBytes,
 } from '../../milvus';
 describe('utils/Search', () => {
   it('should build single search request correctly', () => {
@@ -484,6 +485,374 @@ describe('utils/Search', () => {
     );
   });
 
+  it('should use field placeholder type when no placeholder override is provided', () => {
+    const milvusProtoPath = path.resolve(
+      __dirname,
+      '../../proto/proto/milvus.proto'
+    );
+    const milvusProto = protobuf.loadSync(milvusProtoPath);
+    const PlaceholderGroup = milvusProto.lookupType(
+      'milvus.proto.common.PlaceholderGroup'
+    );
+    const placeholderGroup = PlaceholderGroup.decode(
+      buildPlaceholderGroupBytes(
+        milvusProto,
+        [[1, 2, 3, 4]],
+        {
+          data_type: 'FloatVector',
+          dataType: DataType.FloatVector,
+          _placeholderType: PlaceholderType.EmbListFloatVector,
+        } as any
+      )
+    ).toJSON() as any;
+
+    expect(placeholderGroup.placeholders[0].type).toEqual('EmbListFloatVector');
+  });
+
+  it('should build embedding-list placeholder for struct MAX_SIM search', () => {
+    const milvusProtoPath = path.resolve(
+      __dirname,
+      '../../proto/proto/milvus.proto'
+    );
+    const milvusProto = protobuf.loadSync(milvusProtoPath);
+    const searchParams = {
+      collection_name: 'test',
+      data: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+      ],
+      anns_field: 'struct_field[struct_float_vec]',
+      limit: 2,
+      output_fields: ['struct_field[struct_int]'],
+    };
+    const describeCollectionResponse = {
+      status: { error_code: 'Success', reason: '' },
+      collection_name: 'test',
+      consistency_level: 'Session',
+      schema: {
+        fields: [
+          {
+            name: 'id',
+            dataType: DataType.Int64,
+            is_primary_key: true,
+            data_type: 'Int64',
+          },
+        ],
+      },
+      anns_fields: {
+        'struct_field[struct_float_vec]': {
+          name: 'struct_float_vec',
+          data_type: 'FloatVector',
+          dataType: DataType.FloatVector,
+          _placeholderType: PlaceholderType.EmbListFloatVector,
+          index_params: [{ key: 'metric_type', value: 'MAX_SIM' }],
+        },
+      },
+    } as any;
+
+    const result = buildSearchRequest(
+      searchParams,
+      describeCollectionResponse,
+      milvusProto
+    );
+    const PlaceholderGroup = milvusProto.lookupType(
+      'milvus.proto.common.PlaceholderGroup'
+    );
+    const placeholderGroup = PlaceholderGroup.decode(
+      (result.request as any).placeholder_group
+    ).toJSON() as any;
+
+    expect(placeholderGroup.placeholders[0].type).toEqual('EmbListFloatVector');
+  });
+
+  it('should build plain vector placeholder for element-level struct vector search', () => {
+    const milvusProtoPath = path.resolve(
+      __dirname,
+      '../../proto/proto/milvus.proto'
+    );
+    const milvusProto = protobuf.loadSync(milvusProtoPath);
+    const searchParams = {
+      collection_name: 'test',
+      data: [1, 2, 3, 4],
+      anns_field: 'struct_field[struct_float_vec]',
+      limit: 2,
+      output_fields: ['struct_field[struct_int]'],
+    };
+    const describeCollectionResponse = {
+      status: { error_code: 'Success', reason: '' },
+      collection_name: 'test',
+      consistency_level: 'Session',
+      schema: {
+        fields: [
+          {
+            name: 'id',
+            dataType: DataType.Int64,
+            is_primary_key: true,
+            data_type: 'Int64',
+          },
+        ],
+      },
+      anns_fields: {
+        'struct_field[struct_float_vec]': {
+          name: 'struct_float_vec',
+          data_type: 'FloatVector',
+          dataType: DataType.FloatVector,
+          _placeholderType: PlaceholderType.EmbListFloatVector,
+          index_params: [{ key: 'metric_type', value: 'COSINE' }],
+        },
+      },
+    } as any;
+
+    const result = buildSearchRequest(
+      searchParams,
+      describeCollectionResponse,
+      milvusProto
+    );
+    const PlaceholderGroup = milvusProto.lookupType(
+      'milvus.proto.common.PlaceholderGroup'
+    );
+    const placeholderGroup = PlaceholderGroup.decode(
+      (result.request as any).placeholder_group
+    ).toJSON() as any;
+
+    expect(placeholderGroup.placeholders[0].type).toEqual('FloatVector');
+  });
+
+  it('should build string primary-key id search request without placeholder data', () => {
+    const milvusProtoPath = path.resolve(
+      __dirname,
+      '../../proto/proto/milvus.proto'
+    );
+    const milvusProto = protobuf.loadSync(milvusProtoPath);
+    const result = buildSearchRequest(
+      {
+        collection_name: 'test',
+        ids: ['a', 'b'],
+        anns_field: 'vector',
+        limit: 2,
+      },
+      {
+        status: { error_code: 'Success', reason: '' },
+        collection_name: 'test',
+        consistency_level: 'Session',
+        schema: {
+          fields: [
+            {
+              name: 'id',
+              dataType: DataType.VarChar,
+              is_primary_key: true,
+              data_type: 'VarChar',
+            },
+          ],
+        },
+        anns_fields: {
+          vector: {
+            data_type: 'FloatVector',
+            dataType: DataType.FloatVector,
+            _placeholderType: PlaceholderType.FloatVector,
+            index_params: [],
+          },
+        },
+      } as any,
+      milvusProto
+    );
+
+    expect((result.request as any).ids).toEqual({
+      str_id: { data: ['a', 'b'] },
+    });
+    expect((result.request as any).placeholder_group).toBeUndefined();
+  });
+
+  it('should ignore non-metric index params when choosing placeholder type', () => {
+    const milvusProtoPath = path.resolve(
+      __dirname,
+      '../../proto/proto/milvus.proto'
+    );
+    const milvusProto = protobuf.loadSync(milvusProtoPath);
+    const result = buildSearchRequest(
+      {
+        collection_name: 'test',
+        data: [1, 2, 3, 4],
+        anns_field: 'vector',
+        limit: 2,
+      },
+      {
+        status: { error_code: 'Success', reason: '' },
+        collection_name: 'test',
+        consistency_level: 'Session',
+        schema: {
+          fields: [
+            {
+              name: 'id',
+              dataType: DataType.Int64,
+              is_primary_key: true,
+              data_type: 'Int64',
+            },
+          ],
+        },
+        anns_fields: {
+          vector: {
+            data_type: 'FloatVector',
+            dataType: DataType.FloatVector,
+            _placeholderType: PlaceholderType.FloatVector,
+            index_params: [{ key: 'nlist', value: 128 }],
+          },
+        },
+      } as any,
+      milvusProto
+    );
+    const PlaceholderGroup = milvusProto.lookupType(
+      'milvus.proto.common.PlaceholderGroup'
+    );
+    const placeholderGroup = PlaceholderGroup.decode(
+      (result.request as any).placeholder_group
+    ).toJSON() as any;
+
+    expect(placeholderGroup.placeholders[0].type).toEqual('FloatVector');
+  });
+
+  it('should fall back to data_type when formatted dataType is unavailable', () => {
+    const milvusProtoPath = path.resolve(
+      __dirname,
+      '../../proto/proto/milvus.proto'
+    );
+    const milvusProto = protobuf.loadSync(milvusProtoPath);
+    const result = buildSearchRequest(
+      {
+        collection_name: 'test',
+        data: [1, 2, 3, 4],
+        anns_field: 'vector',
+        limit: 2,
+      },
+      {
+        status: { error_code: 'Success', reason: '' },
+        collection_name: 'test',
+        consistency_level: 'Session',
+        schema: {
+          fields: [
+            {
+              name: 'id',
+              dataType: DataType.Int64,
+              is_primary_key: true,
+              data_type: 'Int64',
+            },
+          ],
+        },
+        anns_fields: {
+          vector: {
+            data_type: 'FloatVector',
+            _placeholderType: PlaceholderType.FloatVector,
+            index_params: [],
+          },
+        },
+      } as any,
+      milvusProto
+    );
+    const PlaceholderGroup = milvusProto.lookupType(
+      'milvus.proto.common.PlaceholderGroup'
+    );
+    const placeholderGroup = PlaceholderGroup.decode(
+      (result.request as any).placeholder_group
+    ).toJSON() as any;
+
+    expect(placeholderGroup.placeholders[0].type).toEqual('FloatVector');
+  });
+
+  it('should build plain vector placeholder when index params are absent', () => {
+    const milvusProtoPath = path.resolve(
+      __dirname,
+      '../../proto/proto/milvus.proto'
+    );
+    const milvusProto = protobuf.loadSync(milvusProtoPath);
+    const result = buildSearchRequest(
+      {
+        collection_name: 'test',
+        data: [1, 2, 3, 4],
+        anns_field: 'vector',
+        limit: 2,
+      },
+      {
+        status: { error_code: 'Success', reason: '' },
+        collection_name: 'test',
+        consistency_level: 'Session',
+        schema: {
+          fields: [
+            {
+              name: 'id',
+              dataType: DataType.Int64,
+              is_primary_key: true,
+              data_type: 'Int64',
+            },
+          ],
+        },
+        anns_fields: {
+          vector: {
+            data_type: 'FloatVector',
+            dataType: DataType.FloatVector,
+            _placeholderType: PlaceholderType.FloatVector,
+          },
+        },
+      } as any,
+      milvusProto
+    );
+    const PlaceholderGroup = milvusProto.lookupType(
+      'milvus.proto.common.PlaceholderGroup'
+    );
+    const placeholderGroup = PlaceholderGroup.decode(
+      (result.request as any).placeholder_group
+    ).toJSON() as any;
+
+    expect(placeholderGroup.placeholders[0].type).toEqual('FloatVector');
+  });
+
+  it('should build plain vector placeholder when metric is unavailable', () => {
+    const milvusProtoPath = path.resolve(
+      __dirname,
+      '../../proto/proto/milvus.proto'
+    );
+    const milvusProto = protobuf.loadSync(milvusProtoPath);
+    const result = buildSearchRequest(
+      {
+        collection_name: 'test',
+        data: [1, 2, 3, 4],
+        anns_field: 'vector',
+        limit: 2,
+      },
+      {
+        status: { error_code: 'Success', reason: '' },
+        collection_name: 'test',
+        consistency_level: 'Session',
+        schema: {
+          fields: [
+            {
+              name: 'id',
+              dataType: DataType.Int64,
+              is_primary_key: true,
+              data_type: 'Int64',
+            },
+          ],
+        },
+        anns_fields: {
+          vector: {
+            data_type: 'FloatVector',
+            dataType: DataType.FloatVector,
+            _placeholderType: PlaceholderType.FloatVector,
+            index_params: [],
+          },
+        },
+      } as any,
+      milvusProto
+    );
+    const PlaceholderGroup = milvusProto.lookupType(
+      'milvus.proto.common.PlaceholderGroup'
+    );
+    const placeholderGroup = PlaceholderGroup.decode(
+      (result.request as any).placeholder_group
+    ).toJSON() as any;
+
+    expect(placeholderGroup.placeholders[0].type).toEqual('FloatVector');
+  });
+
   it(`it should get NO_ANNS_FEILD_FOUND_IN_SEARCH if buildSearchRequest with wrong searchParams`, () => {
     // path
     const milvusProtoPath = path.resolve(
@@ -911,6 +1280,98 @@ describe('utils/Search', () => {
     ];
     const results2 = formatSearchResult(searchPromise2, { round_decimal: -1 });
     expect(results2).toEqual(expectedResults2);
+  });
+
+  it('should expose element indices as offsets on search hits', () => {
+    const searchPromise: any = {
+      results: {
+        fields_data: [
+          {
+            type: 'Int64',
+            field_name: 'id',
+            field_id: '101',
+            is_dynamic: false,
+            scalars: {
+              long_data: { data: ['1', '2', '3'] },
+              data: 'long_data',
+            },
+            field: 'scalars',
+          },
+        ],
+        scores: [1, 2, 3],
+        topks: ['2', '1'],
+        output_fields: ['id'],
+        num_queries: '2',
+        top_k: '3',
+        ids: {
+          int_id: { data: ['1', '2', '3'] },
+          id_field: 'int_id',
+        },
+        element_indices: { data: ['10', '20', '30'] },
+        group_by_field_values: [],
+      },
+    };
+
+    const results = formatSearchResult(searchPromise, { round_decimal: -1 });
+
+    expect(results).toEqual([
+      [
+        { score: 1, id: '1', offset: '10' },
+        { score: 2, id: '2', offset: '20' },
+      ],
+      [{ score: 3, id: '3', offset: '30' }],
+    ]);
+  });
+
+  it('should expose group-by field values on search hits', () => {
+    const searchPromise: any = {
+      results: {
+        fields_data: [
+          {
+            type: 'Int64',
+            field_name: 'id',
+            field_id: '101',
+            is_dynamic: false,
+            scalars: {
+              long_data: { data: ['1', '2'] },
+              data: 'long_data',
+            },
+            field: 'scalars',
+          },
+        ],
+        scores: [1, 2],
+        topks: ['2'],
+        output_fields: ['id'],
+        num_queries: '1',
+        top_k: '2',
+        ids: {
+          int_id: { data: ['1', '2'] },
+          id_field: 'int_id',
+        },
+        group_by_field_values: [
+          {
+            type: 'VarChar',
+            field_name: 'category',
+            field_id: '102',
+            is_dynamic: false,
+            scalars: {
+              string_data: { data: ['red', 'blue'] },
+              data: 'string_data',
+            },
+            field: 'scalars',
+          },
+        ],
+      },
+    };
+
+    const results = formatSearchResult(searchPromise, { round_decimal: -1 });
+
+    expect(results).toEqual([
+      [
+        { score: 1, id: '1', group_by_field_values: { category: 'red' } },
+        { score: 2, id: '2', group_by_field_values: { category: 'blue' } },
+      ],
+    ]);
   });
 
   // Add new test case for multiple queries and fields

--- a/test/utils/Search.spec.ts
+++ b/test/utils/Search.spec.ts
@@ -1579,6 +1579,55 @@ describe('utils/Search', () => {
     ]);
   });
 
+  it('should build varchar placeholder for function output vector search', () => {
+    const milvusProtoPath = path.resolve(
+      __dirname,
+      '../../proto/proto/milvus.proto'
+    );
+    const milvusProto = protobuf.loadSync(milvusProtoPath);
+    const result = buildSearchRequest(
+      {
+        collection_name: 'test',
+        data: 'hello world',
+        anns_field: 'dense',
+        limit: 2,
+      },
+      {
+        status: { error_code: 'Success', reason: '' },
+        collection_name: 'test',
+        consistency_level: 'Session',
+        schema: {
+          fields: [
+            {
+              name: 'id',
+              dataType: DataType.Int64,
+              is_primary_key: true,
+              data_type: 'Int64',
+            },
+          ],
+        },
+        anns_fields: {
+          dense: {
+            data_type: 'FloatVector',
+            dataType: DataType.FloatVector,
+            _placeholderType: PlaceholderType.VarChar,
+            is_function_output: true,
+            index_params: [],
+          },
+        },
+      } as any,
+      milvusProto
+    );
+    const PlaceholderGroup = milvusProto.lookupType(
+      'milvus.proto.common.PlaceholderGroup'
+    );
+    const placeholderGroup = PlaceholderGroup.decode(
+      (result.request as any).placeholder_group
+    ).toJSON() as any;
+
+    expect(placeholderGroup.placeholders[0].type).toEqual('VarChar');
+  });
+
   it('should throw error if ids type is not match Int64 primary key', () => {
     const milvusProtoPath = path.resolve(
       __dirname,


### PR DESCRIPTION
## Summary
- Parse search `element_indices` into per-hit `offset` and expose search `group_by_field_values`.
- Expand query rows with `element_indices` into offset-bearing rows, matching PyMilvus behavior.
- Preserve correct placeholder semantics for struct-vector element-level vs embedding-list searches.

## Test plan
- [x] `NODE_ENV=dev npx jest test/utils/Search.spec.ts test/utils/Data.spec.ts test/grpc/Data.spec.ts test/grpc/Struct.spec.ts test/grpc/ElementLevel.spec.ts --testPathIgnorePatterns=none --runInBand`
- [x] `yarn build`
- [x] Coverage check: modified executable lines and branches all covered via `coverage/lcov.info`

🤖 Generated with [Claude Code](https://claude.com/claude-code)