### PR TITLE
docs: update feature coverage for 2.6 APIs

### DIFF
--- a/docs/content/advanced/full-text-search.mdx
+++ b/docs/content/advanced/full-text-search.mdx
@@ -25,13 +25,33 @@ console.log('Results:', result.results);
 // Each text input produces an AnalyzerResult with tokens
 ```
 
+You can also test analyzers that are configured on a collection field, request detailed token data, and include token hashes:
+
+```javascript
+const result = await client.runAnalyzer({
+  db_name: 'default',
+  collection_name: 'articles',
+  field_name: 'body',
+  analyzer_names: ['english_analyzer'],
+  text: ['Running analyzers with offsets and hashes'],
+  with_detail: true,
+  with_hash: true,
+});
+
+result.results[0].tokens.forEach(token => {
+  console.log(token.token, token.start_offset, token.end_offset, token.hash);
+});
+```
+
+`runAnalyzer()` accepts either `analyzer_params` for an ad-hoc analyzer configuration or collection context fields (`db_name`, `collection_name`, `field_name`, `analyzer_names`) to use analyzers defined in a schema.
+
 ### Analyzer Types
 
-| Type | Description |
-|------|-------------|
+| Type       | Description                              |
+| ---------- | ---------------------------------------- |
 | `standard` | Standard tokenizer with lowercase filter |
-| `english` | English-specific tokenizer with stemming |
-| `chinese` | Chinese text tokenizer |
+| `english`  | English-specific tokenizer with stemming |
+| `chinese`  | Chinese text tokenizer                   |
 
 ## Creating a Full-Text Search Collection
 
@@ -44,9 +64,24 @@ const client = new MilvusClient({ address: 'localhost:19530' });
 await client.createCollection({
   collection_name: 'articles',
   fields: [
-    { name: 'id', data_type: DataType.Int64, is_primary_key: true, autoID: true },
-    { name: 'title', data_type: DataType.VarChar, max_length: 256, enable_analyzer: true },
-    { name: 'body', data_type: DataType.VarChar, max_length: 10000, enable_analyzer: true },
+    {
+      name: 'id',
+      data_type: DataType.Int64,
+      is_primary_key: true,
+      autoID: true,
+    },
+    {
+      name: 'title',
+      data_type: DataType.VarChar,
+      max_length: 256,
+      enable_analyzer: true,
+    },
+    {
+      name: 'body',
+      data_type: DataType.VarChar,
+      max_length: 10000,
+      enable_analyzer: true,
+    },
     { name: 'sparse_vector', data_type: DataType.SparseFloatVector },
   ],
   functions: [
@@ -96,8 +131,14 @@ await client.loadCollectionSync({ collection_name: 'articles' });
 await client.insert({
   collection_name: 'articles',
   data: [
-    { title: 'Introduction to Machine Learning', body: 'Machine learning is a branch of AI...' },
-    { title: 'Deep Learning Basics', body: 'Deep learning uses neural networks...' },
+    {
+      title: 'Introduction to Machine Learning',
+      body: 'Machine learning is a branch of AI...',
+    },
+    {
+      title: 'Deep Learning Basics',
+      body: 'Deep learning uses neural networks...',
+    },
   ],
 });
 
@@ -129,7 +170,7 @@ const results = await client.search({
   limit: 10,
   output_fields: ['title', 'body'],
   highlighter: {
-    type: 0,  // HighlightType.Lexical
+    type: 0, // HighlightType.Lexical
     pre_tags: ['<em>'],
     post_tags: ['</em>'],
     fragment_size: 100,
@@ -150,7 +191,7 @@ const results = await client.search({
   limit: 10,
   output_fields: ['title', 'body'],
   highlighter: {
-    type: 1,  // HighlightType.Semantic
+    type: 1, // HighlightType.Semantic
     queries: ['machine learning'],
     input_fields: ['body'],
     pre_tags: ['<mark>'],
@@ -159,6 +200,25 @@ const results = await client.search({
   },
 });
 ```
+
+### Highlight Results
+
+Search hits include highlight data when highlighting is enabled. Each highlighted field contains text fragments and optional scores.
+
+```javascript
+results.results.forEach(hit => {
+  console.log('Title:', hit.title);
+  console.log('Highlight:', hit.highlight);
+
+  const bodyHighlight = hit.highlight?.body;
+  bodyHighlight?.fragments.forEach((fragment, index) => {
+    console.log('Fragment:', fragment);
+    console.log('Score:', bodyHighlight.scores?.[index]);
+  });
+});
+```
+
+For lexical highlighting, set `highlight_search_text: true` to include the matched search text in highlight output when supported by Milvus. For semantic highlighting, set `highlight_only: true` to return only highlighted fragments instead of the full source text.
 
 ## Managing Collection Functions
 

