### PR TITLE
fix: forward compact advanced params

### DIFF
--- a/milvus/grpc/Collection.ts
+++ b/milvus/grpc/Collection.ts
@@ -1208,14 +1208,27 @@ export class Collection extends Database {
    */
   async compact(data: CompactReq): Promise<CompactionResponse> {
     checkCollectionName(data);
-    const collectionInfo = await this.describeCollection(data);
+
+    const describeReq: DescribeCollectionReq = {
+      collection_name: data.collection_name,
+    };
+    if (data.db_name) {
+      describeReq.db_name = data.db_name;
+    }
+    if (typeof data.timeout !== 'undefined') {
+      describeReq.timeout = data.timeout;
+    }
+
+    const collectionInfo = await this.describeCollection(describeReq);
+    const { timeout, ...compactionReq } = data;
     const res = await promisify(
       this.channelPool,
       'ManualCompaction',
       {
+        ...compactionReq,
         collectionID: collectionInfo.collectionID,
       },
-      data.timeout || this.timeout
+      timeout || this.timeout
     );
     return res;
   }

--- a/test/grpc/Compaction.spec.ts
+++ b/test/grpc/Compaction.spec.ts
@@ -1,9 +1,4 @@
-import {
-  MilvusClient,
-  DataType,
-  ErrorCode,
-  ERROR_REASONS,
-} from '../../milvus';
+import { MilvusClient, DataType, ErrorCode, ERROR_REASONS } from '../../milvus';
 import {
   IP,
   generateInsertData,
@@ -67,6 +62,15 @@ describe(`Compaction API`, () => {
     });
     expect(res.status.error_code).toEqual(ErrorCode.SUCCESS);
     expect(res).toHaveProperty('compactionID');
+  });
+
+  it(`Compact should forward target_size to server`, async () => {
+    const res = await milvusClient.compact({
+      collection_name: COLLECTION_NAME,
+      target_size: 1,
+    });
+    expect(res.status.error_code).toEqual(ErrorCode.IllegalArgument);
+    expect(res.status.reason).toContain('targetSize 1 MB');
   });
 
   it(`GetCompactionState should contain failedPlanNo`, async () => {

--- a/test/utils/Compaction.spec.ts
+++ b/test/utils/Compaction.spec.ts
@@ -1,0 +1,73 @@
+import { ErrorCode, MilvusClient } from '../../milvus';
+
+describe('utils/Compaction', () => {
+  it('should forward advanced compaction params to ManualCompaction', async () => {
+    const client = new MilvusClient({
+      address: 'localhost:19530',
+      __SKIP_CONNECT__: true,
+    });
+
+    let describeParams: any;
+    let compactionParams: any;
+    (client as any).channelPool = {
+      acquire: jest.fn().mockResolvedValue({
+        DescribeCollection: (params: any, _options: any, cb: any) => {
+          describeParams = params;
+          cb(null, {
+            status: { error_code: ErrorCode.SUCCESS, reason: '' },
+            collectionID: '100',
+            schema: { fields: [], functions: [] },
+            consistency_level: 'Bounded',
+            properties: [],
+            aliases: [],
+            virtual_channel_names: [],
+            physical_channel_names: [],
+            start_positions: [],
+          });
+        },
+        ManualCompaction: (params: any, _options: any, cb: any) => {
+          compactionParams = params;
+          cb(null, {
+            status: { error_code: ErrorCode.SUCCESS, reason: '' },
+            compactionID: '1',
+            compactionPlanCount: 1,
+          });
+        },
+      }),
+      release: jest.fn(),
+    };
+
+    const res = await client.compact({
+      collection_name: 'test_collection',
+      db_name: 'test_db',
+      timetravel: '123',
+      majorCompaction: true,
+      partition_id: '456',
+      channel: 'by-dev-rootcoord-dml_0',
+      segment_ids: [111, 222],
+      l0Compaction: true,
+      target_size: '536870912',
+      timeout: 1000,
+    });
+
+    expect(res.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(describeParams).toEqual({
+      collection_name: 'test_collection',
+      db_name: 'test_db',
+      timeout: 1000,
+    });
+    expect(compactionParams).toEqual({
+      collection_name: 'test_collection',
+      db_name: 'test_db',
+      collectionID: '100',
+      timetravel: '123',
+      majorCompaction: true,
+      partition_id: '456',
+      channel: 'by-dev-rootcoord-dml_0',
+      segment_ids: [111, 222],
+      l0Compaction: true,
+      target_size: '536870912',
+    });
+    expect(compactionParams).not.toHaveProperty('timeout');
+  });
+});


### PR DESCRIPTION
## Summary
- Forward advanced compact options to the ManualCompaction RPC payload
- Keep timeout out of the RPC payload while preserving it as the call deadline
- Add unit coverage for request forwarding and gRPC e2e coverage for target_size reaching Milvus

## Test plan
- [x] `NODE_ENV=dev npx jest test/utils/Compaction.spec.ts --runInBand`
- [x] `NODE_ENV=dev npx jest test/grpc/Compaction.spec.ts --runInBand`
- [x] `npm run build`