### PR TITLE
feat: support partial array upsert ops

### DIFF
--- a/3.0_change.md
+++ b/3.0_change.md
@@ -164,16 +164,27 @@ message UpsertRequest {
 }
 ```
 
-Node SDK impact:
+Node SDK support:
 
-```text
-milvus/types/Data.ts or upsert request types
-  - Add field_ops support.
-  - Expose op values REPLACE, ARRAY_APPEND, ARRAY_REMOVE.
+```typescript
+import { FieldPartialUpdateOpType } from '@zilliz/milvus2-sdk-node';
 
-milvus/grpc/Data.ts and request preparation logic
-  - Pass field_ops through to UpsertRequest.
+await client.upsert({
+  collection_name: 'my_collection',
+  data: [{ id: 1, tags: ['new'], scores: [3] }],
+  field_ops: [
+    { field_name: 'tags', op: FieldPartialUpdateOpType.ARRAY_APPEND },
+    { field_name: 'scores', op: 'ARRAY_REMOVE' },
+  ],
+});
 ```
+
+Implementation notes:
+
+- `UpsertReq.field_ops` is passed through to `UpsertRequest.field_ops`.
+- `FieldPartialUpdateOpType` exposes `REPLACE`, `ARRAY_APPEND`, and `ARRAY_REMOVE`.
+- Numeric enum values are converted to proto enum names before sending the gRPC request.
+- Providing `field_ops` automatically sends `partial_update: true`.
 
 ## Element-Level Query/Search
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,25 @@ await client.upsert({
   collection_name: string;
   data: Record<string, any>[];
   partition_name?: string;
+  partial_update?: boolean;
+  field_ops?: Array<{
+    field_name: string;
+    op: 'REPLACE' | 'ARRAY_APPEND' | 'ARRAY_REMOVE';
+  }>;
+});
+```
+
+Partial array upsert can append to or remove from existing Array fields:
+
+```typescript
+import { FieldPartialUpdateOpType } from '@zilliz/milvus2-sdk-node';
+
+await client.upsert({
+  collection_name: 'articles',
+  data: [{ id: 1, tags: ['featured'] }],
+  field_ops: [
+    { field_name: 'tags', op: FieldPartialUpdateOpType.ARRAY_APPEND },
+  ],
 });
 ```
 

--- a/docs/content/operations/data-operations-insert.mdx
+++ b/docs/content/operations/data-operations-insert.mdx
@@ -69,7 +69,9 @@ Insert large amounts of data efficiently:
 
 ```javascript
 const batchSize = 1000;