--- a/docs/content/core-concepts/client-configuration.mdx
+++ b/docs/content/core-concepts/client-configuration.mdx
@@ -69,23 +69,23 @@ const client = new MilvusClient({
     rootCertPath: '/path/to/ca.pem',
     // Or certificate buffer
     rootCert: Buffer.from('...'),
-    
+
     // Private key path (for client authentication)
     privateKeyPath: '/path/to/key.pem',
     // Or private key buffer
     privateKey: Buffer.from('...'),
-    
+
     // Certificate chain path
     certChainPath: '/path/to/cert.pem',
     // Or certificate buffer
     certChain: Buffer.from('...'),
-    
+
     // Server name for SNI
     serverName: 'milvus.example.com',
-    
+
     // Skip certificate verification (not recommended for production)
     skipCertCheck: false,
-    
+
     // Additional verify options
     verifyOptions: {},
   },
@@ -171,6 +171,22 @@ const client = new MilvusClient({
 });
 ```
 
+### Connect Reserved Options
+
+Use `option` to pass reserved key-value metadata in the initial Milvus `Connect` request. These values are sent as `client_info.reserved` and are useful for deployment-specific routing, attribution, or internal integrations.
+
+```javascript
+const client = new MilvusClient({
+  address: 'localhost:19530',
+  option: {
+    app: 'recommendation-service',
+    environment: 'production',
+  },
+});
+```
+
+`option` values must be strings.
+
 ## Environment-Specific Configuration
 
 ### Development
@@ -217,32 +233,32 @@ const client = new MilvusClient({
 const client = new MilvusClient({
   // Required
   address: 'localhost:19530',
-  
+
   // Authentication (choose one)
   username: 'root',
   password: 'Milvus',
   // OR
   token: 'api-key',
-  
+
   // SSL/TLS
   ssl: true,
   tls: {
     rootCertPath: '/path/to/ca.pem',
     serverName: 'milvus.example.com',
   },
-  
+
   // Timeouts and retries
   timeout: 30000,
   maxRetries: 3,
   retryDelay: 1000,
-  
+
   // Database
   database: 'default',
-  
+
   // Logging
   logLevel: 'info',
   logPrefix: 'milvus',
-  
+
   // Connection pooling
   pool: {
     min: 2,
@@ -263,6 +279,7 @@ interface ClientConfig {
   username?: string;
   password?: string;
   channelOptions?: ChannelOptions;
+  option?: Record<string, string>;
   timeout?: number | string;
   maxRetries?: number;
   retryDelay?: number;
@@ -307,6 +324,7 @@ await client.createCollection({
 ```
 
 **Features:**
+
 - Automatic timestamp: Every request includes `client-request-unixmsec`
 - Trace ID support: Add `client_request_id` or `client-request-id` to track requests
 - Global support: All API methods automatically support trace IDs
@@ -319,4 +337,3 @@ For more details, see [Request Tracing](../advanced/advanced-features#request-tr
 - Learn about [Data Types & Schemas](./data-types-schemas)
 - Explore [Collection Management](./collection-management)
 - Check out [Best Practices](./best-practices) for production configurations
-

--- a/docs/content/core-concepts/data-types-schemas.mdx
+++ b/docs/content/core-concepts/data-types-schemas.mdx
@@ -144,15 +144,22 @@ Sparse vectors store only non-zero values with their indices. Commonly used for 
 Sparse vectors can be inserted in two formats:
 
 **Dictionary format** (recommended):
+
 ```javascript
 // Keys are indices, values are float weights
 { 10: 0.5, 100: 0.3, 500: 0.8, 1200: 0.1 }
 ```
 
 **Array of tuples format:**
+
 ```javascript
 // [index, value] pairs
-[[10, 0.5], [100, 0.3], [500, 0.8], [1200, 0.1]]
+[
+  [10, 0.5],
+  [100, 0.3],
+  [500, 0.8],
+  [1200, 0.1],
+];
 ```
 
 Note: Dimension is determined automatically from the maximum index across all vectors.
@@ -193,6 +200,29 @@ BFloat16 vector:
 }
 ```
 
+#### Nullable Vector Fields
+
+Vector fields can be marked as nullable. Insert or upsert `null` for rows that do not have an embedding yet; query and search results return `null` for those fields.
+
+```javascript
+{
+  name: 'optional_embedding',
+  data_type: DataType.FloatVector,
+  dim: 128,
+  nullable: true,
+}
+
+await client.insert({
+  collection_name: 'my_collection',
+  data: [
+    { id: 1, optional_embedding: [/* 128 floats */] },
+    { id: 2, optional_embedding: null },
+  ],
+});
+```
+
+Nullable vector payloads are supported for `FloatVector`, `BinaryVector`, `Float16Vector`, `BFloat16Vector`, `SparseFloatVector`, and `Int8Vector`.
+
 ### Complex Types
 
 #### Array
@@ -207,6 +237,35 @@ Array of scalar values:
   max_capacity: 100,
 }
 ```
+
+#### ArrayOfVector
+
+`DataType.ArrayOfVector` stores multiple vectors in a single field value. This is useful for documents split into chunks, multi-vector embeddings, or struct array payloads that contain vector arrays.
+
+```javascript
+{
+  name: 'chunk_embeddings',
+  data_type: DataType.ArrayOfVector,
+  element_type: DataType.FloatVector,
+  dim: 128,
+  max_capacity: 32,
+}
+
+await client.insert({
+  collection_name: 'my_collection',
+  data: [
+    {
+      id: 1,
+      chunk_embeddings: [
+        [/* first 128-d vector */],
+        [/* second 128-d vector */],
+      ],
+    },
+  ],
+});
+```
+
+Supported element vector types include dense, binary, float16, bfloat16, sparse, and int8 vector payloads where supported by Milvus.
 
 #### Struct
 
@@ -237,6 +296,9 @@ Each field in a collection schema must include:
   autoID: false,                // Optional: auto-generate IDs
   max_length: 256,              // Required for VarChar
   dim: 128,                     // Required for vector types
+  nullable: false,              // Optional: allow null values
+  default_value: undefined,     // Optional scalar default value
+  external_field: undefined,    // Optional: source field name for external collections
 }
 ```
 
@@ -364,9 +426,11 @@ await client.insert({
   collection_name: 'my_collection',
   data: [
     {
-      vector: [/* ... */],
+      vector: [
+        /* ... */
+      ],
       dynamic_field_1: 'value1', // Automatically added
-      dynamic_field_2: 123,      // Automatically added
+      dynamic_field_2: 123, // Automatically added
     },
   ],
 });
@@ -395,4 +459,3 @@ The SDK validates schemas before creating collections. Common validation errors:
 - Learn about [Collection Management](./collection-management)
 - Explore [Data Operations](./data-operations-insert)
 - Check out [Best Practices](./best-practices)
-

--- a/docs/content/management/collection-management.mdx
+++ b/docs/content/management/collection-management.mdx
@@ -46,10 +46,59 @@ await client.createCollection({
   collection_name: 'my_collection',
   fields: schema,
   properties: {
-    'collection.ttl.seconds': 3600, // TTL in seconds
+    'collection.ttl.seconds': 3600, // Collection-level TTL in seconds
   },
 });
 ```
+
+### Entity-Level TTL
+
+Entity-level TTL lets each row carry its own expiration time. Create a nullable `Timestamptz` field and set the collection property `ttl_field` to that field name.
+
+```javascript
+import { CollectionProperties, DataType } from '@zilliz/milvus2-sdk-node';
+
+await client.createCollection({
+  collection_name: 'entity_ttl_collection',
+  fields: [
+    { name: 'id', data_type: DataType.Int64, is_primary_key: true },
+    { name: 'vector', data_type: DataType.FloatVector, dim: 128 },
+    { name: 'expire_at', data_type: DataType.Timestamptz, nullable: true },
+  ],
+  properties: {
+    [CollectionProperties.TTL_FIELD]: 'expire_at',
+  },
+});
+
+await client.insert({
+  collection_name: 'entity_ttl_collection',
+  data: [
+    {
+      id: 1,
+      vector: [
+        /* ... */
+      ],
+      expire_at: null,
+    }, // never expires
+    {
+      id: 2,
+      vector: [
+        /* ... */
+      ],
+      expire_at: '2099-12-31T00:00:00Z',
+    },
+    {
+      id: 3,
+      vector: [
+        /* ... */
+      ],
+      expire_at: '2000-01-01T00:00:00Z',
+    }, // expired
+  ],
+});
+```
+
+Expired entities are excluded from query and search results. You can add a TTL field to an existing collection with `addCollectionField()` and then set `CollectionProperties.TTL_FIELD` with `alterCollectionProperties()`.
 
 ### Collection with Partition Configuration
 
