### PR TITLE
fix: support project region in import jobs

### DIFF
--- a/milvus/http/Import.ts
+++ b/milvus/http/Import.ts
@@ -2,11 +2,12 @@ import { HttpBaseClient } from '../HttpClient';
 import {
   Constructor,
   FetchOptions,
-  HttpBaseReq,
   HttpImportListResponse,
+  HttpImportListReq,
   HttpImportCreateReq,
   HttpImportCreateResponse,
   HttpImportProgressReq,
+  HttpImportProgressResponse,
 } from '../types';
 
 /**
@@ -24,7 +25,7 @@ export function Import<T extends Constructor<HttpBaseClient>>(Base: T) {
       return '/vectordb/jobs/import';
     }
 
-    async listImportJobs(params: HttpBaseReq, options?: FetchOptions) {
+    async listImportJobs(params: HttpImportListReq, options?: FetchOptions) {
       const url = `${this.importPrefix}/list`;
       return await this.POST<HttpImportListResponse>(url, params, options);
     }
@@ -42,7 +43,7 @@ export function Import<T extends Constructor<HttpBaseClient>>(Base: T) {
       options?: FetchOptions
     ) {
       const url = `${this.importPrefix}/get_progress`;
-      return await this.POST<HttpImportCreateResponse>(url, params, options);
+      return await this.POST<HttpImportProgressResponse>(url, params, options);
     }
   };
 }

--- a/milvus/types/Http.ts
+++ b/milvus/types/Http.ts
@@ -471,7 +471,18 @@ type ImportJobDetailType = {
 export interface HttpImportListResponse
   extends HttpBaseResponse<{ records: ImportJobType[] }> {}
 
-export interface HttpImportCreateReq extends HttpBaseReq {
+interface HttpImportProjectRegionReq {
+  projectId?: string;
+  regionId?: string;
+}
+
+export interface HttpImportListReq
+  extends HttpBaseReq,
+    HttpImportProjectRegionReq {}
+
+export interface HttpImportCreateReq
+  extends HttpBaseReq,
+    HttpImportProjectRegionReq {
   files: string[][];
   options?: {
     timeout: string;
@@ -483,7 +494,9 @@ export interface HttpImportCreateResponse
     jobId: string;
   }> {}
 
-export interface HttpImportProgressReq extends Pick<HttpBaseReq, 'dbName'> {
+export interface HttpImportProgressReq
+  extends Pick<HttpBaseReq, 'dbName'>,
+    HttpImportProjectRegionReq {
   jobId: string;
 }
 

--- a/test/http/import.spec.ts
+++ b/test/http/import.spec.ts
@@ -1,0 +1,94 @@
+import { HttpClient } from '../../milvus';
+
+describe('HTTP Import API', () => {
+  const baseURL = 'http://127.0.0.1:19530/v2';
+
+  const createClient = () => {
+    const requests: { url: string; body: any }[] = [];
+    const fetch = jest
+      .fn()
+      .mockImplementation(async (url: string, init: any) => {
+        requests.push({ url, body: JSON.parse(init.body) });
+        return {
+          ok: true,
+          json: async () => ({
+            code: 0,
+            data: { jobId: 'job-1', records: [] },
+          }),
+        };
+      });
+
+    const client = new HttpClient({
+      baseURL,
+      token: 'token',
+      database: 'default',
+      fetch: fetch as any,
+    });
+
+    return { client, requests };
+  };
+
+  it('should pass projectId and regionId when creating import jobs', async () => {
+    const { client, requests } = createClient();
+
+    await client.createImportJobs({
+      collectionName: 'test_collection',
+      files: [['s3://bucket/path/file.parquet']],
+      projectId: 'proj-xxx',
+      regionId: 'aws-us-west-2',
+    });
+
+    expect(requests[0].url).toEqual(`${baseURL}/vectordb/jobs/import/create`);
+    expect(requests[0].body).toEqual(
+      expect.objectContaining({
+        dbName: 'default',
+        collectionName: 'test_collection',
+        files: [['s3://bucket/path/file.parquet']],
+        projectId: 'proj-xxx',
+        regionId: 'aws-us-west-2',
+      })
+    );
+  });
+
+  it('should pass projectId and regionId when listing import jobs', async () => {
+    const { client, requests } = createClient();
+
+    await client.listImportJobs({
+      collectionName: 'test_collection',
+      projectId: 'proj-xxx',
+      regionId: 'aws-us-west-2',
+    });
+
+    expect(requests[0].url).toEqual(`${baseURL}/vectordb/jobs/import/list`);
+    expect(requests[0].body).toEqual(
+      expect.objectContaining({
+        dbName: 'default',
+        collectionName: 'test_collection',
+        projectId: 'proj-xxx',
+        regionId: 'aws-us-west-2',
+      })
+    );
+  });
+
+  it('should pass projectId and regionId when getting import job progress', async () => {
+    const { client, requests } = createClient();
+
+    await client.getImportJobProgress({
+      jobId: 'job-1',
+      projectId: 'proj-xxx',
+      regionId: 'aws-us-west-2',
+    });
+
+    expect(requests[0].url).toEqual(
+      `${baseURL}/vectordb/jobs/import/get_progress`
+    );
+    expect(requests[0].body).toEqual(
+      expect.objectContaining({
+        dbName: 'default',
+        jobId: 'job-1',
+        projectId: 'proj-xxx',
+        regionId: 'aws-us-west-2',
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `projectId` and `regionId` request fields to HTTP import job create/list/progress APIs
- Use the proper HTTP import progress response type for `getImportJobProgress`
- Add unit coverage to verify project/region fields are forwarded in request bodies

## Test plan
- [x] `NODE_ENV=dev npx jest test/http/import.spec.ts --runInBand`
- [x] `npm run build`