### PR TITLE
docs: document search by primary key

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,9 @@ Vector similarity search.
 ```typescript
 const results = await client.search({
   collection_name: string;
-  data: number[][] | number[];  // Query vector(s)
-  limit: number;                // Top-K results (default: 100)
+  data?: number[][] | number[]; // Query vector(s), not required when ids is provided
+  ids?: (string | number)[];    // Primary key IDs for Search By PK
+  limit?: number;               // Top-K results (default: 100)
   output_fields?: string[];     // Fields to return
   filter?: string;              // Scalar filter expression
   metric_type?: MetricType;     // Distance metric
@@ -247,6 +248,16 @@ const results = await client.search({
   group_by_field?: string;      // Group results by field
 });
 // Returns: { results: [{ id, score, ...output_fields }], ... }
+```
+
+Search by primary key IDs without providing query vectors:
+
+```typescript
+const results = await client.search({
+  collection_name: 'articles',
+  ids: [1, 2, 3],
+  output_fields: ['title', 'category'],
+});
 ```
 
 #### query

--- a/docs/content/reference/api-reference.mdx
+++ b/docs/content/reference/api-reference.mdx
@@ -367,8 +367,9 @@ search(data: SearchReq): Promise<SearchResults>
 **Parameters**:
 
 - `collection_name`: Collection name
-- `data`: Array of search vectors
-- `limit`: Number of results
+- `data?`: Array of search vectors. Not required when `ids` is provided.
+- `ids?`: Primary key IDs for Search By PK. Values must match the collection's primary key type (`Int64` or `VarChar`).
+- `limit?`: Number of results
 - `expr?`: Filter expression
 - `output_fields?`: Fields to return
 - `params?`: Search parameters

--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -687,8 +687,9 @@ export class Data extends Collection {
    * @param {string} [params.db_name] - The name of the database (optional).
    *
    * For SearchSimpleReq:
-   * @param {SearchData | SearchData[]} params.data - Vector or text to search.
+   * @param {SearchData | SearchData[]} [params.data] - Vector or text to search. Not required when ids is provided.
    * @param {SearchData | SearchData[]} [params.vector] - Alias for data (optional).
+   * @param {(number[] | string[])} [params.ids] - Primary key IDs for Search By PK. When provided, vector data is not required.
    * @param {string[]} [params.partition_names] - Array of partition names (optional).
    * @param {string} [params.anns_field] - Vector field name, required for multi-vector collections (optional).
    * @param {string[]} [params.output_fields] - Fields to return (optional).
@@ -711,6 +712,7 @@ export class Data extends Collection {
    * @param {OutputTransformers} [params.transformers] - Custom data transformers for bf16/f16 vectors (optional).
    * @param {RerankerObj | FunctionObject} [params.rerank] - Reranker configuration (optional).
    * @param {number} [params.nq] - Number of query vectors (optional).
+   * @param {(number[] | string[])} [params.ids] - Primary key IDs for Search By PK. When provided, vector data is not required.
    *
    * For HybridSearchReq:
    * @param {HybridSearchSingleReq[]} params.data - Array of search requests.


### PR DESCRIPTION
## Summary
- document Search By PK usage in README search API reference
- add ids parameter details to docs API reference
- update search JSDoc to note ids-based search does not require vector data

## Test plan
- [x] `git diff --check`