@@ -60,6 +109,33 @@ await client.createCollection({
   num_partitions: 8, // Number of partitions
 });
 ```
+
+### Allow Insert with AutoID
+
+For collections whose primary key field uses `autoID: true`, inserts normally omit the primary key. If you need to import or backfill rows with explicit primary keys, enable the `allow_insert_auto_id` collection property.
+
+```javascript
+await client.alterCollectionProperties({
+  collection_name: 'my_collection',
+  properties: {
+    allow_insert_auto_id: 'true',
+  },
+});
+
+await client.insert({
+  collection_name: 'my_collection',
+  data: [
+    {
+      id: 10001, // accepted even when the primary key field has autoID: true
+      vector: [
+        /* ... */
+      ],
+    },
+  ],
+});
+```
+
+Use this only when you need to preserve existing IDs. For normal writes to an AutoID collection, keep omitting the primary key field.
 
 ## Checking Collection Existence
 
@@ -379,6 +455,24 @@ const replicas = await client.getReplicas({
 console.log('Replicas:', replicas.replicas);
 ```
 
+Include shard node details or query by collection ID when needed:
+
+```javascript
+const replicas = await client.getReplicas({
+  collection_name: 'my_collection',
+  db_name: 'default',
+  with_shard_nodes: true,
+});
+
+replicas.replicas.forEach(replica => {
+  console.log('Resource group:', replica.resource_group_name);
+  console.log('Outbound nodes:', replica.num_outbound_node);
+  console.log('Shard replicas:', replica.shard_replicas);
+});
+```
+
+`getReplicas()` accepts either `collection_name`/`db_name` or a `collectionID`, depending on what identifiers are available in your application.
+
 ## Primary Key Information
 
 ### Get Primary Key Field Name
@@ -495,6 +589,114 @@ await client.dropCollectionProperties({
 });
 ```
 
+## External Collections
+
+External collections reference data stored outside Milvus. Use `external_source` and `external_spec` at collection creation time, and map Milvus fields to source fields with `external_field`.
+
+```javascript
+await client.createCollection({
+  collection_name: 'external_products',
+  external_source: 's3://bucket/path/products/',
+  external_spec: JSON.stringify({ format: 'parquet' }),
+  do_physical_backfill: false,
+  file_resource_ids: ['resource-id-1'],
+  fields: [
+    {
+      name: 'id',
+      data_type: DataType.Int64,
+      is_primary_key: true,
+      external_field: 'product_id',
+    },
+    {
+      name: 'name',
+      data_type: DataType.VarChar,
+      max_length: 256,
+      external_field: 'title',
+    },
+    {
+      name: 'vector',
+      data_type: DataType.FloatVector,
+      dim: 128,
+      external_field: 'embedding',
+    },
+  ],
+});
+```
+
+Refresh an external collection when the source changes:
+
+```javascript
+const refresh = await client.refreshExternalCollection({
+  collection_name: 'external_products',
+  external_source: 's3://bucket/path/products-v2/', // optional
+  external_spec: JSON.stringify({ format: 'parquet' }), // optional
+});
+
+const progress = await client.getRefreshExternalCollectionProgress({
+  job_id: refresh.job_id,
+});
+
+const jobs = await client.listRefreshExternalCollectionJobs({
+  collection_name: 'external_products',
+});
+```
+
+## Collection Snapshots
+
+Snapshots capture a collection at a point in time. You can describe, restore, pin, and remove snapshots with the snapshot APIs.
+
+```javascript
+await client.createSnapshot({
+  collection_name: 'my_collection',
+  snapshot_name: 'my_collection_snapshot_001',
+  description: 'Before schema migration',
+  compaction_protection_seconds: 3600,
+});
+
+const snapshots = await client.listSnapshots({
+  collection_name: 'my_collection',
+});
+
+const snapshot = await client.describeSnapshot({
+  collection_name: 'my_collection',
+  snapshot_name: 'my_collection_snapshot_001',
+});
+```
+
+Restore a snapshot into another collection and check the restore job:
+
+```javascript
+const restore = await client.restoreSnapshot({
+  snapshot_name: 'my_collection_snapshot_001',
+  source_collection_name: 'my_collection',
+  target_collection_name: 'my_collection_restored',
+});
+
+const state = await client.getRestoreSnapshotState({
+  job_id: restore.job_id,
+});
+
+const restoreJobs = await client.listRestoreSnapshotJobs({
+  collection_name: 'my_collection_restored',
+});
+```
+
+Pin snapshot data while copying it out, then release the pin when finished:
+
+```javascript
+const pin = await client.pinSnapshotData({
+  collection_name: 'my_collection',
+  snapshot_name: 'my_collection_snapshot_001',
+  ttl_seconds: 3600,
+});
+
+await client.unpinSnapshotData({ pin_id: pin.pin_id });
+await client.dropSnapshot({
+  collection_name: 'my_collection',
+  snapshot_name: 'my_collection_snapshot_001',
+});
+```
+
 ## Collection Functions
 
 Collection functions are auto-processing pipelines that transform data at insert and query time. The most common use case is BM25 full-text search, where a function automatically converts text to sparse vectors.
@@ -542,4 +744,3 @@ await client.refreshLoad({
 - Learn about [Partition Management](./partition-management)
 - Explore [Index Management](./index-management)
 - Check out [Data Operations](./data-operations-insert)
-

--- a/docs/content/management/index-management.mdx
+++ b/docs/content/management/index-management.mdx
@@ -47,7 +47,7 @@ await client.createIndex({
   index_type: 'HNSW',
   metric_type: 'L2',
   params: {
-    M: 16,           // Number of connections
+    M: 16, // Number of connections
     efConstruction: 200, // Construction parameter
   },
 });
@@ -97,7 +97,7 @@ await client.createIndex({
   metric_type: 'L2',
   params: {
     nlist: 1024,
-    m: 8,    // Number of sub-vectors
+    m: 8, // Number of sub-vectors
     nbits: 8, // Number of bits per sub-vector
   },
 });
@@ -129,6 +129,29 @@ await client.createIndex({
 });
 ```
 
+### MINHASH_LSH
+
+`MINHASH_LSH` is an index for binary vectors that uses MinHash locality-sensitive hashing. It is useful for approximate similarity search on binary signatures, sets, shingles, or other binary encodings where Jaccard-style similarity is appropriate.
+
+```javascript
+await client.createCollection({
+  collection_name: 'binary_docs',
+  fields: [
+    { name: 'id', data_type: DataType.Int64, is_primary_key: true },
+    { name: 'binary_vector', data_type: DataType.BinaryVector, dim: 128 },
+  ],
+});
+
+await client.createIndex({
+  collection_name: 'binary_docs',
+  field_name: 'binary_vector',
+  index_type: 'MINHASH_LSH',
+  metric_type: 'JACCARD',
+});
+```
+
+For binary vectors, the `dim` value must be a multiple of 8, and inserted binary vector payloads use `dim / 8` bytes.
+
 ## Metric Types
 
 Choose the appropriate metric type for your use case:
@@ -137,7 +160,7 @@ Choose the appropriate metric type for your use case:
 - **IP**: Inner product
 - **COSINE**: Cosine similarity
 - **HAMMING**: Hamming distance (for binary vectors)
-- **JACCARD**: Jaccard distance (for binary vectors)
+- **JACCARD**: Jaccard distance (for binary vectors, including MinHash use cases)
 
 ```javascript
 // L2 distance
@@ -259,17 +282,21 @@ await client.dropIndex({
 3. **Large datasets (> 10M vectors)**: Use IVF_PQ for memory efficiency
 4. **High-dimensional vectors**: Prefer HNSW or IVF_FLAT
 5. **Memory-constrained**: Use IVF_SQ8 or IVF_PQ
+6. **Binary signatures / set similarity**: Use MINHASH_LSH with JACCARD
 
 ### Index Parameters
 
 **HNSW Parameters:**
+
 - `M`: Higher values improve recall but increase memory (typical: 16-32)
 - `efConstruction`: Higher values improve index quality but slower build (typical: 100-500)
 
 **IVF Parameters:**
+
 - `nlist`: Number of clusters (typical: sqrt(total_vectors) to total_vectors/10)
 
 **IVF_PQ Parameters:**
+
 - `m`: Number of sub-vectors (typical: 8-16)
 - `nbits`: Bits per sub-vector (typical: 8)
 
@@ -279,6 +306,7 @@ await client.dropIndex({
 - **IP**: Use for embeddings trained with inner product
 - **COSINE**: Use for normalized embeddings
 - **HAMMING/JACCARD**: Use for binary vectors
+- **JACCARD + MINHASH_LSH**: Use for binary signatures and set-similarity workloads
 
 ### Index Building
 
@@ -311,7 +339,9 @@ await client.createCollection({
 // Insert data
 await client.insert({
   collection_name: 'my_collection',
-  data: [/* ... */],
+  data: [
+    /* ... */
+  ],
 });
 
 // Create index
@@ -344,7 +374,9 @@ await client.loadCollectionSync({
 // Now you can search
 const results = await client.search({
   collection_name: 'my_collection',
-  data: [/* vector */],
+  data: [
+    /* vector */
+  ],
   limit: 10,
 });
 ```
