### PR TITLE
feat: support nullable vector payloads

### DIFF
--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -162,55 +162,59 @@ export class Data extends Collection {
     // Tip: The field data sequence needs to be set same as `collectionInfo.schema.fields`.
     const functionOutputFields: string[] = [];
     const fieldMap = new Map<string, _Field>(
-      collectionInfo.schema.fields.reduce((acc, v) => {
-        // if autoID is true, ignore the primary key field or if upsert is true or allow_insert_auto_id is true
-        const insertable = !v.autoID || upsert || allowInsertAutoId === 'true';
+      collectionInfo.schema.fields.reduce(
+        (acc, v) => {
+          // if autoID is true, ignore the primary key field or if upsert is true or allow_insert_auto_id is true
+          const insertable =
+            !v.autoID || upsert || allowInsertAutoId === 'true';
 
-        //  if function field is set, you need to ignore the field value in the data.
-        if (v.is_function_output) {
-          functionOutputFields.push(v.name); // ignore function field
-        } else if (insertable) {
-          const field: _Field = {
-            name: v.name,
-            type: convertToDataType(v.data_type), // milvus return string here
-            elementType: convertToDataType(v.element_type!),
-            dim: Number(v.dim),
-            data: [], // values container
-            nullable: v.nullable,
-            default_value: v.default_value,
-            fieldMap: new Map(),
-          };
+          //  if function field is set, you need to ignore the field value in the data.
+          if (v.is_function_output) {
+            functionOutputFields.push(v.name); // ignore function field
+          } else if (insertable) {
+            const field: _Field = {
+              name: v.name,
+              type: convertToDataType(v.data_type), // milvus return string here
+              elementType: convertToDataType(v.element_type!),
+              dim: Number(v.dim),
+              data: [], // values container
+              nullable: v.nullable,
+              default_value: v.default_value,
+              fieldMap: new Map(),
+            };
 
-          // Check if this is a struct field (Array with element_type = 'Struct')
-          if (
-            convertToDataType(v.data_type) === DataType.Array &&
-            convertToDataType(v.element_type!) === DataType.Struct &&
-            v.fields
-          ) {
-            // build struct field map
-            field.fieldMap = new Map(
-              v.fields.map(field => [
-                field.name,
-                {
-                  name: field.name,
-                  type: isVectorType(convertToDataType(field.data_type))
-                    ? (106 as DataType)
-                    : DataType.Array,
-                  elementType: convertToDataType(field.data_type),
-                  dim: Number(field.dim),
-                  data: [],
-                  nullable: field.nullable,
-                  default_value: field.default_value,
-                  fieldMap: new Map(),
-                },
-              ])
-            );
+            // Check if this is a struct field (Array with element_type = 'Struct')
+            if (
+              convertToDataType(v.data_type) === DataType.Array &&
+              convertToDataType(v.element_type!) === DataType.Struct &&
+              v.fields
+            ) {
+              // build struct field map
+              field.fieldMap = new Map(
+                v.fields.map(field => [
+                  field.name,
+                  {
+                    name: field.name,
+                    type: isVectorType(convertToDataType(field.data_type))
+                      ? (106 as DataType)
+                      : DataType.Array,
+                    elementType: convertToDataType(field.data_type),
+                    dim: Number(field.dim),
+                    data: [],
+                    nullable: field.nullable,
+                    default_value: field.default_value,
+                    fieldMap: new Map(),
+                  },
+                ])
+              );
+            }
+
+            acc.push([v.name, field]);
           }
-
-          acc.push([v.name, field]);
-        }
-        return acc;
-      }, [] as [string, _Field][])
+          return acc;
+        },
+        [] as [string, _Field][]
+      )
     );
 
     // dynamic field is enabled, create $meta field
@@ -259,29 +263,27 @@ export class Data extends Collection {
             `${ERROR_REASONS.INSERT_CHECK_WRONG_FIELD} ${rowIndex}`
           );
         }
-        if (
-          field.type === DataType.BinaryVector &&
-          (rowData[name] as BinaryVector).length !== field.dim! / 8
-        ) {
-          throw new Error(ERROR_REASONS.INSERT_CHECK_WRONG_DIM);
+        const fieldData = buildFieldData(
+          rowData,
+          field,
+          data.transformers,
+          rowIndex
+        );
+
+        if (field.type === DataType.BinaryVector && fieldData != null) {
+          if ((fieldData as BinaryVector).length !== field.dim! / 8) {
+            throw new Error(ERROR_REASONS.INSERT_CHECK_WRONG_DIM);
+          }
         }
 
-        // build field data
-        switch (field.type) {
-          case DataType.BinaryVector:
-          case DataType.FloatVector:
-            field.data.push(
-              ...(buildFieldData(rowData, field) as FloatVector | BinaryVector)
-            );
-            break;
-          default:
-            field.data[rowIndex] = buildFieldData(
-              rowData,
-              field,
-              data.transformers,
-              rowIndex
-            );
-            break;
+        if (
+          field.nullable !== true &&
+          (field.type === DataType.BinaryVector ||
+            field.type === DataType.FloatVector)
+        ) {
+          field.data.push(...(fieldData as FloatVector | BinaryVector));
+        } else {
+          field.data[rowIndex] = fieldData;
         }
       });
     });
