### PR TITLE
fix: bump uuid resolution to 11.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "lodash": "^4.18.1",
     "picomatch": "^2.3.2",
     "thrift": "^0.23.0",
-    "thrift/uuid": "11.1.0"
+    "thrift/uuid": "11.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3894,10 +3894,10 @@ utilium@^1.3.3:
   optionalDependencies:
     "@xterm/xterm" "^5.5.0"
 
-uuid@11.1.0, uuid@^13.0.0:
-  version "11.1.0"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
-  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
+uuid@11.1.1, uuid@^13.0.0:
+  version "11.1.1"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
related: https://github.com/milvus-io/milvus-sdk-node/security/dependabot/249

## Summary
- Bump the `thrift/uuid` Yarn resolution from `11.1.0` to patched `11.1.1`.
- Update `yarn.lock` so transitive `uuid` resolves to a version fixed for GHSA-w5hq-g745-h8pq / CVE-2026-41907.

## Test plan
- [x] `yarn why uuid`
- [x] `yarn build`