@@ -354,4 +386,3 @@ const results = await client.search({
 - Learn about [Data Operations](./data-operations-insert)
 - Explore [Search Operations](./data-operations-query)
 - Check out [Best Practices](./best-practices)
-

--- a/docs/content/management/resource-management.mdx
+++ b/docs/content/management/resource-management.mdx
@@ -118,6 +118,39 @@ await client.transferReplica({
 }
 ```
 
+### Transfer Policies and Node Filters
+
+Resource group configuration can also define where to borrow missing nodes from, where to send redundant nodes, and which node labels are allowed in the group.
+
+```javascript
+await client.updateResourceGroup({
+  resource_groups: {
+    rg1: {
+      requests: { node_num: 2 },
+      limits: { node_num: 4 },
+      transfer_from: [{ resource_group: '__default_resource_group' }],
+      transfer_to: [{ resource_group: 'rg_overflow' }],
+      node_filter: {
+        node_labels: [{ key: 'workload', value: 'search' }],
+      },
+    },
+  },
+});
+```
+
+When describing a resource group, the response includes node and movement details when Milvus returns them:
+
+```javascript
+const info = await client.describeResourceGroup({
+  resource_group: 'rg1',
+});
+
+console.log('Available nodes:', info.resource_group.num_available_node);
+console.log('Incoming nodes:', info.resource_group.num_incoming_node);
+console.log('Outgoing nodes:', info.resource_group.num_outgoing_node);
+console.log('Nodes:', info.resource_group.nodes);
+```
+
 ## Best Practices
 
 1. **Organize by workload**: Create resource groups for different workloads
@@ -129,4 +162,3 @@ await client.transferReplica({
 
 - Learn about [Collection Management](./collection-management)
 - Explore [Best Practices](./best-practices)
-

--- a/docs/content/operations/data-management.mdx
+++ b/docs/content/operations/data-management.mdx
@@ -42,6 +42,29 @@ const state = await client.getFlushState({
 console.log('Flushed:', state.flushed);
 ```
 
+### Flush All Collections
+
+Flush all collections in the cluster, or wait until the flush-all operation completes:
+
+```javascript
+const flushAll = await client.flushAll();
+
+const state = await client.getFlushAllState({
+  flush_all_tss: flushAll.flush_all_tss,
+});
+
+console.log('Flush-all completed:', state.flushed);
+```
+
+Use `flushAllSync()` to trigger flush-all and poll until completion:
+
+```javascript
+const result = await client.flushAllSync();
+console.log('Flush-all completed:', result.flushed);
+```
+
+`flushAll()` and `getFlushAllState()` also accept the common request options such as `timeout`. The legacy `db_name` and `flush_all_ts` fields are still accepted for compatibility, but `flush_all_tss` is preferred.
+
 ## Compaction
 
 Compaction merges small segments to improve query performance.
@@ -55,6 +78,33 @@ const result = await client.compact({
 
 console.log('Compaction ID:', result.compactionID);
 ```
+
+Pass advanced compaction options when you need to target specific partitions, channels, or segments:
+
+```javascript
+const result = await client.compact({
+  collection_name: 'my_collection',
+  timetravel: 0,
+  majorCompaction: true,
+  partition_id: '12345',
+  channel: 'by-dev-rootcoord-dml_0',
+  segment_ids: [111, 222],
+  l0Compaction: false,
+  target_size: '536870912', // bytes
+});
+```
+
+Common advanced fields:
+
+| Field             | Description                       |
+| ----------------- | --------------------------------- |
+| `timetravel`      | Timestamp boundary for compaction |
+| `majorCompaction` | Request major compaction          |
+| `partition_id`    | Target a specific partition       |
+| `channel`         | Target a specific DML channel     |
+| `segment_ids`     | Compact specific segments         |
+| `l0Compaction`    | Request L0 compaction             |
+| `target_size`     | Target segment size in bytes      |
 
 ### Get Compaction State
 
@@ -89,10 +139,7 @@ Import data from files.
 ```javascript
 const result = await client.bulkInsert({
   collection_name: 'my_collection',
-  files: [
-    '/path/to/data.json',
-    '/path/to/data2.json',
-  ],
+  files: ['/path/to/data.json', '/path/to/data2.json'],
 });
 
 console.log('Task ID:', result.tasks[0].taskID);
@@ -134,15 +181,18 @@ Get information about query segments:
 
 ```javascript
 const info = await client.getQuerySegmentInfo({
-  collection_name: 'my_collection',
+  collectionName: 'my_collection',
+  dbName: 'default',
 });
 
 info.infos.forEach(segment => {
   console.log('Segment ID:', segment.segmentID);
   console.log('State:', segment.state);
-  console.log('Size:', segment.size);
+  console.log('Level:', segment.level);
 });
 ```
+
+> The segment info APIs use proto field names: `collectionName` and `dbName`.
 
 ### Get Persistent Segment Info
 
@@ -150,13 +200,14 @@ Get information about persistent segments:
 
 ```javascript
 const info = await client.getPersistentSegmentInfo({
-  collection_name: 'my_collection',
+  collectionName: 'my_collection',
+  dbName: 'default',
 });
 
 info.infos.forEach(segment => {
   console.log('Segment ID:', segment.segmentID);
   console.log('State:', segment.state);
-  console.log('Size:', segment.size);
+  console.log('Level:', segment.level);
 });
 ```
 
@@ -186,4 +237,3 @@ console.log('Metrics:', metrics);
 
 - Learn about [Collection Management](./collection-management)
 - Explore [Best Practices](./best-practices)
-

--- a/docs/content/operations/data-operations-query.mdx
+++ b/docs/content/operations/data-operations-query.mdx
@@ -30,15 +30,34 @@ const results = await client.query({
 });
 ```
 
-### Query with Limit and Offset
+### Query with Limit, Offset, and Ordering
 
 ```javascript
 const results = await client.query({
   collection_name: 'my_collection',
   expr: 'age > 25',
-  output_fields: ['id', 'text'],
+  output_fields: ['id', 'text', 'price'],
   limit: 10,
   offset: 0,
+  order_by_fields: [{ field: 'price', order: 'desc' }],
+});
+```
+
+`order_by_fields` can be a string, an array of strings, or an array of `{ field, order }` objects:
+
+```javascript
+await client.query({
+  collection_name: 'my_collection',
+  expr: 'age > 25',
+  output_fields: ['id', 'price', 'rating'],
+  order_by_fields: 'price:asc,rating:desc',
+});
+
+await client.query({
+  collection_name: 'my_collection',
+  expr: 'age > 25',
+  output_fields: ['id', 'price', 'rating'],
+  order_by: ['price:asc', { field: 'rating', order: 'desc' }], // alias
 });
 ```
 
@@ -68,7 +87,7 @@ const iterator = await client.queryIterator({
 while (true) {
   const batch = await iterator.next();
   if (batch.done) break;
-  
+
   console.log('Batch:', batch.value);
 }
 ```
@@ -127,6 +146,7 @@ const results = await client.search({
 ```
 
 > [!NOTE]
+>
 > - When `ids` are provided, the `data` parameter (dummy vectors) is not required.
 > - The provided `ids` must match the collection's Primary Key type (`Int64` or `VarChar`).
 > - For collections with multiple vector fields, explicitly specifying `anns_field` is recommended (and required to disambiguate).
@@ -158,6 +178,25 @@ const results = await client.search({
   output_fields: ['id', 'text', 'age'],
 });
 ```
+
+### Search with Ordering
+
+Sort search results by scalar fields after vector retrieval:
+
+```javascript
+const results = await client.search({
+  collection_name: 'my_collection',
+  data: [[0.1, 0.2, 0.3, 0.4]],
+  limit: 10,
+  output_fields: ['id', 'price', 'rating'],
+  order_by_fields: [
+    { field: 'price', order: 'asc' },
+    { field: 'rating', order: 'desc' },
+  ],
+});
+```
+
+You can also pass `order_by_fields` as a string, for example `'price:asc,rating:desc'`. If you also pass `params.order_by_fields`, the top-level `order_by_fields` value takes precedence.
 
 ### Search Parameters
 
@@ -212,7 +251,7 @@ const iterator = await client.searchIterator({
 while (true) {
   const batch = await iterator.next();
   if (batch.done) break;
-  
+
   console.log('Batch:', batch.value);
 }
 ```
@@ -251,41 +290,41 @@ Filter expressions use Milvus expression syntax:
 ### Comparison Operators
 
 ```javascript
-'age > 25'
-'age >= 25'
-'age < 25'
-'age <= 25'
-'age == 25'
-'age != 25'
+'age > 25';
+'age >= 25';
+'age < 25';
+'age <= 25';
+'age == 25';
+'age != 25';
 ```
 
 ### Logical Operators
 
 ```javascript
-'age > 25 AND category == "tech"'
-'age > 25 OR age < 18'
-'NOT (age > 25)'
+'age > 25 AND category == "tech"';
+'age > 25 OR age < 18';
+'NOT (age > 25)';
 ```
 
 ### In Operator
 
 ```javascript
-'id in [1, 2, 3, 4, 5]'
-'category in ["tech", "science"]'
+'id in [1, 2, 3, 4, 5]';
+'category in ["tech", "science"]';
 ```
 
 ### String Operations
 
 ```javascript
-'text like "milvus%"'
-'text like "%database%"'
+'text like "milvus%"';
+'text like "%database%"';
 ```
 
 ### JSON Field Access
 
 ```javascript
-'metadata.category == "tech"'
-'metadata.tags[0] == "ai"'
+'metadata.category == "tech"';
+'metadata.tags[0] == "ai"';
 ```
 
 ## Search Results
@@ -307,19 +346,42 @@ results.results.forEach(result => {
 });
 ```
 
+### Element-Level Offsets
+
+For element-level retrieval, Milvus can return the matching element offsets for array or multi-vector fields. The SDK flattens `element_indices` into result rows and adds an `offset` property that identifies the matched element within the source field.
+
+```javascript
+const results = await client.search({
+  collection_name: 'chunked_docs',
+  data: [
+    [
+      /* query vector */
+    ],
+  ],
+  anns_field: 'chunk_embeddings',
+  limit: 10,
+  output_fields: ['doc_id', 'title'],
+});
+
+results.results.forEach(row => {
+  console.log('Document:', row.doc_id);
+  console.log('Matched element offset:', row.offset);
+});
+```
+
 ## Output Fields
 
 Specify which fields to return:
 
 ```javascript
 // Return specific fields
-output_fields: ['id', 'text', 'age']
+output_fields: ['id', 'text', 'age'];
 
 // Return all fields
-output_fields: ['*']
+output_fields: ['*'];
 
 // Return vector fields
-output_fields: ['id', 'vector']
+output_fields: ['id', 'vector'];
 ```
 
 ## Performance Optimization
@@ -327,9 +389,11 @@ output_fields: ['id', 'vector']
 ### Search Parameters Tuning
 
 **IVF indexes:**
+
 - `nprobe`: Higher values improve recall but slower (typical: 16-256)
 
 **HNSW indexes:**
+
 - `ef`: Higher values improve recall but slower (typical: 50-200)
 
 ### Batch Search
@@ -340,9 +404,15 @@ Search multiple vectors efficiently:
 const results = await client.search({
   collection_name: 'my_collection',
   data: [
-    [/* vector 1 */],
-    [/* vector 2 */],
-    [/* vector 3 */],
+    [
+      /* vector 1 */
+    ],
+    [
+      /* vector 2 */
+    ],
+    [
+      /* vector 3 */
+    ],
   ],
   limit: 10,
 });
@@ -358,7 +428,9 @@ await client.loadCollectionSync({
 });
 
 // Now search
-const results = await client.search({ /* ... */ });
+const results = await client.search({
+  /* ... */
+});
 ```
 
 ## Best Practices
@@ -416,4 +488,3 @@ console.log('Search results:', searchResults.results);
 - Learn about [Delete Operations](./data-operations-delete)
 - Explore [Data Management](./data-management)
 - Check out [Best Practices](./best-practices)
-

--- a/docs/content/operations/database-operations.mdx
+++ b/docs/content/operations/database-operations.mdx
@@ -12,6 +12,18 @@ await client.createDatabase({
 });
 ```
 
+Create a database with properties:
+
+```javascript
+await client.createDatabase({
+  db_name: 'my_database',
+  properties: {
+    owner: 'analytics-team',
+    environment: 'production',
+  },
+});
+```
+
 ## Listing Databases
 
 List all databases:
@@ -35,15 +47,16 @@ const result = await client.describeDatabase({
 console.log('Database info:', result);
 ```
 
-## Altering a Database
+## Altering Database Properties
 
 Modify database properties:
 
 ```javascript
-await client.alterDatabase({
+await client.alterDatabaseProperties({
   db_name: 'my_database',
   properties: {
-    'database.property': 'value',
+    owner: 'search-team',
+    environment: 'staging',
   },
 });
 ```
@@ -55,7 +68,7 @@ Remove specific properties from a database:
 ```javascript
 await client.dropDatabaseProperties({
   db_name: 'my_database',
-  property_names: ['database.property'],
+  properties: ['environment'],
 });
 ```
 
@@ -98,15 +111,20 @@ const db2Client = new MilvusClient({
 });
 
 // Use db1Client for database1 operations
-await db1Client.createCollection({ /* ... */ });
+await db1Client.createCollection({
+  /* ... */
+});
 
 // Use db2Client for database2 operations
-await db2Client.createCollection({ /* ... */ });
+await db2Client.createCollection({
+  /* ... */
+});
 ```
 
 ### Database Isolation
 
 Each database is isolated:
+
 - Collections in different databases are completely separate
 - Operations on one database don't affect others
 - Users and roles can have different permissions per database
@@ -122,4 +140,3 @@ Each database is isolated:
 
 - Learn about [Collection Management](./collection-management)
 - Explore [User & Role Management](./user-role-management)
-

--- a/docs/content/operations/hybrid-search.mdx
+++ b/docs/content/operations/hybrid-search.mdx
@@ -35,14 +35,14 @@ const results = await client.hybridSearch({
 
 Each item in the `data` array is a `HybridSearchSingleReq`:
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `data` | `number[]` or `object` | The search vector (dense array or sparse dict) |
-| `anns_field` | `string` | The vector field to search |
-| `expr` | `string` | Optional filter expression |
-| `exprValues` | `object` | Optional template values for filter expression |
-| `params` | `object` | Optional search parameters (e.g., `{ nprobe: 10 }`) |
-| `group_by_field` | `string` | Optional field to group results by |
+| Parameter        | Type                   | Description                                         |
+| ---------------- | ---------------------- | --------------------------------------------------- |
+| `data`           | `number[]` or `object` | The search vector (dense array or sparse dict)      |
+| `anns_field`     | `string`               | The vector field to search                          |
+| `expr`           | `string`               | Optional filter expression                          |
+| `exprValues`     | `object`               | Optional template values for filter expression      |
+| `params`         | `object`               | Optional search parameters (e.g., `{ nprobe: 10 }`) |
+| `group_by_field` | `string`               | Optional field to group results by                  |
 
 ## Reranking Strategies
 
@@ -72,34 +72,69 @@ rerank: {
 
 ### FunctionScore
 
-Advanced reranking using custom scoring functions.
+Advanced reranking using custom scoring functions. A `FunctionScore` contains one or more function definitions plus optional top-level parameters for the reranker.
 
 ```javascript
-rerank: {
-  functions: [
+import { FunctionType } from '@zilliz/milvus2-sdk-node';
+
+const results = await client.hybridSearch({
+  collection_name: 'my_collection',
+  data: [
     {
-      name: 'my_scorer',
-      type: FunctionType.RERANK,
-      input_field_names: ['text'],
-      output_field_names: ['score'],
-      params: { key: 'value' },
+      data: [0.1, 0.2, 0.3, 0.4],
+      anns_field: 'dense_vector',
+      params: { nprobe: 10 },
+    },
+    {
+      data: { 1: 0.5, 100: 0.3 },
+      anns_field: 'sparse_vector',
     },
   ],
-  params: {},
-}
+  rerank: {
+    functions: [
+      {
+        name: 'freshness_boost',
+        type: FunctionType.RERANK,
+        input_field_names: ['publish_time'],
+        output_field_names: ['score'],
+        params: {
+          weight: 0.2,
+          decay: 'gauss',
+        },
+      },
+      {
+        name: 'quality_boost',
+        type: FunctionType.RERANK,
+        input_field_names: ['quality_score'],
+        output_field_names: ['score'],
+        params: {
+          weight: 0.8,
+        },
+      },
+    ],
+    params: {
+      score_mode: 'sum',
+      boost_mode: 'multiply',
+    },
+  },
+  limit: 10,
+  output_fields: ['id', 'text', 'publish_time', 'quality_score'],
+});
 ```
+
+Use FunctionScore when you need to blend vector similarity with business signals such as recency, popularity, quality scores, or custom server-side rerank functions.
 
 ## Top-Level Parameters
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `collection_name` | `string` | The collection to search |
-| `data` | `HybridSearchSingleReq[]` | Array of individual search requests |
-| `rerank` | `RerankerObj \| FunctionScore` | Reranking strategy |
-| `limit` | `number` | Maximum number of results to return |
-| `output_fields` | `string[]` | Fields to include in results |
-| `consistency_level` | `string` | Optional consistency level |
-| `partition_names` | `string[]` | Optional partitions to search |
+| Parameter           | Type                           | Description                         |
+| ------------------- | ------------------------------ | ----------------------------------- |
+| `collection_name`   | `string`                       | The collection to search            |
+| `data`              | `HybridSearchSingleReq[]`      | Array of individual search requests |
+| `rerank`            | `RerankerObj \| FunctionScore` | Reranking strategy                  |
+| `limit`             | `number`                       | Maximum number of results to return |
+| `output_fields`     | `string[]`                     | Fields to include in results        |
+| `consistency_level` | `string`                       | Optional consistency level          |
+| `partition_names`   | `string[]`                     | Optional partitions to search       |
 
 ## End-to-End Example
 
@@ -112,7 +147,12 @@ const client = new MilvusClient({ address: 'localhost:19530' });
 await client.createCollection({
   collection_name: 'hybrid_demo',
   fields: [
-    { name: 'id', data_type: DataType.Int64, is_primary_key: true, autoID: true },
+    {
+      name: 'id',
+      data_type: DataType.Int64,
+      is_primary_key: true,
+      autoID: true,
+    },
     { name: 'text', data_type: DataType.VarChar, max_length: 512 },
     { name: 'dense_vector', data_type: DataType.FloatVector, dim: 4 },
     { name: 'sparse_vector', data_type: DataType.SparseFloatVector },
@@ -123,8 +163,16 @@ await client.createCollection({
 await client.createIndex({
   collection_name: 'hybrid_demo',
   index_params: [
-    { field_name: 'dense_vector', index_type: 'AUTOINDEX', metric_type: 'COSINE' },
-    { field_name: 'sparse_vector', index_type: 'SPARSE_INVERTED_INDEX', metric_type: 'IP' },
+    {
+      field_name: 'dense_vector',
+      index_type: 'AUTOINDEX',
+      metric_type: 'COSINE',
+    },
+    {
+      field_name: 'sparse_vector',
+      index_type: 'SPARSE_INVERTED_INDEX',
+      metric_type: 'IP',
+    },
   ],
 });
 

--- a/docs/content/reference/api-reference.mdx
+++ b/docs/content/reference/api-reference.mdx
@@ -19,7 +19,7 @@ new MilvusClient(config: ClientConfig | string, ssl?: boolean, username?: string
 Get SDK version information:
 
 ```typescript
-MilvusClient.sdkInfo
+MilvusClient.sdkInfo;
 // Returns: { version: string, recommendMilvus: string }
 ```
 
@@ -34,10 +34,15 @@ createCollection(data: CreateCollectionReq): Promise<ResStatus>
 ```
 
 **Parameters**:
+
 - `collection_name`: Collection name
 - `fields`: Array of field schemas
 - `consistency_level?`: Consistency level
 - `properties?`: Collection properties
+- `external_source?`: External collection source path
+- `external_spec?`: External collection source configuration
+- `do_physical_backfill?`: Whether to physically backfill external data
+- `file_resource_ids?`: External file resource IDs
 
 ### hasCollection
 
@@ -112,6 +117,7 @@ truncateCollection(data: DropCollectionReq): Promise<{ status: ResStatus }>
 ```
 
 **Parameters**:
+
 - `collection_name`: Collection name
 
 ### batchDescribeCollections
@@ -123,6 +129,7 @@ batchDescribeCollections(data: BatchDescribeCollectionReq): Promise<BatchDescrib
 ```
 
 **Parameters**:
+
 - `collection_names`: Array of collection names
 
 ### renameCollection
@@ -134,6 +141,7 @@ renameCollection(data: RenameCollectionReq): Promise<ResStatus>
 ```
 
 **Parameters**:
+
 - `collection_name`: Current collection name
 - `new_collection_name`: New collection name
 
@@ -162,6 +170,7 @@ addCollectionFunction(data: AddCollectionFunctionReq): Promise<ResStatus>
 ```
 
 **Parameters**:
+
 - `collection_name`: Collection name
 - `function`: Function schema (name, type, input/output fields, params)
 
@@ -171,6 +180,102 @@ Remove a function from a collection.
 
 ```typescript
 dropCollectionFunction(data: DropCollectionFunctionReq): Promise<ResStatus>
+```
+
+### refreshExternalCollection
+
+Trigger a refresh job for an external collection.
+
+```typescript
+refreshExternalCollection(data: RefreshExternalCollectionReq): Promise<RefreshExternalCollectionResponse>
+```
+
+### getRefreshExternalCollectionProgress
+
+Get external collection refresh job progress.
+
+```typescript
+getRefreshExternalCollectionProgress(data: GetRefreshExternalCollectionProgressReq): Promise<GetRefreshExternalCollectionProgressResponse>
+```
+
+### listRefreshExternalCollectionJobs
+
+List external collection refresh jobs.
+
+```typescript
+listRefreshExternalCollectionJobs(data?: ListRefreshExternalCollectionJobsReq): Promise<ListRefreshExternalCollectionJobsResponse>
+```
+
+### createSnapshot
+
+Create a collection snapshot.
+
+```typescript
+createSnapshot(data: CreateSnapshotReq): Promise<ResStatus>
+```
+
+### dropSnapshot
+
+Drop a collection snapshot.
+
+```typescript
+dropSnapshot(data: DropSnapshotReq): Promise<ResStatus>
+```
+
+### listSnapshots
+
+List snapshots for a collection.
+
+```typescript
+listSnapshots(data: ListSnapshotsReq): Promise<ListSnapshotsResponse>
+```
+
+### describeSnapshot
+
+Describe a collection snapshot.
+
+```typescript
+describeSnapshot(data: DescribeSnapshotReq): Promise<DescribeSnapshotResponse>
+```
+
+### restoreSnapshot
+
+Restore a snapshot into a target collection.
+
+```typescript
+restoreSnapshot(data: RestoreSnapshotReq): Promise<RestoreSnapshotResponse>
+```
+
+### getRestoreSnapshotState
+
+Get restore snapshot job state.
+
+```typescript
+getRestoreSnapshotState(data: GetRestoreSnapshotStateReq): Promise<GetRestoreSnapshotStateResponse>
+```
+
+### listRestoreSnapshotJobs
+
+List restore snapshot jobs.
+
+```typescript
+listRestoreSnapshotJobs(data?: ListRestoreSnapshotJobsReq): Promise<ListRestoreSnapshotJobsResponse>
+```
+
+### pinSnapshotData
+
+Pin snapshot data to protect it from garbage collection while it is copied out.
+
+```typescript
+pinSnapshotData(data: PinSnapshotDataReq): Promise<PinSnapshotDataResponse>
+```
+
+### unpinSnapshotData
+
+Release a snapshot data pin.
+
+```typescript
+unpinSnapshotData(data: UnpinSnapshotDataReq): Promise<ResStatus>
 ```
 
 ## Data Operations
@@ -184,6 +289,7 @@ insert(data: InsertReq): Promise<MutationResult>
 ```
 
 **Parameters**:
+
 - `collection_name`: Collection name
 - `data`: Array of data objects
 - `partition_name?`: Partition name
@@ -205,11 +311,14 @@ query(data: QueryReq): Promise<QueryResults>
 ```
 
 **Parameters**:
+
 - `collection_name`: Collection name
 - `expr`: Filter expression
 - `output_fields`: Fields to return
 - `limit?`: Result limit
 - `offset?`: Result offset
+- `order_by_fields?`: Sort fields, for example `'price:asc'` or `[{ field: 'price', order: 'asc' }]`
+- `order_by?`: Alias for `order_by_fields`
 
 ### search
 
@@ -220,12 +329,14 @@ search(data: SearchReq): Promise<SearchResults>
 ```
 
 **Parameters**:
+
 - `collection_name`: Collection name
 - `data`: Array of search vectors
 - `limit`: Number of results
 - `expr?`: Filter expression
 - `output_fields?`: Fields to return
 - `params?`: Search parameters
+- `order_by_fields?`: Sort fields, for example `'price:asc'` or `[{ field: 'price', order: 'asc' }]`
 
 ### delete
 
@@ -236,6 +347,7 @@ delete(data: DeleteReq): Promise<MutationResult>
 ```
 
 **Parameters**:
+
 - `collection_name`: Collection name
 - `ids?`: Array of IDs
 - `filter?`: Filter expression
@@ -282,6 +394,7 @@ get(data: GetReq): Promise<QueryResults>
 ```
 
 **Parameters**:
+
 - `collection_name`: Collection name
 - `ids`: Array of primary key values
 - `output_fields`: Fields to return
@@ -291,15 +404,20 @@ get(data: GetReq): Promise<QueryResults>
 Flush all collections asynchronously.
 
 ```typescript
-flushAll(): Promise<FlushAllResponse>
+flushAll(data?: FlushAllReq): Promise<FlushAllResponse>
 ```
+
+**Parameters**:
+
+- `db_name?`: Legacy database name field
+- `timeout?`: Request timeout
 
 ### flushAllSync
 
 Flush all collections synchronously (waits for completion).
 
 ```typescript
-flushAllSync(): Promise<GetFlushAllStateResponse>
+flushAllSync(data?: FlushAllReq): Promise<GetFlushAllStateResponse>
 ```
 
 ### getFlushAllState
@@ -310,6 +428,13 @@ Get the state of a flush-all operation.
 getFlushAllState(data: GetFlushAllStateReq): Promise<GetFlushAllStateResponse>
 ```
 
+**Parameters**:
+
+- `flush_all_tss?`: Flush timestamps returned by `flushAll()`
+- `flush_all_ts?`: Legacy flush timestamp field
+- `db_name?`: Legacy database name field
+- `timeout?`: Request timeout
+
 ### compact
 
 Compact a collection (brief entry — see [Data Management](/operations/data-management) for details).
@@ -317,6 +442,17 @@ Compact a collection (brief entry — see [Data Management](/operations/data-man
 ```typescript
 compact(data: CompactReq): Promise<CompactionResponse>
 ```
+
+**Parameters**:
+
+- `collection_name`: Collection name
+- `timetravel?`: Timestamp boundary for compaction
+- `majorCompaction?`: Request major compaction
+- `partition_id?`: Target partition ID
+- `channel?`: Target DML channel
+- `segment_ids?`: Target segment IDs
+- `l0Compaction?`: Request L0 compaction
+- `target_size?`: Target segment size in bytes
 
 ### getCompactionState
 
@@ -361,9 +497,10 @@ createIndex(data: CreateIndexReq): Promise<ResStatus>
 ```
 
 **Parameters**:
+
 - `collection_name`: Collection name
 - `field_name`: Field name
-- `index_type`: Index type
+- `index_type`: Index type, such as `HNSW`, `IVF_FLAT`, `AUTOINDEX`, or `MINHASH_LSH`
 - `metric_type`: Metric type
 - `params?`: Index parameters
 
@@ -459,6 +596,11 @@ Create a database.
 createDatabase(data: CreateDatabaseRequest): Promise<ResStatus>
 ```
 
+**Parameters**:
+
+- `db_name`: Database name
+- `properties?`: Database properties
+
 ### listDatabases
 
 List all databases.
@@ -498,6 +640,11 @@ Remove database properties.
 ```typescript
 dropDatabaseProperties(data: DropDatabasePropertiesRequest): Promise<ResStatus>
 ```
+
+**Parameters**:
+
+- `db_name`: Database name
+- `properties`: Property names to remove
 
 ## User & Role Operations
 
@@ -568,8 +715,15 @@ runAnalyzer(data: RunAnalyzerRequest): Promise<RunAnalyzerResponse>
 ```
 
 **Parameters**:
-- `text`: Array of text strings to analyze
-- `analyzer_params`: Analyzer configuration (type, etc.)
+
+- `text`: Text string or array of text strings to analyze
+- `analyzer_params?`: Analyzer configuration for ad-hoc analysis
+- `with_detail?`: Return detailed token data
+- `with_hash?`: Return token hash values
+- `db_name?`: Database name when using collection field analyzers
+- `collection_name?`: Collection name when using collection field analyzers
+- `field_name?`: Field name when using collection field analyzers
+- `analyzer_names?`: Analyzer names configured on the field
 
 ### getMetric
 
@@ -604,6 +758,7 @@ enum DataType {
   BFloat16Vector = 103,
   SparseFloatVector = 104,
   Int8Vector = 105,
+  ArrayOfVector = 106,
   Struct = 201,
 }
 ```
@@ -673,4 +828,3 @@ interface SearchResults {
 - Explore [Examples & Tutorials](./examples-tutorials)
 - Check [Best Practices](./best-practices)
 - Read [Troubleshooting](./troubleshooting)
-


### PR DESCRIPTION
## Summary
- Document missing 2.6 SDK features including snapshots, external collections, entity TTL, ordering, nullable vectors, and ArrayOfVector
- Add coverage for MinHash, flush-all, compaction options, resource group fields, analyzer options, FunctionScore, and highlighter results
- Update API reference and configuration/database docs to match current SDK types

## Test plan
- [x] `npx prettier --check docs/content/advanced/full-text-search.mdx docs/content/core-concepts/client-configuration.mdx docs/content/core-concepts/data-types-schemas.mdx docs/content/management/collection-management.mdx docs/content/management/index-management.mdx docs/content/management/resource-management.mdx docs/content/operations/data-management.mdx docs/content/operations/data-operations-query.mdx docs/content/operations/database-operations.mdx docs/content/operations/hybrid-search.mdx docs/content/reference/api-reference.mdx`