@@ -326,18 +328,21 @@ export class Data extends Collection {
         const elementTypeKey = getDataKeyWithTimestamptz(field.elementType);
 
         // check if need valid data
-        // vector field doesn't support nullable
         // nullable field should always have valid_data array (format is unified)
         const needValidData =
-          key !== 'vectors' &&
-          (field.nullable === true ||
-            (typeof field.default_value !== 'undefined' &&
-              field.default_value !== null));
+          field.nullable === true ||
+          (key !== 'vectors' &&
+            typeof field.default_value !== 'undefined' &&
+            field.default_value !== null);
 
         // get valid data
         const valid_data = needValidData
           ? getValidDataArray(field.data, data.fields_data?.length!)
           : [];
+        const physicalData =
+          field.nullable === true && VectorDataTypes.includes(field.type)
+            ? field.data.filter(v => v !== undefined && v !== null)
+            : field.data;
 
         // build key value
         let keyValue;
@@ -346,7 +351,7 @@ export class Data extends Collection {
             keyValue = {
               dim: field.dim,
               [dataKey]: {
-                data: field.data,
+                data: (physicalData as FloatVector[]).flat(),
               },
             };
             break;
@@ -354,29 +359,34 @@ export class Data extends Collection {
           case DataType.Float16Vector:
             keyValue = {
               dim: field.dim,
-              [dataKey]: Buffer.concat(field.data as Uint8Array[]),
+              [dataKey]: Buffer.concat(physicalData as Uint8Array[]),
             };
             break;
           case DataType.BinaryVector:
             keyValue = {
               dim: field.dim,
-              [dataKey]: f32ArrayToBinaryBytes(field.data as BinaryVector),
+              [dataKey]: f32ArrayToBinaryBytes(
+                (physicalData as BinaryVector[]).flat()
+              ),
             };
             break;
           case DataType.SparseFloatVector:
-            const dim = getSparseDim(field.data as SparseFloatVector[]);
+            const dim =
+              field.dim || getSparseDim(physicalData as SparseFloatVector[]);
             keyValue = {
               dim,
               [dataKey]: {
                 dim,
-                contents: sparseRowsToBytes(field.data as SparseFloatVector[]),
+                contents: sparseRowsToBytes(
+                  physicalData as SparseFloatVector[]
+                ),
               },
             };
             break;
           case DataType.Int8Vector:
             keyValue = {
               dim: field.dim,
-              [dataKey]: int8VectorRowsToBytes(field.data as Int8Vector[]),
+              [dataKey]: int8VectorRowsToBytes(physicalData as Int8Vector[]),
             };
             break;
 
@@ -470,7 +480,10 @@ export class Data extends Collection {
     );
 
     // if schema mismatch, reload collection info and redo the insert request
-    if (promise.status.error_code === ErrorCode.SchemaMismatch && enable_cache) {
+    if (
+      promise.status.error_code === ErrorCode.SchemaMismatch &&
+      enable_cache
+    ) {
       // redo the insert request with collection cache off
       promise = await this._insert(data, upsert, false);
     }

--- a/milvus/utils/Data.ts
+++ b/milvus/utils/Data.ts
@@ -68,6 +68,23 @@ export const processVectorData = (
   const dataKey = item.vectors!.data;
   let field_data: any;
 
+  const applyValidData = (physicalData: any[]) => {
+    if (!item.valid_data || !item.valid_data.length) {
+      return physicalData;
+    }
+    if (item.valid_data.every(Boolean)) {
+      return physicalData;
+    }
+
+    let physicalIndex = 0;
+    return item.valid_data.map((valid: boolean) => {
+      if (!valid) {
+        return null;
+      }
+      return physicalData[physicalIndex++];
+    });
+  };
+
   switch (dataKey) {
     case 'float_vector':
     case 'binary_vector':
@@ -160,7 +177,7 @@ export const processVectorData = (
       break;
   }
 
-  return field_data;
+  return applyValidData(field_data);
 };
 
 /**

--- a/test/grpc/NullableVector.spec.ts
+++ b/test/grpc/NullableVector.spec.ts
@@ -1,0 +1,308 @@
+import {
+  MilvusClient,
+  ErrorCode,
+  DataType,
+  IndexType,
+  MetricType,
+} from '../../milvus';
+import { IP, GENERATE_NAME } from '../tools';
+
+const milvusClient = new MilvusClient({ address: IP, logLevel: 'info' });
+const dbParam = {
+  db_name: 'nullable_vector_test',
+};
+
+type NullableVectorCase = {
+  label: string;
+  dataType: DataType;
+  dim?: number;
+  metricType: MetricType;
+  indexType: IndexType;
+  indexParams?: Record<string, any>;
+  searchParams?: Record<string, any>;
+  vectors: any[];
+  searchVector: any;
+  expectVector: (actual: any, expected: any) => void;
+};
+
+const expectDenseVector = (actual: number[], expected: number[]) => {
+  expect(actual.length).toBe(expected.length);
+  expected.forEach((value, index) => {
+    expect(actual[index]).toBeCloseTo(value, 3);
+  });
+};
+
+const expectExactVector = (actual: any, expected: any) => {
+  expect(actual).toEqual(expected);
+};
+
+const cleanupCollection = async (collectionName: string) => {
+  await milvusClient
+    .releaseCollection({ collection_name: collectionName })
+    .catch(() => undefined);
+  await milvusClient
+    .dropCollection({ collection_name: collectionName })
+    .catch(() => undefined);
+};
+
+const nullableVectorCases: NullableVectorCase[] = [
+  {
+    label: 'float vector',
+    dataType: DataType.FloatVector,
+    dim: 2,
+    metricType: MetricType.L2,
+    indexType: IndexType.AUTOINDEX,
+    vectors: [[1, 2], null, [3, 4]],
+    searchVector: [1, 2],
+    expectVector: expectDenseVector,
+  },
+  {
+    label: 'binary vector',
+    dataType: DataType.BinaryVector,
+    dim: 8,
+    metricType: MetricType.HAMMING,
+    indexType: IndexType.BIN_IVF_FLAT,
+    indexParams: { nlist: 8 },
+    vectors: [[1], null, [2]],
+    searchVector: [1],
+    expectVector: expectExactVector,
+  },
+  {
+    label: 'float16 vector',
+    dataType: DataType.Float16Vector,
+    dim: 2,
+    metricType: MetricType.L2,
+    indexType: IndexType.AUTOINDEX,
+    vectors: [[1, 2], null, [3, 4]],
+    searchVector: [1, 2],
+    expectVector: expectDenseVector,
+  },
+  {
+    label: 'bfloat16 vector',
+    dataType: DataType.BFloat16Vector,
+    dim: 2,
+    metricType: MetricType.L2,
+    indexType: IndexType.AUTOINDEX,
+    vectors: [[1, 2], null, [3, 4]],
+    searchVector: [1, 2],
+    expectVector: expectDenseVector,
+  },
+  {
+    label: 'sparse vector',
+    dataType: DataType.SparseFloatVector,
+    metricType: MetricType.IP,
+    indexType: IndexType.SPARSE_WAND,
+    indexParams: { inverted_index_algo: 'DAAT_MAXSCORE' },
+    searchParams: { drop_ratio_search: 0.2 },
+    vectors: [{ '0': 1 }, null, { '1': 2 }],
+    searchVector: { '0': 1 },
+    expectVector: expectExactVector,
+  },
+  {
+    label: 'int8 vector',
+    dataType: DataType.Int8Vector,
+    dim: 2,
+    metricType: MetricType.L2,
+    indexType: IndexType.HNSW,
+    indexParams: { M: 16, efConstruction: 64 },
+    vectors: [[1, 2], null, [3, 4]],
+    searchVector: [1, 2],
+    expectVector: expectExactVector,
+  },
+];
+
+describe('Nullable vector API testing', () => {
+  beforeAll(async () => {
+    await milvusClient.createDatabase(dbParam);
+    await milvusClient.use(dbParam);
+  });
+
+  afterAll(async () => {
+    await milvusClient.use({ db_name: 'default' });
+    await milvusClient.dropDatabase(dbParam);
+  });
+
+  it.each(nullableVectorCases)(
+    'insert, upsert, query, and search nullable $label should be successful',
+    async testCase => {
+      const collectionName = GENERATE_NAME();
+
+      try {
+        const vectorField: any = {
+          name: 'vector',
+          data_type: testCase.dataType,
+          nullable: true,
+        };
+        if (testCase.dim) {
+          vectorField.dim = testCase.dim;
+        }
+
+        const create = await milvusClient.createCollection({
+          collection_name: collectionName,
+          fields: [
+            vectorField,
+            {
+              name: 'id',
+              data_type: DataType.Int64,
+              is_primary_key: true,
+              autoID: false,
+            },
+          ],
+        });
+        expect(create.error_code).toEqual(ErrorCode.SUCCESS);
+
+        const rows = testCase.vectors.map((vector, index) => ({
+          id: index + 1,
+          vector,
+        }));
+        const insert = await milvusClient.insert({
+          collection_name: collectionName,
+          data: rows,
+        });
+        expect(insert.status.error_code).toEqual(ErrorCode.SUCCESS);
+        expect(insert.succ_index.length).toEqual(rows.length);
+
+        const upsert = await milvusClient.upsert({
+          collection_name: collectionName,
+          data: [
+            { id: 2, vector: testCase.vectors[2] },
+            { id: 3, vector: null },
+          ],
+        });
+        expect(upsert.status.error_code).toEqual(ErrorCode.SUCCESS);
+
+        const index = await milvusClient.createIndex({
+          collection_name: collectionName,
+          field_name: 'vector',
+          metric_type: testCase.metricType,
+          index_type: testCase.indexType,
+          params: testCase.indexParams,
+        });
+        expect(index.error_code).toEqual(ErrorCode.SUCCESS);
+
+        const load = await milvusClient.loadCollectionSync({
+          collection_name: collectionName,
+        });
+        expect(load.error_code).toEqual(ErrorCode.SUCCESS);
+
+        const query = await milvusClient.query({
+          collection_name: collectionName,
+          filter: 'id >= 1',
+          output_fields: ['id', 'vector'],
+        });
+        expect(query.status.error_code).toEqual(ErrorCode.SUCCESS);
+        expect(query.data).toHaveLength(rows.length);
+        const sortedRows = [...query.data].sort(
+          (a, b) => Number(a.id) - Number(b.id)
+        );
+        testCase.expectVector(sortedRows[0].vector, testCase.vectors[0]);
+        testCase.expectVector(sortedRows[1].vector, testCase.vectors[2]);
+        expect(sortedRows[2].vector).toBeNull();
+
+        const search = await milvusClient.search({
+          collection_name: collectionName,
+          data: testCase.searchVector,
+          output_fields: ['id', 'vector'],
+          limit: 3,
+          params: testCase.searchParams,
+        });
+        expect(search.status.error_code).toEqual(ErrorCode.SUCCESS);
+        const searchResults = search.results as any[];
+        expect(searchResults.length).toBeGreaterThan(0);
+        expect(searchResults.every(result => result.vector !== null)).toBe(
+          true
+        );
+      } finally {
+        await cleanupCollection(collectionName);
+      }
+    }
+  );
+
+  it('new nullable vector field should return null for old rows', async () => {
+    const collectionName = GENERATE_NAME();
+
+    try {
+      const create = await milvusClient.createCollection({
+        collection_name: collectionName,
+        fields: [
+          {
+            name: 'vector',
+            data_type: DataType.FloatVector,
+            dim: 2,
+          },
+          {
+            name: 'id',
+            data_type: DataType.Int64,
+            is_primary_key: true,
+            autoID: false,
+          },
+        ],
+      });
+      expect(create.error_code).toEqual(ErrorCode.SUCCESS);
+
+      const insert = await milvusClient.insert({
+        collection_name: collectionName,
+        data: [
+          { id: 1, vector: [1, 2] },
+          { id: 2, vector: [3, 4] },
+        ],
+      });
+      expect(insert.status.error_code).toEqual(ErrorCode.SUCCESS);
+
+      const addNullableVector = await milvusClient.addCollectionField({
+        collection_name: collectionName,
+        field: {
+          name: 'nullable_vector',
+          data_type: DataType.FloatVector,
+          dim: 2,
+          nullable: true,
+        },
+      });
+      expect(addNullableVector.error_code).toEqual(ErrorCode.SUCCESS);
+
+      const index = await milvusClient.createIndex([
+        {
+          collection_name: collectionName,
+          field_name: 'vector',
+          metric_type: MetricType.L2,
+          index_type: IndexType.AUTOINDEX,
+        },
+        {
+          collection_name: collectionName,
+          field_name: 'nullable_vector',
+          metric_type: MetricType.L2,
+          index_type: IndexType.AUTOINDEX,
+        },
+      ]);
+      expect(index.error_code).toEqual(ErrorCode.SUCCESS);
+
+      const load = await milvusClient.loadCollectionSync({
+        collection_name: collectionName,
+      });
+      expect(load.error_code).toEqual(ErrorCode.SUCCESS);
+
+      const queryOldRows = await milvusClient.query({
+        collection_name: collectionName,
+        filter: 'id >= 1',
+        output_fields: ['id', 'nullable_vector'],
+      });
+      expect(queryOldRows.status.error_code).toEqual(ErrorCode.SUCCESS);
+      expect(queryOldRows.data).toHaveLength(2);
+      expect(queryOldRows.data.every(row => row.nullable_vector === null)).toBe(
+        true
+      );
+
+      const addNonNullableVector = await milvusClient.addCollectionField({
+        collection_name: collectionName,
+        field: {
+          name: 'non_nullable_vector',
+          data_type: DataType.FloatVector,
+          dim: 2,
+        },
+      });
+      expect(addNonNullableVector.error_code).not.toEqual(ErrorCode.SUCCESS);
+    } finally {
+      await cleanupCollection(collectionName);
+    }
+  });
+});

--- a/test/utils/Data.spec.ts
+++ b/test/utils/Data.spec.ts
@@ -5,9 +5,263 @@ import {
   DataType,
   ERROR_REASONS,
   MilvusClient,
+  ErrorCode,
+  f32ArrayToF16Bytes,
+  f32ArrayToBf16Bytes,
+  sparseRowsToBytes,
+  int8VectorRowsToBytes,
+  f32ArrayToBinaryBytes,
+  processVectorData,
 } from '../../milvus';
 
 describe('utils/Data', () => {
+  const captureInsertField = async (
+    vectorType: DataType,
+    rows: any[],
+    dim = 2
+  ) => {
+    const client = new MilvusClient({
+      address: 'localhost:19530',
+      __SKIP_CONNECT__: true,
+    });
+    let insertParams: any;
+    (client as any).describeCollection = jest.fn().mockResolvedValue({
+      status: { error_code: ErrorCode.SUCCESS, reason: '' },
+      schema: {
+        enable_dynamic_field: false,
+        fields: [
+          {
+            name: 'id',
+            data_type: DataType.Int64,
+            is_primary_key: true,
+            autoID: false,
+            nullable: false,
+            element_type: DataType.None,
+          },
+          {
+            name: 'vector',
+            data_type: vectorType,
+            dim: String(dim),
+            nullable: true,
+            element_type: DataType.None,
+          },
+        ],
+      },
+      properties: [],
+    });
+    (client as any).channelPool = {
+      acquire: jest.fn().mockResolvedValue({
+        Insert: (params: any, _options: any, cb: any) => {
+          insertParams = params;
+          cb(null, {
+            status: { error_code: ErrorCode.SUCCESS, reason: '' },
+            succ_index: [],
+            err_index: [],
+            acknowledged: true,
+            insert_cnt: String(rows.length),
+            delete_cnt: '0',
+            upsert_cnt: '0',
+            timestamp: '0',
+            IDs: {
+              int_id: { data: rows.map((_, i) => String(i + 1)) },
+              id_field: 'int_id',
+            },
+          });
+        },
+      }),
+      release: jest.fn(),
+    };
+
+    await client.insert({
+      collection_name: 'nullable_vector_collection',
+      fields_data: rows.map((vector, i) => ({ id: i + 1, vector })),
+    });
+
+    return insertParams.fields_data.find(
+      (field: any) => field.field_name === 'vector'
+    );
+  };
+
+  it('should encode nullable float vectors with valid_data and dense payload', async () => {
+    const vectorField = await captureInsertField(DataType.FloatVector, [
+      [1, 2],
+      null,
+      [3, 4],
+    ]);
+
+    expect(vectorField.valid_data).toEqual([true, false, true]);
+    expect(vectorField.vectors.float_vector.data).toEqual([1, 2, 3, 4]);
+  });
+
+  it('should encode nullable binary vectors with valid_data and dense payload', async () => {
+    const vectorField = await captureInsertField(
+      DataType.BinaryVector,
+      [[1], null, [2]],
+      8
+    );
+
+    expect(vectorField.valid_data).toEqual([true, false, true]);
+    expect(vectorField.vectors.binary_vector).toEqual(
+      f32ArrayToBinaryBytes([1, 2])
+    );
+  });
+
+  it('should encode nullable float16 vectors with valid_data and dense payload', async () => {
+    const vectorField = await captureInsertField(DataType.Float16Vector, [
+      [1, 2],
+      null,
+      [3, 4],
+    ]);
+
+    expect(vectorField.valid_data).toEqual([true, false, true]);
+    expect(vectorField.vectors.float16_vector).toEqual(
+      Buffer.concat([f32ArrayToF16Bytes([1, 2]), f32ArrayToF16Bytes([3, 4])])
+    );
+  });
+
+  it('should encode nullable bfloat16 vectors with valid_data and dense payload', async () => {
+    const vectorField = await captureInsertField(DataType.BFloat16Vector, [
+      [1, 2],
+      null,
+      [3, 4],
+    ]);
+
+    expect(vectorField.valid_data).toEqual([true, false, true]);
+    expect(vectorField.vectors.bfloat16_vector).toEqual(
+      Buffer.concat([f32ArrayToBf16Bytes([1, 2]), f32ArrayToBf16Bytes([3, 4])])
+    );
+  });
+
+  it('should encode nullable sparse vectors with valid_data and dense payload', async () => {
+    const rows = [{ '0': 1 }, null, { '1': 2 }];
+    const vectorField = await captureInsertField(
+      DataType.SparseFloatVector,
+      rows
+    );
+
+    expect(vectorField.valid_data).toEqual([true, false, true]);
+    expect(vectorField.vectors.sparse_float_vector.contents).toEqual(
+      sparseRowsToBytes([rows[0], rows[2]] as any)
+    );
+  });
+
+  it('should encode nullable int8 vectors with valid_data and dense payload', async () => {
+    const rows = [[1, 2], null, [3, 4]];
+    const vectorField = await captureInsertField(DataType.Int8Vector, rows);
+
+    expect(vectorField.valid_data).toEqual([true, false, true]);
+    expect(vectorField.vectors.int8_vector).toEqual(
+      int8VectorRowsToBytes([rows[0], rows[2]] as any)
+    );
+  });
+
+  it('should encode all-null nullable vectors with valid_data and empty payload', async () => {
+    const vectorField = await captureInsertField(DataType.FloatVector, [
+      null,
+      null,
+    ]);
+
+    expect(vectorField.valid_data).toEqual([false, false]);
+    expect(vectorField.vectors.dim).toBe(2);
+    expect(vectorField.vectors.float_vector.data).toEqual([]);
+  });
+
+  it('should decode nullable float vectors from valid_data and dense payload', () => {
+    const result = processVectorData({
+      valid_data: [true, false, true],
+      vectors: {
+        data: 'float_vector',
+        dim: 2,
+        float_vector: { data: [1, 2, 3, 4] },
+      },
+    });
+
+    expect(result).toEqual([[1, 2], null, [3, 4]]);
+  });
+
+  it('should decode nullable binary vectors from valid_data and dense payload', () => {
+    const result = processVectorData({
+      valid_data: [true, false, true],
+      vectors: {
+        data: 'binary_vector',
+        dim: 8,
+        binary_vector: f32ArrayToBinaryBytes([1, 2]),
+      },
+    });
+
+    expect(result).toEqual([[1], null, [2]]);
+  });
+
+  it('should decode nullable float16 vectors from valid_data and dense payload', () => {
+    const result = processVectorData({
+      valid_data: [true, false, true],
+      vectors: {
+        data: 'float16_vector',
+        dim: 2,
+        float16_vector: Buffer.concat([
+          f32ArrayToF16Bytes([1, 2]),
+          f32ArrayToF16Bytes([3, 4]),
+        ]),
+      },
+    });
+
+    expect(result[0]).toEqual([1, 2]);
+    expect(result[1]).toBeNull();
+    expect(result[2]).toEqual([3, 4]);
+  });
+
+  it('should decode nullable bfloat16 vectors from valid_data and dense payload', () => {
+    const result = processVectorData({
+      valid_data: [true, false, true],
+      vectors: {
+        data: 'bfloat16_vector',
+        dim: 2,
+        bfloat16_vector: Buffer.concat([
+          f32ArrayToBf16Bytes([1, 2]),
+          f32ArrayToBf16Bytes([3, 4]),
+        ]),
+      },
+    });
+
+    expect(result[0]).toEqual([1, 2]);
+    expect(result[1]).toBeNull();
+    expect(result[2]).toEqual([3, 4]);
+  });
+
+  it('should decode nullable sparse vectors from valid_data and dense payload', () => {
+    const result = processVectorData({
+      valid_data: [true, false, true],
+      vectors: {
+        data: 'sparse_float_vector',
+        dim: 2,
+        sparse_float_vector: {
+          dim: 2,
+          contents: sparseRowsToBytes([{ '0': 1 }, { '1': 2 }]).map(bytes =>
+            Buffer.from(bytes)
+          ),
+        },
+      },
+    });
+
+    expect(result).toEqual([{ '0': 1 }, null, { '1': 2 }]);
+  });
+
+  it('should decode nullable int8 vectors from valid_data and dense payload', () => {
+    const result = processVectorData({
+      valid_data: [true, false, true],
+      vectors: {
+        data: 'int8_vector',
+        dim: 2,
+        int8_vector: int8VectorRowsToBytes([
+          [1, 2],
+          [3, 4],
+        ]),
+      },
+    });
+
+    expect(result).toEqual([[1, 2], null, [3, 4]]);
+  });
+
   it('should expand query rows with element indices into offset rows', async () => {
     const client = new MilvusClient({
       address: 'localhost:19530',


### PR DESCRIPTION
## Summary
- Encode nullable vector fields with `valid_data` and compact physical vector payloads.
- Decode nullable vector query/search results back to logical rows with `null` entries.
- Add unit and gRPC integration coverage for nullable vector insert, upsert, query, search, and add-field flows.

## Test plan
- [x] `NODE_ENV=dev npx jest test/utils/Data.spec.ts --runInBand`
- [x] `NODE_ENV=dev npx jest test/grpc/NullableVector.spec.ts --runInBand`
- [x] `yarn build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)