-const allData = [/* large array of data */];
+const allData = [
+  /* large array of data */
+];
 
 for (let i = 0; i < allData.length; i += batchSize) {
   const batch = allData.slice(i, i + batchSize);
@@ -196,6 +198,49 @@ await client.upsert({
 });
 ```
 
+### Partial Array Upsert
+
+For Array fields, use `field_ops` to append values to or remove values from the existing array instead of replacing the whole field.
+
+```javascript
+import { FieldPartialUpdateOpType } from '@zilliz/milvus2-sdk-node';
+
+await client.upsert({
+  collection_name: 'my_collection',
+  data: [
+    {
+      id: 1,
+      tags: ['new-tag'], // Appended to the existing tags array
+      scores: [3], // Removed from the existing scores array
+    },
+  ],
+  field_ops: [
+    { field_name: 'tags', op: FieldPartialUpdateOpType.ARRAY_APPEND },
+    { field_name: 'scores', op: FieldPartialUpdateOpType.ARRAY_REMOVE },
+  ],
+});
+```
+
+You can also pass operation names as strings:
+
+```javascript
+await client.upsert({
+  collection_name: 'my_collection',
+  data: [{ id: 1, tags: ['urgent'] }],
+  field_ops: [{ field_name: 'tags', op: 'ARRAY_APPEND' }],
+});
+```
+
+Notes:
+
+- `field_ops` is supported only by `upsert()`.
+- Each `field_ops[].field_name` must refer to an Array field.
+- The primary key must be included in each upsert row.
+- Fields not included in the upsert row remain unchanged.
+- `ARRAY_APPEND` must not make the array exceed its `max_capacity`.
+- `ARRAY_REMOVE` removes matching values from the existing array.
+- When `field_ops` is provided, the SDK automatically sends `partial_update: true`.
+
 ## Insert Transformers
 
 For Float16 and BFloat16 vectors, use transformers:
@@ -211,7 +256,7 @@ await client.insert({
     },
   ],
   transformers: {
-    vector: (data) => f32ArrayToF16Bytes(data), // Convert to f16 bytes
+    vector: data => f32ArrayToF16Bytes(data), // Convert to f16 bytes
   },
 });
 ```
@@ -223,7 +268,9 @@ The insert operation returns mutation results:
 ```javascript
 const result = await client.insert({
   collection_name: 'my_collection',
-  data: [/* ... */],
+  data: [
+    /* ... */
+  ],
 });
 
 console.log('IDs:', result.IDs); // Array of inserted IDs
@@ -251,7 +298,9 @@ Handle insertion errors:
 try {
   await client.insert({
     collection_name: 'my_collection',
-    data: [/* ... */],
+    data: [
+      /* ... */
+    ],
   });
 } catch (error) {
   if (error.message.includes('field does not exist')) {
@@ -335,4 +384,3 @@ await client.flush({
 - Learn about [Query Operations](./data-operations-query)
 - Explore [Delete Operations](./data-operations-delete)
 - Check out [Data Management](./data-management)
-

--- a/docs/content/reference/api-reference.mdx
+++ b/docs/content/reference/api-reference.mdx
@@ -302,6 +302,42 @@ Upsert data (insert or update).
 upsert(data: UpsertReq): Promise<MutationResult>
 ```
 
+**Parameters**:
+
+- `collection_name`: Collection name
+- `data` or `fields_data`: Array of row objects
+- `partition_name?`: Partition name
+- `partial_update?`: Whether to update only provided fields
+- `field_ops?`: Per-field partial update operations for Array fields. Providing `field_ops` automatically enables `partial_update`.
+
+```typescript
+type FieldPartialUpdateOp = {
+  field_name: string;
+  op:
+    | FieldPartialUpdateOpType.REPLACE
+    | FieldPartialUpdateOpType.ARRAY_APPEND
+    | FieldPartialUpdateOpType.ARRAY_REMOVE
+    | 'REPLACE'
+    | 'ARRAY_APPEND'
+    | 'ARRAY_REMOVE';
+};
+```
+
+Example:
+
+```typescript
+import { FieldPartialUpdateOpType } from '@zilliz/milvus2-sdk-node';
+
+await client.upsert({
+  collection_name: 'my_collection',
+  data: [{ id: 1, tags: ['new'], scores: [3] }],
+  field_ops: [
+    { field_name: 'tags', op: FieldPartialUpdateOpType.ARRAY_APPEND },
+    { field_name: 'scores', op: 'ARRAY_REMOVE' },
+  ],
+});
+```
+
 ### query
 
 Query entities by filter.

--- a/milvus/const/milvus.ts
+++ b/milvus/const/milvus.ts
@@ -304,6 +304,13 @@ export enum DataType {
   Struct = 201,
 }
 
+// partial update operation enum for array fields in upsert
+export enum FieldPartialUpdateOpType {
+  REPLACE = 0,
+  ARRAY_APPEND = 1,
+  ARRAY_REMOVE = 2,
+}
+
 export enum PlaceholderType {
   None = 0,
   BinaryVector = 100,

--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -79,6 +79,8 @@ import {
   GetQuerySegmentInfoResponse,
   SearchData,
   FloatVector,
+  FieldPartialUpdateOpType,
+  FieldPartialUpdateOp,
 } from '../';
 import { Collection } from './Collection';
 
@@ -144,6 +146,9 @@ export class Data extends Collection {
       throw new Error(ERROR_REASONS.INSERT_CHECK_FIELD_DATA_IS_REQUIRED);
     }
     const { collection_name } = data;
+    const fieldOps = upsert
+      ? this.normalizeFieldOps((data as UpsertReq).field_ops)
+      : [];
 
     const describeReq = { collection_name, cache: enable_cache };
     if (data.db_name) {
@@ -234,7 +239,8 @@ export class Data extends Collection {
 
     // Track which fields are present in the original row data for partial updates
     const isPartialUpdate =
-      'partial_update' in data && data.partial_update === true;
+      ('partial_update' in data && data.partial_update === true) ||
+      fieldOps.length > 0;
     const originalRowKeys = new Set<string>();
 
     // Loop through each row and set the corresponding field values in the Map.
@@ -297,10 +303,11 @@ export class Data extends Collection {
       schema_timestamp:
         collectionInfo.update_timestamp_str ||
         (collectionInfo.update_timestamp as string | number | undefined),
-      // Ensure partial_update is passed for upsert operations
-      ...(upsert && (data as UpsertReq).partial_update
-        ? { partial_update: true }
-        : {}),
+      // Ensure partial_update is passed for explicit partial updates and
+      // non-REPLACE field_ops. Milvus server also auto-promotes non-REPLACE
+      // ops, but setting the flag keeps the request self-descriptive.
+      ...(upsert && isPartialUpdate ? { partial_update: true } : {}),
+      ...(upsert && fieldOps.length > 0 ? { field_ops: fieldOps } : {}),
     };
     /* istanbul ignore next if */
     if (data.skip_check_schema) {
@@ -527,6 +534,35 @@ export class Data extends Collection {
     }
 
     return promise;
+  }
+
+  private normalizeFieldOps(
+    fieldOps?: FieldPartialUpdateOp[]
+  ): { field_name: string; op: keyof typeof FieldPartialUpdateOpType }[] {
+    if (!fieldOps || fieldOps.length === 0) {
+      return [];
+    }
+
+    return fieldOps.map(({ field_name, op }) => {
+      if (!field_name) {
+        throw new Error('field_ops field_name is required');
+      }
+
+      if (typeof op === 'number') {
+        const opName = FieldPartialUpdateOpType[op] as
+          | keyof typeof FieldPartialUpdateOpType
+          | undefined;
+        if (typeof opName === 'undefined') {
+          throw new Error(`unsupported field partial update op: ${op}`);
+        }
+        return { field_name, op: opName };
+      }
+
+      if (typeof FieldPartialUpdateOpType[op] === 'undefined') {
+        throw new Error(`unsupported field partial update op: ${op}`);
+      }
+      return { field_name, op };
+    });
   }
 
   /**

--- a/milvus/types/Insert.ts
+++ b/milvus/types/Insert.ts
@@ -19,6 +19,7 @@ import {
   VectorTypes,
   BFloat16Vector,
   Float16Vector,
+  FieldPartialUpdateOpType,
 } from '../';
 
 // Represents the possible data types for a field(cell)
@@ -72,8 +73,19 @@ interface BaseInsertReq extends collectionNameReq {
 
 // Union type to enforce mutual exclusivity
 export type InsertReq = DataInsertReq | FieldsDataInsertReq;
+export type FieldPartialUpdateOpName = keyof typeof FieldPartialUpdateOpType;
+export type FieldPartialUpdateOpValue =
+  | FieldPartialUpdateOpType
+  | FieldPartialUpdateOpName;
+
+export interface FieldPartialUpdateOp {
+  field_name: string;
+  op: FieldPartialUpdateOpValue;
+}
+
 export type UpsertReq = (DataInsertReq | FieldsDataInsertReq) & {
   partial_update?: boolean;
+  field_ops?: FieldPartialUpdateOp[];
 };
 
 // Variant with data property

--- a/test/grpc/UpsertArrayPartialOp.spec.ts
+++ b/test/grpc/UpsertArrayPartialOp.spec.ts
@@ -1,0 +1,142 @@
+import {
+  DataType,
+  ErrorCode,
+  FieldPartialUpdateOpType,
+  MilvusClient,
+} from '../../milvus';
+import { GENERATE_NAME, IP, VECTOR_FIELD_NAME } from '../tools';
+
+const milvusClient = new MilvusClient({
+  address: IP,
+  logLevel: 'info',
+});
+
+const COLLECTION_NAME = GENERATE_NAME();
+
+describe('Upsert array partial ops', () => {
+  beforeAll(async () => {
+    await milvusClient.createCollection({
+      collection_name: COLLECTION_NAME,
+      fields: [
+        {
+          name: 'id',
+          data_type: DataType.Int64,
+          is_primary_key: true,
+        },
+        {
+          name: VECTOR_FIELD_NAME,
+          data_type: DataType.FloatVector,
+          dim: 4,
+        },
+        {
+          name: 'tags',
+          data_type: DataType.Array,
+          element_type: DataType.VarChar,
+          max_capacity: 8,
+          max_length: 32,
+        },
+        {
+          name: 'scores',
+          data_type: DataType.Array,
+          element_type: DataType.Int64,
+          max_capacity: 8,
+        },
+      ],
+    });
+
+    await milvusClient.createIndex({
+      collection_name: COLLECTION_NAME,
+      field_name: VECTOR_FIELD_NAME,
+      extra_params: {
+        index_type: 'AUTOINDEX',
+        metric_type: 'L2',
+      },
+    });
+
+    const insert = await milvusClient.insert({
+      collection_name: COLLECTION_NAME,
+      fields_data: [
+        {
+          id: 1,
+          [VECTOR_FIELD_NAME]: [0.1, 0.2, 0.3, 0.4],
+          tags: ['red', 'green'],
+          scores: [1, 2, 3],
+        },
+        {
+          id: 2,
+          [VECTOR_FIELD_NAME]: [0.2, 0.3, 0.4, 0.5],
+          tags: ['blue'],
+          scores: [10, 20],
+        },
+      ],
+    });
+    expect(insert.status.error_code).toEqual(ErrorCode.SUCCESS);
+
+    await milvusClient.flushSync({ collection_names: [COLLECTION_NAME] });
+    await milvusClient.loadCollectionSync({ collection_name: COLLECTION_NAME });
+  });
+
+  afterAll(async () => {
+    await milvusClient.dropCollection({ collection_name: COLLECTION_NAME });
+    milvusClient.closeConnection();
+  });
+
+  it('should append array values and auto-enable partial update', async () => {
+    const upsert = await milvusClient.upsert({
+      collection_name: COLLECTION_NAME,
+      fields_data: [
+        { id: 1, tags: ['blue'], scores: [4, 5] },
+        { id: 2, tags: ['yellow', 'purple'], scores: [30] },
+      ],
+      field_ops: [
+        { field_name: 'tags', op: FieldPartialUpdateOpType.ARRAY_APPEND },
+        { field_name: 'scores', op: 'ARRAY_APPEND' },
+      ],
+    });
+    expect(upsert.status).toEqual({
+      ...upsert.status,
+      error_code: ErrorCode.SUCCESS,
+    });
+
+    await milvusClient.flushSync({ collection_names: [COLLECTION_NAME] });
+
+    const query = await milvusClient.query({
+      collection_name: COLLECTION_NAME,
+      expr: 'id in [1, 2]',
+      output_fields: ['id', 'tags', 'scores'],
+    });
+    expect(query.status.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const rows = [...query.data].sort((a: any, b: any) => a.id - b.id);
+    expect(rows[0].tags).toEqual(['red', 'green', 'blue']);
+    expect(rows[0].scores).toEqual(['1', '2', '3', '4', '5']);
+    expect(rows[1].tags).toEqual(['blue', 'yellow', 'purple']);
+    expect(rows[1].scores).toEqual(['10', '20', '30']);
+  });
+
+  it('should remove array values with field_ops', async () => {
+    const upsert = await milvusClient.upsert({
+      collection_name: COLLECTION_NAME,
+      fields_data: [{ id: 1, tags: ['green'], scores: [2, 5] }],
+      field_ops: [
+        { field_name: 'tags', op: FieldPartialUpdateOpType.ARRAY_REMOVE },
+        { field_name: 'scores', op: 'ARRAY_REMOVE' },
+      ],
+    });
+    expect(upsert.status).toEqual({
+      ...upsert.status,
+      error_code: ErrorCode.SUCCESS,
+    });
+
+    await milvusClient.flushSync({ collection_names: [COLLECTION_NAME] });
+
+    const query = await milvusClient.query({
+      collection_name: COLLECTION_NAME,
+      expr: 'id == 1',
+      output_fields: ['id', 'tags', 'scores'],
+    });
+    expect(query.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(query.data[0].tags).toEqual(['red', 'blue']);
+    expect(query.data[0].scores).toEqual(['1', '3', '4']);
+  });
+});

--- a/test/utils/Data.spec.ts
+++ b/test/utils/Data.spec.ts
@@ -14,6 +14,7 @@ import {
   f32ArrayToInt8Bytes,
   processVectorData,
   findKeyValue,
+  FieldPartialUpdateOpType,
 } from '../../milvus';
 
 describe('utils/Data', () => {
@@ -49,6 +50,142 @@ describe('utils/Data', () => {
     expect(findKeyValue(queryParams.query_params, 'order_by_fields')).toBe(
       'price:asc,rating:desc'
     );
+  });
+
+  const captureUpsertParams = async (
+    describeResponse: any,
+    rows: any[],
+    extraParams: any = {}
+  ) => {
+    const client = new MilvusClient({
+      address: 'localhost:19530',
+      __SKIP_CONNECT__: true,
+    });
+    let upsertParams: any;
+    (client as any).describeCollection = jest
+      .fn()
+      .mockResolvedValue(describeResponse);
+    (client as any).channelPool = {
+      acquire: jest.fn().mockResolvedValue({
+        Upsert: (params: any, _options: any, cb: any) => {
+          upsertParams = params;
+          cb(null, {
+            status: { error_code: ErrorCode.SUCCESS, reason: '' },
+            succ_index: [],
+            err_index: [],
+            acknowledged: true,
+            insert_cnt: '0',
+            delete_cnt: '0',
+            upsert_cnt: String(rows.length),
+            timestamp: '0',
+            IDs: {
+              int_id: { data: rows.map((_, i) => String(i + 1)) },
+              id_field: 'int_id',
+            },
+          });
+        },
+      }),
+      release: jest.fn(),
+    };
+
+    await client.upsert({
+      collection_name: 'test_collection',
+      fields_data: rows,
+      ...extraParams,
+    });
+
+    return upsertParams;
+  };
+
+  const arrayPartialDescribeResponse = {
+    status: { error_code: ErrorCode.SUCCESS, reason: '' },
+    schema: {
+      enable_dynamic_field: false,
+      fields: [
+        {
+          name: 'id',
+          data_type: DataType.Int64,
+          is_primary_key: true,
+          autoID: false,
+          nullable: false,
+          element_type: DataType.None,
+        },
+        {
+          name: 'vector',
+          data_type: DataType.FloatVector,
+          dim: '2',
+          nullable: false,
+          element_type: DataType.None,
+        },
+        {
+          name: 'tags',
+          data_type: DataType.Array,
+          element_type: DataType.VarChar,
+          max_capacity: '8',
+          nullable: false,
+        },
+        {
+          name: 'scores',
+          data_type: DataType.Array,
+          element_type: DataType.Int64,
+          max_capacity: '8',
+          nullable: false,
+        },
+      ],
+    },
+    properties: [],
+  };
+
+  it('should pass field_ops through and auto-enable partial_update for upsert', async () => {
+    const upsertParams = await captureUpsertParams(
+      arrayPartialDescribeResponse,
+      [{ id: 1, tags: ['new'], scores: [2] }],
+      {
+        field_ops: [
+          { field_name: 'tags', op: FieldPartialUpdateOpType.ARRAY_APPEND },
+          { field_name: 'scores', op: 'ARRAY_REMOVE' },
+        ],
+      }
+    );
+
+    expect(upsertParams.partial_update).toBe(true);
+    expect(upsertParams.field_ops).toEqual([
+      { field_name: 'tags', op: 'ARRAY_APPEND' },
+      { field_name: 'scores', op: 'ARRAY_REMOVE' },
+    ]);
+    expect(upsertParams.fields_data.map((f: any) => f.field_name)).toEqual([
+      'id',
+      'tags',
+      'scores',
+    ]);
+  });
+
+  it('should reject unsupported field_ops op values', async () => {
+    await expect(
+      captureUpsertParams(
+        arrayPartialDescribeResponse,
+        [{ id: 1, tags: ['new'] }],
+        { field_ops: [{ field_name: 'tags', op: 999 }] }
+      )
+    ).rejects.toThrow('unsupported field partial update op: 999');
+
+    await expect(
+      captureUpsertParams(
+        arrayPartialDescribeResponse,
+        [{ id: 1, tags: ['new'] }],
+        { field_ops: [{ field_name: 'tags', op: 'INVALID_OP' }] }
+      )
+    ).rejects.toThrow('unsupported field partial update op: INVALID_OP');
+  });
+
+  it('should reject field_ops without field_name', async () => {
+    await expect(
+      captureUpsertParams(
+        arrayPartialDescribeResponse,
+        [{ id: 1, tags: ['new'] }],
+        { field_ops: [{ field_name: '', op: 'ARRAY_APPEND' }] }
+      )
+    ).rejects.toThrow('field_ops field_name is required');
   });
 
   const captureInsertParams = async (describeResponse: any, rows: any[]) => {


### PR DESCRIPTION
## Summary
- Add `FieldPartialUpdateOpType` and `UpsertReq.field_ops` for partial array upsert operations.
- Pass `field_ops` through gRPC upsert requests and auto-enable `partial_update` when field ops are provided.
- Add request-construction coverage, end-to-end ARRAY_APPEND/ARRAY_REMOVE tests, and docs/examples.

## Test plan
- [x] `npm run build`
- [x] `NODE_ENV=dev npx jest test/grpc/Upsert.spec.ts test/grpc/UpsertArrayPartialOp.spec.ts test/utils/Data.spec.ts --coverage --collectCoverageFrom='milvus/grpc/Data.ts' --collectCoverageFrom='milvus/types/Insert.ts' --collectCoverageFrom='milvus/const/milvus.ts'`