### PR TITLE
feat: support array-of-vector struct payloads

### DIFF
--- a/milvus/const/milvus.ts
+++ b/milvus/const/milvus.ts
@@ -299,6 +299,7 @@ export enum DataType {
   BFloat16Vector = 103,
   SparseFloatVector = 104,
   Int8Vector = 105,
+  ArrayOfVector = 106,
 
   Struct = 201,
 }
@@ -359,6 +360,7 @@ export const DataTypeMap: { [key in keyof typeof DataType]: number } = {
   BFloat16Vector: 103,
   SparseFloatVector: 104,
   Int8Vector: 105,
+  ArrayOfVector: 106,
   Struct: 201,
 };
 
@@ -383,6 +385,7 @@ export enum DataTypeStringEnum {
   BFloat16Vector = 'BFloat16Vector',
   SparseFloatVector = 'SparseFloatVector',
   Int8Vector = 'Int8Vector',
+  ArrayOfVector = 'ArrayOfVector',
   Struct = 'Struct',
 }
 

--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -66,6 +66,7 @@ import {
   sparseRowsToBytes,
   Int8Vector,
   int8VectorRowsToBytes,
+  f32ArrayToInt8Bytes,
   getSparseDim,
   f32ArrayToBinaryBytes,
   getValidDataArray,
@@ -196,7 +197,7 @@ export class Data extends Collection {
                   {
                     name: field.name,
                     type: isVectorType(convertToDataType(field.data_type))
-                      ? (106 as DataType)
+                      ? DataType.ArrayOfVector
                       : DataType.Array,
                     elementType: convertToDataType(field.data_type),
                     dim: Number(field.dim),
@@ -316,8 +317,7 @@ export class Data extends Collection {
       };
 
       return Array.from(fields.values()).map(field => {
-        // 106 is ArrayOfVector, only internal data type
-        let key = [...VectorDataTypes, 106 as DataType].includes(field.type)
+        let key = [...VectorDataTypes, DataType.ArrayOfVector].includes(field.type)
           ? 'vectors'
           : 'scalars';
         if (field.elementType === DataType.Struct) {
@@ -390,24 +390,63 @@ export class Data extends Collection {
             };
             break;
 
-          // ArrayOfVector
-          case 106 as DataType:
-            keyValue = {
-              [dataKey]: {
-                dim: field.dim,
-                data: field.data.map(d => {
+          case DataType.ArrayOfVector: {
+            const buildVectorArrayData = (vector: any) => {
+              switch (field.elementType) {
+                case DataType.FloatVector:
+                  return {
+                    dim: field.dim,
+                    [elementTypeKey]: {
+                      data: vector,
+                    },
+                  };
+                case DataType.BinaryVector:
+                  return {
+                    dim: field.dim,
+                    [elementTypeKey]: f32ArrayToBinaryBytes(vector),
+                  };
+                case DataType.BFloat16Vector:
+                case DataType.Float16Vector:
+                  return {
+                    dim: field.dim,
+                    [elementTypeKey]: Buffer.concat(
+                      Array.isArray(vector) ? vector : [vector]
+                    ),
+                  };
+                case DataType.Int8Vector:
+                  return {
+                    dim: field.dim,
+                    [elementTypeKey]:
+                      Array.isArray(vector) && typeof vector[0] === 'number'
+                        ? f32ArrayToInt8Bytes(vector)
+                        : Array.isArray(vector)
+                          ? int8VectorRowsToBytes(vector)
+                          : Buffer.from(
+                              vector.buffer,
+                              vector.byteOffset,
+                              vector.byteLength
+                            ),
+                  };
+                default:
                   return {
                     dim: field.dim,
                     [elementTypeKey]: {
                       type: field.elementType,
-                      data: d,
+                      data: vector,
                     },
                   };
-                }),
+              }
+            };
+
+            keyValue = {
+              [dataKey]: {
+                dim: field.dim,
+                data: field.data.map(buildVectorArrayData),
                 element_type: field.elementType,
               },
             };
             break;
+          }
 
           case DataType.Array:
             if (field.elementType === DataType.Struct) {

--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -428,13 +428,9 @@ export class Data extends Collection {
                             ),
                   };
                 default:
-                  return {
-                    dim: field.dim,
-                    [elementTypeKey]: {
-                      type: field.elementType,
-                      data: vector,
-                    },
-                  };
+                  throw new Error(
+                    `ArrayOfVector element type is not supported: ${field.elementType}`
+                  );
               }
             };
 

--- a/milvus/utils/Bytes.ts
+++ b/milvus/utils/Bytes.ts
@@ -312,22 +312,26 @@ export const buildPlaceholderGroupBytes = (
         break;
 
       case PlaceholderType.BinaryVector:
+      case PlaceholderType.EmbListBinaryVector:
         bytes = data.map(v => f32ArrayToBinaryBytes(v as BinaryVector));
         break;
 
       case PlaceholderType.BFloat16Vector:
+      case PlaceholderType.EmbListBFloat16Vector:
         bytes = data.map(v =>
           Array.isArray(v) ? f32ArrayToBf16Bytes(v as BFloat16Vector) : v
         );
         break;
 
       case PlaceholderType.Float16Vector:
+      case PlaceholderType.EmbListFloat16Vector:
         bytes = data.map(v =>
           Array.isArray(v) ? f32ArrayToF16Bytes(v as Float16Vector) : v
         );
         break;
 
       case PlaceholderType.Int8Vector:
+      case PlaceholderType.EmbListInt8Vector:
         bytes = data.map(v =>
           Array.isArray(v) ? f32ArrayToInt8Bytes(v as Int8Vector) : v
         );
@@ -336,6 +340,9 @@ export const buildPlaceholderGroupBytes = (
       case PlaceholderType.SparseFloatVector:
         bytes = data.map(v => sparseToBytes(v as SparseFloatVector));
         break;
+
+      case PlaceholderType.EmbListSparseFloatVector:
+        throw new Error('Sparse embedding list search is not supported');
     }
   }
 

--- a/milvus/utils/Data.ts
+++ b/milvus/utils/Data.ts
@@ -16,6 +16,7 @@ import {
   f16BytesToF32Array,
   cloneObj,
   Struct,
+  VectorDataTypes,
 } from '../';
 
 /**
@@ -123,8 +124,13 @@ export const processVectorData = (
       // split buffer data to int8 vector
       for (let i = 0; i < int8Bytes.byteLength; i += int8Dim) {
         const slice = int8Bytes.slice(i, i + int8Dim);
+        const signedSlice = new Int8Array(
+          slice.buffer,
+          slice.byteOffset,
+          slice.byteLength
+        );
 
-        field_data.push(localTransformers[DataType.Int8Vector](slice));
+        field_data.push(localTransformers[DataType.Int8Vector](signedSlice));
       }
 
       break;
@@ -352,6 +358,24 @@ export const buildFieldData = (
         ? Buffer.from(JSON.stringify(rowData[name] || {}))
         : Buffer.alloc(0);
 
+    case DataType.ArrayOfVector:
+      switch (elementType) {
+        case DataType.BFloat16Vector:
+          const bf16Transformer =
+            transformers?.[DataType.BFloat16Vector] || f32ArrayToBf16Bytes;
+          return isFloat32
+            ? bf16Transformer(rowData[name] as BFloat16Vector)
+            : rowData[name];
+        case DataType.Float16Vector:
+          const f16Transformer =
+            transformers?.[DataType.Float16Vector] || f32ArrayToF16Bytes;
+          return isFloat32
+            ? f16Transformer(rowData[name] as Float16Vector)
+            : rowData[name];
+        default:
+          return rowData[name];
+      }
+
     case DataType.Array:
       const elementField = { ...field, type: elementType!, fieldMap: fieldMap };
 
@@ -380,15 +404,14 @@ export const buildFieldData = (
               rowIndex
             );
 
-            // Special handling for binary and float vector types
             const dataArray = structField.data[rowIndex!] || [];
             structField.data[rowIndex!] = dataArray;
 
-            const isVectorType =
-              structField.elementType === DataType.BinaryVector ||
-              structField.elementType === DataType.FloatVector;
+            const isStructVectorField =
+              structField.type === DataType.ArrayOfVector &&
+              VectorDataTypes.includes(structField.elementType!);
 
-            if (isVectorType) {
+            if (isStructVectorField) {
               (dataArray as FieldData[]).push(
                 ...(Array.isArray(fieldData) ? fieldData : [fieldData])
               );

--- a/milvus/utils/Data.ts
+++ b/milvus/utils/Data.ts
@@ -407,15 +407,23 @@ export const buildFieldData = (
             const dataArray = structField.data[rowIndex!] || [];
             structField.data[rowIndex!] = dataArray;
 
-            const isStructVectorField =
-              VectorDataTypes.includes(structField.type) ||
-              (structField.type === DataType.ArrayOfVector &&
-                VectorDataTypes.includes(structField.elementType!));
-
-            if (isStructVectorField) {
+            if (VectorDataTypes.includes(structField.type)) {
               (dataArray as FieldData[]).push(
                 ...(Array.isArray(fieldData) ? fieldData : [fieldData])
               );
+            } else if (
+              structField.type === DataType.ArrayOfVector &&
+              (structField.elementType === DataType.FloatVector ||
+                structField.elementType === DataType.BinaryVector)
+            ) {
+              (dataArray as FieldData[]).push(
+                ...(Array.isArray(fieldData) ? fieldData : [fieldData])
+              );
+            } else if (
+              structField.type === DataType.ArrayOfVector &&
+              VectorDataTypes.includes(structField.elementType!)
+            ) {
+              (dataArray as FieldData[]).push(fieldData);
             } else {
               (dataArray as FieldData[]).push(fieldData);
             }

--- a/milvus/utils/Data.ts
+++ b/milvus/utils/Data.ts
@@ -408,8 +408,9 @@ export const buildFieldData = (
             structField.data[rowIndex!] = dataArray;
 
             const isStructVectorField =
-              structField.type === DataType.ArrayOfVector &&
-              VectorDataTypes.includes(structField.elementType!);
+              VectorDataTypes.includes(structField.type) ||
+              (structField.type === DataType.ArrayOfVector &&
+                VectorDataTypes.includes(structField.elementType!));
 
             if (isStructVectorField) {
               (dataArray as FieldData[]).push(

--- a/milvus/utils/Schema.ts
+++ b/milvus/utils/Schema.ts
@@ -98,7 +98,7 @@ export const getDataKey = (type: DataType, camelCase: boolean = false) => {
     case DataType.Timestamptz:
       dataKey = 'timestamptz_data';
       break;
-    case 106 as DataType: // Internal: ArrayOfVector
+    case DataType.ArrayOfVector:
       dataKey = 'vector_array';
       break;
     case DataType.None:
@@ -230,7 +230,7 @@ export const formatFieldSchema = (
 
   // if element type exist and
   if (
-    (dataType === DataType.Array || dataType === (106 as DataType)) &&
+    (dataType === DataType.Array || dataType === DataType.ArrayOfVector) &&
     typeof element_type !== 'undefined'
   ) {
     createObj.elementType = convertToDataType(element_type);
@@ -314,7 +314,7 @@ export const formatStructArrayFieldSchema = (
       // convert the field to array field, and set the max capacity
       f.element_type = f.data_type;
       f.data_type = isVectorType(convertToDataType(f.data_type as DataType)!)
-        ? (106 as DataType) // ArrayOfVector
+        ? DataType.ArrayOfVector
         : DataType.Array;
       f.max_capacity = field.max_capacity;
 

--- a/milvus/utils/Search.ts
+++ b/milvus/utils/Search.ts
@@ -634,19 +634,50 @@ export const formatSearchData = (
   }
 
   switch (_placeholderType) {
+    case PlaceholderType.EmbListSparseFloatVector:
+      throw new Error('Sparse embedding list search is not supported');
+
     case PlaceholderType.EmbListFloatVector:
+    case PlaceholderType.EmbListBinaryVector:
+    case PlaceholderType.EmbListFloat16Vector:
+    case PlaceholderType.EmbListBFloat16Vector:
+    case PlaceholderType.EmbListInt8Vector: {
+      const isTypedArray = (value: unknown): value is Uint8Array | Int8Array =>
+        value instanceof Uint8Array || value instanceof Int8Array;
+      const flattenEmbeddingList = (embeddingList: any) => {
+        if (
+          Array.isArray(embeddingList) &&
+          embeddingList.length > 0 &&
+          embeddingList.every(isTypedArray)
+        ) {
+          const totalLength = embeddingList.reduce(
+            (total, vector) => total + vector.length,
+            0
+          );
+          const flattened = new Uint8Array(totalLength);
+          let offset = 0;
+          embeddingList.forEach(vector => {
+            flattened.set(vector, offset);
+            offset += vector.length;
+          });
+          return flattened;
+        }
+        return embeddingList.flat();
+      };
       const isMultiEmbeddingList =
         Array.isArray(searchData) &&
         Array.isArray((searchData as any)[0]) &&
-        Array.isArray((searchData as any)[0][0]);
+        (Array.isArray((searchData as any)[0][0]) ||
+          isTypedArray((searchData as any)[0][0]));
 
       if (isMultiEmbeddingList) {
-        return (searchData as SearchEmbList[]).map(v => v.flat()) as [
-          SearchData
-        ];
+        return (searchData as SearchEmbList[]).map(v =>
+          flattenEmbeddingList(v)
+        ) as [SearchData];
       } else {
-        return [(searchData as SearchEmbList).flat() as SearchData];
+        return [flattenEmbeddingList(searchData) as SearchData];
       }
+    }
     case PlaceholderType.FloatVector:
     case PlaceholderType.BinaryVector:
     case PlaceholderType.Float16Vector:

--- a/test/grpc/Struct.spec.ts
+++ b/test/grpc/Struct.spec.ts
@@ -12,6 +12,7 @@ const milvusClient = new MilvusClient({
   logLevel: 'info',
 });
 const COLLECTION_NAME = GENERATE_NAME();
+const VECTOR_TYPE_COLLECTION_NAME = GENERATE_NAME();
 
 const dbParam = {
   db_name: 'struct_DB',
@@ -133,6 +134,55 @@ const collectionParams = {
 
 const data = generateInsertData(collectionParams.fields, 5);
 
+const vectorTypeCollectionParams = {
+  collection_name: VECTOR_TYPE_COLLECTION_NAME,
+  consistency_level: 'Strong',
+  fields: [
+    {
+      name: 'id',
+      description: 'id field',
+      data_type: DataType.Int64,
+      is_primary_key: true,
+      autoID: true,
+    },
+    {
+      name: 'array_of_vector_struct',
+      description: 'struct array field',
+      data_type: DataType.Array,
+      element_type: DataType.Struct,
+      max_capacity: 2,
+      fields: [
+        {
+          name: 'binary_vector_of_struct',
+          description: 'binary vector array field',
+          data_type: DataType.BinaryVector,
+          dim: 8,
+        },
+        {
+          name: 'float16_vector_of_struct',
+          description: 'float16 vector array field',
+          data_type: DataType.Float16Vector,
+          dim: 4,
+        },
+        {
+          name: 'bfloat16_vector_of_struct',
+          description: 'bfloat16 vector array field',
+          data_type: DataType.BFloat16Vector,
+          dim: 4,
+        },
+        {
+          name: 'int8_vector_of_struct',
+          description: 'int8 vector array field',
+          data_type: DataType.Int8Vector,
+          dim: 4,
+        },
+      ],
+    },
+  ],
+};
+
+const vectorTypeData = generateInsertData(vectorTypeCollectionParams.fields, 5);
+
 describe(`Struct API testing`, () => {
   beforeAll(async () => {
     await milvusClient.createDatabase(dbParam);
@@ -140,7 +190,12 @@ describe(`Struct API testing`, () => {
   });
 
   afterAll(async () => {
-    await milvusClient.dropCollection({ collection_name: COLLECTION_NAME });
+    await milvusClient
+      .dropCollection({ collection_name: COLLECTION_NAME })
+      .catch(() => undefined);
+    await milvusClient
+      .dropCollection({ collection_name: VECTOR_TYPE_COLLECTION_NAME })
+      .catch(() => undefined);
     await milvusClient.dropDatabase(dbParam);
   });
 
@@ -187,25 +242,6 @@ describe(`Struct API testing`, () => {
     );
     expect(structArrayFields[1]!.fields![0].dim).toEqual('4');
     expect(structArrayFields[1]!.fields![1].dataType).toEqual(DataType.Bool);
-
-    // expect(structArrayFields[1]!.fields![1].dataType).toEqual(
-    //   DataType.Float16Vector
-    // );
-    // expect(structArrayFields[1]!.fields![1].dim).toEqual('4');
-    // expect(structArrayFields[1]!.fields![2].dataType).toEqual(
-    //   DataType.Int8Vector
-    // );
-    // expect(structArrayFields[1]!.fields![2].dim).toEqual('4');
-    // expect(structArrayFields[1]!.fields![3].dataType).toEqual(DataType.Int64);
-    // expect(structArrayFields[1]!.fields![4].dataType).toEqual(DataType.Bool);
-    // expect(structArrayFields[1]!.fields![5].dataType).toEqual(DataType.Float);
-    // expect(structArrayFields[1]!.fields![6].dataType).toEqual(DataType.Double);
-    // expect(structArrayFields[1]!.fields![7].dataType).toEqual(DataType.VarChar);
-    // expect(structArrayFields[1]!.fields![7].max_length).toEqual('4');
-
-    // expect(vectorArrayFields.length).toBe(1);
-
-    // console.dir(describe.schema, { depth: null });
   });
 
   it(`insert vector array data should be successful`, async () => {
@@ -216,6 +252,113 @@ describe(`Struct API testing`, () => {
 
     expect(insert.status.error_code).toEqual(ErrorCode.SUCCESS);
     expect(insert.succ_index.length).toEqual(data.length);
+  });
+
+  it(`struct vector field types should be queryable`, async () => {
+    const create = await milvusClient.createCollection(
+      vectorTypeCollectionParams
+    );
+    expect(create.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const describe = await milvusClient.describeCollection({
+      collection_name: VECTOR_TYPE_COLLECTION_NAME,
+    });
+    const structArrayField = describe.schema.fields.find(
+      (field: any) =>
+        field.data_type === 'Array' && field.element_type === 'Struct'
+    );
+
+    expect(structArrayField).toBeDefined();
+    expect(
+      structArrayField!.fields!.map((field: any) => field.dataType)
+    ).toEqual([
+      DataType.BinaryVector,
+      DataType.Float16Vector,
+      DataType.BFloat16Vector,
+      DataType.Int8Vector,
+    ]);
+    expect(
+      structArrayField!.fields!.map((field: any) => field.data_type)
+    ).toEqual([
+      'BinaryVector',
+      'Float16Vector',
+      'BFloat16Vector',
+      'Int8Vector',
+    ]);
+
+    const insert = await milvusClient.insert({
+      collection_name: VECTOR_TYPE_COLLECTION_NAME,
+      data: vectorTypeData,
+    });
+    expect(insert.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(insert.succ_index.length).toEqual(vectorTypeData.length);
+
+    const indexes = await milvusClient.createIndex([
+      {
+        collection_name: VECTOR_TYPE_COLLECTION_NAME,
+        index_name: 'array_of_vector_struct_binary',
+        field_name: 'array_of_vector_struct[binary_vector_of_struct]',
+        metric_type: MetricType.HAMMING,
+        index_type: IndexType.AUTOINDEX,
+      },
+      {
+        collection_name: VECTOR_TYPE_COLLECTION_NAME,
+        index_name: 'array_of_vector_struct_float16',
+        field_name: 'array_of_vector_struct[float16_vector_of_struct]',
+        metric_type: MetricType.MAX_SIM,
+        index_type: IndexType.AUTOINDEX,
+      },
+      {
+        collection_name: VECTOR_TYPE_COLLECTION_NAME,
+        index_name: 'array_of_vector_struct_bfloat16',
+        field_name: 'array_of_vector_struct[bfloat16_vector_of_struct]',
+        metric_type: MetricType.MAX_SIM,
+        index_type: IndexType.AUTOINDEX,
+      },
+      {
+        collection_name: VECTOR_TYPE_COLLECTION_NAME,
+        index_name: 'array_of_vector_struct_int8',
+        field_name: 'array_of_vector_struct[int8_vector_of_struct]',
+        metric_type: MetricType.MAX_SIM,
+        index_type: IndexType.AUTOINDEX,
+      },
+    ]);
+    expect(indexes.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const load = await milvusClient.loadCollection({
+      collection_name: VECTOR_TYPE_COLLECTION_NAME,
+    });
+    expect(load.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const query = await milvusClient.query({
+      collection_name: VECTOR_TYPE_COLLECTION_NAME,
+      filter: 'id > 0',
+      output_fields: ['array_of_vector_struct'],
+    });
+    expect(query.status.error_code).toEqual(ErrorCode.SUCCESS);
+
+    query.data.forEach((item: any, index: number) => {
+      expect(item.array_of_vector_struct.length).toEqual(2);
+      item.array_of_vector_struct.forEach(
+        (vector: any, vectorIndex: number) => {
+          const expectedVector =
+            vectorTypeData[index].array_of_vector_struct[vectorIndex];
+
+          expect(vector.binary_vector_of_struct).toEqual(
+            expectedVector.binary_vector_of_struct
+          );
+          vector.float16_vector_of_struct.forEach((v: number, i: number) => {
+            expect(v).toBeCloseTo(expectedVector.float16_vector_of_struct[i]);
+          });
+          vector.bfloat16_vector_of_struct.forEach((v: number, i: number) => {
+            expect(v).toBeCloseTo(expectedVector.bfloat16_vector_of_struct[i]);
+          });
+          expect(vector.int8_vector_of_struct).toEqual(
+            Array.from(expectedVector.int8_vector_of_struct)
+          );
+        }
+      );
+    });
   });
 
   it(`create index should be successful`, async () => {

--- a/test/utils/Data.spec.ts
+++ b/test/utils/Data.spec.ts
@@ -11,10 +11,51 @@ import {
   sparseRowsToBytes,
   int8VectorRowsToBytes,
   f32ArrayToBinaryBytes,
+  f32ArrayToInt8Bytes,
   processVectorData,
 } from '../../milvus';
 
 describe('utils/Data', () => {
+  const captureInsertParams = async (describeResponse: any, rows: any[]) => {
+    const client = new MilvusClient({
+      address: 'localhost:19530',
+      __SKIP_CONNECT__: true,
+    });
+    let insertParams: any;
+    (client as any).describeCollection = jest.fn().mockResolvedValue(
+      describeResponse
+    );
+    (client as any).channelPool = {
+      acquire: jest.fn().mockResolvedValue({
+        Insert: (params: any, _options: any, cb: any) => {
+          insertParams = params;
+          cb(null, {
+            status: { error_code: ErrorCode.SUCCESS, reason: '' },
+            succ_index: [],
+            err_index: [],
+            acknowledged: true,
+            insert_cnt: String(rows.length),
+            delete_cnt: '0',
+            upsert_cnt: '0',
+            timestamp: '0',
+            IDs: {
+              int_id: { data: rows.map((_, i) => String(i + 1)) },
+              id_field: 'int_id',
+            },
+          });
+        },
+      }),
+      release: jest.fn(),
+    };
+
+    await client.insert({
+      collection_name: 'test_collection',
+      fields_data: rows,
+    });
+
+    return insertParams;
+  };
+
   const captureInsertField = async (
     vectorType: DataType,
     rows: any[],
@@ -153,6 +194,158 @@ describe('utils/Data', () => {
     expect(vectorField.vectors.int8_vector).toEqual(
       int8VectorRowsToBytes([rows[0], rows[2]] as any)
     );
+  });
+
+  it('should reject unsupported top-level vector array element types', async () => {
+    await expect(
+      captureInsertParams(
+        {
+          status: { error_code: ErrorCode.SUCCESS, reason: '' },
+          schema: {
+            enable_dynamic_field: false,
+            fields: [
+              {
+                name: 'id',
+                data_type: DataType.Int64,
+                is_primary_key: true,
+                autoID: false,
+                nullable: false,
+                element_type: DataType.None,
+              },
+              {
+                name: 'vectorArray',
+                data_type: DataType.ArrayOfVector,
+                element_type: DataType.VarChar,
+                dim: '4',
+                nullable: false,
+              },
+            ],
+          },
+          properties: [],
+        },
+        [{ id: 1, vectorArray: [['unsupported']] }]
+      )
+    ).rejects.toThrow(
+      `ArrayOfVector element type is not supported: ${DataType.VarChar}`
+    );
+  });
+
+  it('should encode top-level int8 vector arrays from vector rows and typed payloads', async () => {
+    const rows = [
+      { id: 1, vectorArray: [[1, -2, 3, -4], new Int8Array([5, -6, 7, -8])] },
+      { id: 2, vectorArray: new Int8Array([9, -10, 11, -12]) },
+    ];
+    const insertParams = await captureInsertParams(
+      {
+        status: { error_code: ErrorCode.SUCCESS, reason: '' },
+        schema: {
+          enable_dynamic_field: false,
+          fields: [
+            {
+              name: 'id',
+              data_type: DataType.Int64,
+              is_primary_key: true,
+              autoID: false,
+              nullable: false,
+              element_type: DataType.None,
+            },
+            {
+              name: 'vectorArray',
+              data_type: DataType.ArrayOfVector,
+              element_type: DataType.Int8Vector,
+              dim: '4',
+              nullable: false,
+            },
+          ],
+        },
+        properties: [],
+      },
+      rows
+    );
+
+    const vectorField = insertParams.fields_data.find(
+      (field: any) => field.field_name === 'vectorArray'
+    );
+
+    expect(vectorField.vectors.vector_array.data).toEqual([
+      {
+        dim: 4,
+        int8_vector: int8VectorRowsToBytes([
+          [1, -2, 3, -4],
+          new Int8Array([5, -6, 7, -8]),
+        ]),
+      },
+      {
+        dim: 4,
+        int8_vector: Buffer.from(
+          new Int8Array([9, -10, 11, -12]).buffer
+        ),
+      },
+    ]);
+  });
+
+  it('should encode struct int8 vector arrays from number arrays and typed arrays', async () => {
+    const rows = [
+      {
+        id: 1,
+        structArray: [
+          { vector: [1, -2, 3, -4] },
+          { vector: new Int8Array([5, -6, 7, -8]) },
+        ],
+      },
+    ];
+    const insertParams = await captureInsertParams(
+      {
+        status: { error_code: ErrorCode.SUCCESS, reason: '' },
+        schema: {
+          enable_dynamic_field: false,
+          fields: [
+            {
+              name: 'id',
+              data_type: DataType.Int64,
+              is_primary_key: true,
+              autoID: false,
+              nullable: false,
+              element_type: DataType.None,
+            },
+            {
+              name: 'structArray',
+              data_type: DataType.Array,
+              element_type: DataType.Struct,
+              max_capacity: '2',
+              nullable: false,
+              fields: [
+                {
+                  name: 'vector',
+                  data_type: DataType.Int8Vector,
+                  dim: '4',
+                  nullable: false,
+                },
+              ],
+            },
+          ],
+        },
+        properties: [],
+      },
+      rows
+    );
+
+    const structField = insertParams.fields_data.find(
+      (field: any) => field.field_name === 'structArray'
+    );
+    const vectorField = structField.struct_arrays.fields.find(
+      (field: any) => field.field_name === 'vector'
+    );
+
+    expect(vectorField.vectors.vector_array.data).toEqual([
+      {
+        dim: 4,
+        int8_vector: int8VectorRowsToBytes([
+          [1, -2, 3, -4],
+          new Int8Array([5, -6, 7, -8]),
+        ]),
+      },
+    ]);
   });
 
   it('should encode all-null nullable vectors with valid_data and empty payload', async () => {
@@ -747,6 +940,21 @@ describe('utils/Data', () => {
         const result = buildFieldData(row, field, transformers);
         expect(customTransformer).toHaveBeenCalledWith([1.1, 2.2, 3.3]);
         expect(result).toBe('transformed');
+      });
+    });
+
+    describe('ArrayOfVector type', () => {
+      it('should handle Float16Vector with non-float32 input', () => {
+        const row = { vectorArray: new Uint8Array([1, 2, 3, 4]) };
+        const field = {
+          type: DataType.ArrayOfVector,
+          elementType: DataType.Float16Vector,
+          name: 'vectorArray',
+          fieldMap: new Map(),
+        } as _Field;
+
+        const result = buildFieldData(row, field);
+        expect(result).toEqual(new Uint8Array([1, 2, 3, 4]));
       });
     });
 

--- a/test/utils/Schema.spec.ts
+++ b/test/utils/Schema.spec.ts
@@ -143,6 +143,7 @@ describe('utils/Schema', () => {
     expect(convertToDataType('FloatVector')).toEqual(DataType.FloatVector);
     expect(convertToDataType('Bool')).toEqual(DataType.Bool);
     expect(convertToDataType('Array')).toEqual(DataType.Array);
+    expect(convertToDataType('ArrayOfVector')).toEqual(DataType.ArrayOfVector);
     expect(convertToDataType('JSON')).toEqual(DataType.JSON);
   });
 

--- a/test/utils/Search.spec.ts
+++ b/test/utils/Search.spec.ts
@@ -1579,6 +1579,80 @@ describe('utils/Search', () => {
     ]);
   });
 
+  it('should format non-float embedding list vectors correctly', () => {
+    const embeddingListVectors = [
+      new Uint8Array([1, 2]),
+      new Uint8Array([3, 4]),
+    ];
+
+    [
+      PlaceholderType.EmbListBinaryVector,
+      PlaceholderType.EmbListFloat16Vector,
+      PlaceholderType.EmbListBFloat16Vector,
+      PlaceholderType.EmbListInt8Vector,
+    ].forEach(_placeholderType => {
+      const formattedEmbeddingListVectors = formatSearchData(
+        embeddingListVectors,
+        { _placeholderType } as any
+      );
+
+      expect(formattedEmbeddingListVectors).toEqual([
+        new Uint8Array([1, 2, 3, 4]),
+      ]);
+    });
+  });
+
+  it('should build non-float embedding-list placeholder bytes', () => {
+    const milvusProtoPath = path.resolve(
+      __dirname,
+      '../../proto/proto/milvus.proto'
+    );
+    const milvusProto = protobuf.loadSync(milvusProtoPath);
+    const PlaceholderGroup = milvusProto.lookupType(
+      'milvus.proto.common.PlaceholderGroup'
+    );
+
+    [
+      [PlaceholderType.EmbListBinaryVector, 'EmbListBinaryVector'],
+      [PlaceholderType.EmbListFloat16Vector, 'EmbListFloat16Vector'],
+      [PlaceholderType.EmbListBFloat16Vector, 'EmbListBFloat16Vector'],
+      [PlaceholderType.EmbListInt8Vector, 'EmbListInt8Vector'],
+    ].forEach(([_placeholderType, expectedType]) => {
+      const placeholderGroup = PlaceholderGroup.decode(
+        buildPlaceholderGroupBytes(
+          milvusProto,
+          [new Uint8Array([1, 2, 3, 4])],
+          { _placeholderType } as any
+        )
+      ).toJSON() as any;
+
+      expect(placeholderGroup.placeholders[0].type).toEqual(expectedType);
+      expect(placeholderGroup.placeholders[0].values).toEqual(['AQIDBA==']);
+    });
+  });
+
+  it('should reject sparse embedding-list placeholder formatting', () => {
+    expect(() =>
+      formatSearchData([{ 1: 0.5 }, { 3: 0.25 }], {
+        _placeholderType: PlaceholderType.EmbListSparseFloatVector,
+      } as any)
+    ).toThrow('Sparse embedding list search is not supported');
+
+    const milvusProtoPath = path.resolve(
+      __dirname,
+      '../../proto/proto/milvus.proto'
+    );
+    const milvusProto = protobuf.loadSync(milvusProtoPath);
+
+    expect(() =>
+      buildPlaceholderGroupBytes(
+        milvusProto,
+        [{ 1: 0.5 }, { 3: 0.25 }],
+        { _placeholderType: PlaceholderType.EmbListSparseFloatVector } as any
+      )
+    ).toThrow('Sparse embedding list search is not supported');
+  });
+
   it('should build varchar placeholder for function output vector search', () => {
     const milvusProtoPath = path.resolve(
       __dirname,


### PR DESCRIPTION
## Summary
- Expose `DataType.ArrayOfVector` in SDK enums/maps and replace internal hardcoded `106` usages.
- Serialize ArrayOfVector/EmbeddingList payloads by element type for Binary, Float16, BFloat16, and Int8 vectors.
- Add unit and struct integration coverage for non-float embedding-list and struct vector-array fields.

## Test plan
- [x] `NODE_ENV=dev npx jest test/utils/Schema.spec.ts test/utils/Search.spec.ts test/grpc/Struct.spec.ts test/grpc/Int8Vector.spec.ts --runInBand --coverage --collectCoverageFrom='milvus/grpc/Data.ts' --collectCoverageFrom='milvus/utils/Data.ts' --collectCoverageFrom='milvus/utils/Bytes.ts' --collectCoverageFrom='milvus/utils/Schema.ts' --collectCoverageFrom='milvus/utils/Search.ts' --collectCoverageFrom='milvus/const/milvus.ts'`
- [x] `yarn build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)