### PR TITLE
docs: tag Milvus 3.0 features

### DIFF
--- a/docs/src/content/docs/api-reference/collections.mdx
+++ b/docs/src/content/docs/api-reference/collections.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Collection Operations"
+title: 'Collection Operations'
 ---
 
 Collection APIs manage schemas, collection lifecycle, load/release state, aliases, functions, compaction, external collections, and snapshots.
@@ -81,6 +81,10 @@ await client.createCollection({
 ```
 
 ## Schema mutation
+
+<span className="version-tag">Milvus 3.0</span>
+
+Milvus 3.0 introduces collection schema alteration for adding fields and functions to existing collections. The Node SDK exposes this through the following field and function management methods.
 
 ### addCollectionField
 
@@ -481,7 +485,7 @@ getPkFieldType(data: DescribeCollectionReq, desc?: DescribeCollectionResponse): 
 getPkField(data: DescribeCollectionReq): Promise<FieldSchema>
 ```
 
-## External collection refresh
+## External collection refresh <span className="version-tag">Milvus 3.0</span>
 
 ### refreshExternalCollection
 
@@ -515,7 +519,7 @@ listRefreshExternalCollectionJobs(data?: ListRefreshExternalCollectionJobsReq): 
 
 **Parameters**: optional `db_name`, `collection_name`, and `timeout`.
 
-## Snapshots
+## Snapshots <span className="version-tag">Milvus 3.0</span>
 
 ### createSnapshot
 

--- a/docs/src/content/docs/api-reference/data.mdx
+++ b/docs/src/content/docs/api-reference/data.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Data Operations"
+title: 'Data Operations'
 ---
 
 Data APIs write, read, search, delete, flush, compact, and bulk-import collection data. Most request types extend `collectionNameReq`, so they accept `collection_name`, optional `db_name`, optional `timeout`, and optional request tracing fields.
@@ -66,7 +66,7 @@ upsert(data: UpsertReq): Promise<MutationResult>
 In addition to `InsertReq` fields, `UpsertReq` accepts:
 
 - `partial_update?`: Update only provided fields.
-- `field_ops?`: Per-field partial update operations. Providing `field_ops` automatically enables partial update behavior.
+- `field_ops?`: Per-field partial update operations. Providing `field_ops` automatically enables partial update behavior. <span className="version-tag">Milvus 3.0</span>
 
 ```typescript
 type FieldPartialUpdateOp = {
@@ -331,6 +331,10 @@ const res = await client.hybridSearch({
 
 **Search response**:
 
+<span className="version-tag">Milvus 3.0</span> Milvus 3.0 can return
+element-level offsets and grouped search metadata. The SDK exposes them as
+`offset` and `group_by_field_values` on each result row.
+
 ```typescript
 interface SearchResults<T> {
   status: ResStatus;
@@ -345,8 +349,8 @@ interface SearchResultData {
   [fieldName: string]: any;
   score: number;
   id: string;
-  offset?: number | string;
-  group_by_field_values?: Record<string, FieldData>;
+  offset?: number | string; // Milvus 3.0 element-level result offset
+  group_by_field_values?: Record<string, FieldData>; // Milvus 3.0 grouped result metadata
   highlight?: HighlightResult;
 }
 ```

--- a/docs/src/content/docs/api-reference/types-and-enums.mdx
+++ b/docs/src/content/docs/api-reference/types-and-enums.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Types & Enums"
+title: 'Types & Enums'
 ---
 
 This page lists common SDK types and enums used across API requests and responses.
@@ -162,6 +162,9 @@ interface RowData {
 
 Used by `createCollection`, `addCollectionField`, and `addCollectionFields`.
 
+<span className="version-tag">Milvus 3.0</span> `external_field` maps a Milvus
+field to a source field when creating external collections.
+
 ```typescript
 type FieldType = {
   name: string;
@@ -195,6 +198,9 @@ Common `TypeParamKey` values include:
 
 Used for BM25, text embedding, and rerank functions.
 
+<span className="version-tag">Milvus 3.0</span> Collection functions can be
+added to or dropped from existing collections through schema alteration APIs.
+
 ```typescript
 type FunctionObject = {
   name: string;
@@ -204,6 +210,18 @@ type FunctionObject = {
   output_field_names?: string[];
   params: Record<string, any>;
 };
+```
+
+## Partial update enums <span className="version-tag">Milvus 3.0</span>
+
+`FieldPartialUpdateOpType` is used by `upsert({ field_ops })` to control Array field partial updates.
+
+```typescript
+enum FieldPartialUpdateOpType {
+  REPLACE = 0,
+  ARRAY_APPEND = 1,
+  ARRAY_REMOVE = 2,
+}
 ```
 
 ## Search and query result types
@@ -219,9 +237,13 @@ interface QueryResults {
 
 ### SearchResults
 
+<span className="version-tag">Milvus 3.0</span> `offset` represents
+element-level result offsets, and `group_by_field_values` carries grouped search
+metadata when Milvus returns it.
+
 ```typescript
 interface SearchResults<
-  T extends SearchReq | SearchSimpleReq | HybridSearchReq
+  T extends SearchReq | SearchSimpleReq | HybridSearchReq,
 > {
   status: ResStatus;
   results: SearchResultData[] | SearchResultData[][];

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -50,13 +50,26 @@ The Milvus Node.js SDK offers:
 
 The following table shows the recommended `@zilliz/milvus2-sdk-node` versions for different Milvus versions:
 
-| Milvus version | Node SDK version | Installation                               |
-| :------------: | :--------------: | :----------------------------------------- |
-|    v2.6.0+     |    **latest**    | `yarn add @zilliz/milvus2-sdk-node@latest` |
-|    v2.5.0+     |      v2.5.0      | `yarn add @zilliz/milvus2-sdk-node@2.5.12` |
-|    v2.4.0+     |      v2.4.9      | `yarn add @zilliz/milvus2-sdk-node@2.4.9`  |
-|    v2.3.0+     |      v2.3.5      | `yarn add @zilliz/milvus2-sdk-node@2.3.5`  |
-|    v2.2.0+     |      v2.3.5      | `yarn add @zilliz/milvus2-sdk-node@2.3.5`  |
+| Milvus version |   Node SDK version   | Installation                               |
+| :------------: | :------------------: | :----------------------------------------- |
+|    v3.0.0+     | v3.0.0+ / **latest** | `yarn add @zilliz/milvus2-sdk-node@latest` |
+|    v2.6.0+     |        v2.6.x        | `yarn add @zilliz/milvus2-sdk-node@2.6.9`  |
+|    v2.5.0+     |        v2.5.x        | `yarn add @zilliz/milvus2-sdk-node@2.5.12` |
+|    v2.4.0+     |        v2.4.9        | `yarn add @zilliz/milvus2-sdk-node@2.4.9`  |
+|    v2.3.0+     |        v2.3.5        | `yarn add @zilliz/milvus2-sdk-node@2.3.5`  |
+|    v2.2.0+     |        v2.3.5        | `yarn add @zilliz/milvus2-sdk-node@2.3.5`  |
+
+## Milvus 3.0 feature highlights <span className="version-tag">Milvus 3.0</span>
+
+Features that require a Milvus 3.0 server are marked with the `Milvus 3.0` tag throughout this documentation. The Node SDK 3.x docs now cover:
+
+- External collections: create collections over external data sources and refresh external collection jobs.
+- Collection snapshots: create, list, describe, restore, pin, unpin, and drop snapshots.
+- Partial array upsert: append to or remove from Array fields with `field_ops`.
+- Element-level result metadata: read `offset` values from query/search results and `group_by_field_values` from grouped search results.
+- Schema and function management: add fields/functions and manage collection functions from the SDK.
+
+See [Migration & Compatibility](./reference/migration-compatibility) for the detailed coverage matrix, including Milvus 3.0 proto additions that are not exposed as public SDK methods.
 
 ## Prerequisites
 

--- a/docs/src/content/docs/management/collection-management.mdx
+++ b/docs/src/content/docs/management/collection-management.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Collection Management"
+title: 'Collection Management'
 ---
 
 Collections are the primary data structure in Milvus, similar to tables in traditional databases. This guide covers all collection management operations.
@@ -169,7 +169,7 @@ const result = await client.showCollections({
   type: ShowCollectionsType.All, // 'All' or 'InMemory'
 });
 
-result.data.forEach(collection => {
+result.data.forEach((collection) => {
   console.log(`Collection: ${collection.name}`);
   console.log(`ID: ${collection.id}`);
   console.log(`Loaded: ${collection.loadedPercentage}%`);
@@ -466,7 +466,7 @@ const replicas = await client.getReplicas({
   with_shard_nodes: true,
 });
 
-replicas.replicas.forEach(replica => {
+replicas.replicas.forEach((replica) => {
   console.log('Resource group:', replica.resource_group_name);
   console.log('Outbound nodes:', replica.num_outbound_node);
   console.log('Shard replicas:', replica.shard_replicas);
@@ -547,9 +547,9 @@ const result = await client.batchDescribeCollections({
   collection_names: ['collection_a', 'collection_b', 'collection_c'],
 });
 
-result.responses.forEach(col => {
+result.responses.forEach((col) => {
   console.log(`Collection: ${col.collectionName}`);
-  console.log(`Fields: ${col.schema.fields.map(f => f.name)}`);
+  console.log(`Fields: ${col.schema.fields.map((f) => f.name)}`);
 });
 ```
 
@@ -591,7 +591,7 @@ await client.dropCollectionProperties({
 });
 ```
 
-## External Collections
+## External Collections <span className="version-tag">Milvus 3.0</span>
 
 External collections reference data stored outside Milvus. Use `external_source` and `external_spec` at collection creation time, and map Milvus fields to source fields with `external_field`.
 
@@ -643,7 +643,7 @@ const jobs = await client.listRefreshExternalCollectionJobs({
 });
 ```
 
-## Collection Snapshots
+## Collection Snapshots <span className="version-tag">Milvus 3.0</span>
 
 Snapshots capture a collection at a point in time. You can describe, restore, pin, and remove snapshots with the snapshot APIs.
 
@@ -704,6 +704,10 @@ await client.dropSnapshot({
 Collection functions are auto-processing pipelines that transform data at insert and query time. The most common use case is BM25 full-text search, where a function automatically converts text to sparse vectors.
 
 ### Add a Function
+
+<span className="version-tag">Milvus 3.0</span>
+
+Milvus 3.0's collection schema alteration support includes adding and dropping functions on existing collections. In the Node SDK, use the collection function APIs below.
 
 ```javascript
 import { FunctionType } from '@zilliz/milvus2-sdk-node';

--- a/docs/src/content/docs/operations/data-operations-insert.mdx
+++ b/docs/src/content/docs/operations/data-operations-insert.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Data Operations - Insert & Update"
+title: 'Data Operations - Insert & Update'
 ---
 
 This guide covers inserting and updating data in Milvus collections.
@@ -200,7 +200,7 @@ await client.upsert({
 });
 ```
 
-### Partial Array Upsert
+### Partial Array Upsert <span className="version-tag">Milvus 3.0</span>
 
 For Array fields, use `field_ops` to append values to or remove values from the existing array instead of replacing the whole field.
 
@@ -258,7 +258,7 @@ await client.insert({
     },
   ],
   transformers: {
-    vector: data => f32ArrayToF16Bytes(data), // Convert to f16 bytes
+    vector: (data) => f32ArrayToF16Bytes(data), // Convert to f16 bytes
   },
 });
 ```

--- a/docs/src/content/docs/operations/data-operations-query.mdx
+++ b/docs/src/content/docs/operations/data-operations-query.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Data Operations - Query & Search"
+title: 'Data Operations - Query & Search'
 ---
 
 This guide covers querying and searching data in Milvus collections.
@@ -340,7 +340,7 @@ const results = await client.search({
   limit: 10,
 });
 
-results.results.forEach(result => {
+results.results.forEach((result) => {
   console.log('ID:', result.id);
   console.log('Distance:', result.distance);
   console.log('Score:', result.score);
@@ -348,7 +348,7 @@ results.results.forEach(result => {
 });
 ```
 
-### Element-Level Offsets
+### Element-Level Offsets <span className="version-tag">Milvus 3.0</span>
 
 For element-level retrieval, Milvus can return the matching element offsets for array or multi-vector fields. The SDK flattens `element_indices` into result rows and adds an `offset` property that identifies the matched element within the source field.
 
@@ -365,9 +365,18 @@ const results = await client.search({
   output_fields: ['doc_id', 'title'],
 });
 
-results.results.forEach(row => {
+results.results.forEach((row) => {
   console.log('Document:', row.doc_id);
   console.log('Matched element offset:', row.offset);
+});
+```
+
+Grouped search responses can also include `group_by_field_values`, which the SDK exposes on each result row:
+
+```javascript
+results.results.forEach((row) => {
+  console.log('Score:', row.score);
+  console.log('Group by values:', row.group_by_field_values);
 });
 ```
 

--- a/docs/src/content/docs/reference/migration-compatibility.mdx
+++ b/docs/src/content/docs/reference/migration-compatibility.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Migration & Compatibility"
+title: 'Migration & Compatibility'
 ---
 
 This guide covers version compatibility, migration paths, and breaking changes.
@@ -8,13 +8,14 @@ This guide covers version compatibility, migration paths, and breaking changes.
 
 ### SDK and Milvus Compatibility
 
-| Milvus version | Node SDK version | Installation                               |
-| :------------: | :--------------: | :----------------------------------------- |
-|    v2.6.0+     |    **latest**    | `yarn add @zilliz/milvus2-sdk-node@latest` |
-|    v2.5.0+     |      v2.5.0      | `yarn add @zilliz/milvus2-sdk-node@2.5.12` |
-|    v2.4.0+     |      v2.4.9      | `yarn add @zilliz/milvus2-sdk-node@2.4.9`  |
-|    v2.3.0+     |      v2.3.5      | `yarn add @zilliz/milvus2-sdk-node@2.3.5`  |
-|    v2.2.0+     |      v2.3.5      | `yarn add @zilliz/milvus2-sdk-node@2.3.5`  |
+| Milvus version |   Node SDK version   | Installation                               |
+| :------------: | :------------------: | :----------------------------------------- |
+|    v3.0.0+     | v3.0.0+ / **latest** | `yarn add @zilliz/milvus2-sdk-node@latest` |
+|    v2.6.0+     |        v2.6.x        | `yarn add @zilliz/milvus2-sdk-node@2.6.9`  |
+|    v2.5.0+     |        v2.5.x        | `yarn add @zilliz/milvus2-sdk-node@2.5.12` |
+|    v2.4.0+     |        v2.4.9        | `yarn add @zilliz/milvus2-sdk-node@2.4.9`  |
+|    v2.3.0+     |        v2.3.5        | `yarn add @zilliz/milvus2-sdk-node@2.3.5`  |
+|    v2.2.0+     |        v2.3.5        | `yarn add @zilliz/milvus2-sdk-node@2.3.5`  |
 
 ### Node.js Compatibility
 
@@ -52,6 +53,7 @@ const info = await client.getMetric({
    - Review breaking changes in release notes
 
 2. **Update Package**:
+
 ```bash
 yarn add @zilliz/milvus2-sdk-node@latest
 # or specific version
@@ -75,7 +77,27 @@ yarn add @zilliz/milvus2-sdk-node@2.6.9
 
 5. **Test**: Verify all operations work correctly
 
+## Milvus 3.0 feature coverage <span className="version-tag">Milvus 3.0</span>
+
+The following SDK features require a Milvus 3.0 server. They are marked with the `Milvus 3.0` tag in the relevant guides and API reference pages.
+
+| Area                           | SDK surface                                                                                                                                                                                                                   | Docs                                                                                                                                               |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| External collections           | `external_source`, `external_spec`, `do_physical_backfill`, `file_resource_ids`, field-level `external_field`, `refreshExternalCollection()`, `getRefreshExternalCollectionProgress()`, `listRefreshExternalCollectionJobs()` | [Collection Management](../management/collection-management), [Collection Operations](../api-reference/collections)                                |
+| Collection snapshots           | `createSnapshot()`, `dropSnapshot()`, `listSnapshots()`, `describeSnapshot()`, `restoreSnapshot()`, `getRestoreSnapshotState()`, `listRestoreSnapshotJobs()`, `pinSnapshotData()`, `unpinSnapshotData()`                      | [Collection Management](../management/collection-management), [Collection Operations](../api-reference/collections)                                |
+| Partial array upsert           | `upsert({ field_ops })`, `FieldPartialUpdateOpType.REPLACE`, `ARRAY_APPEND`, `ARRAY_REMOVE`                                                                                                                                   | [Insert & Update](../operations/data-operations-insert), [Data Operations](../api-reference/data)                                                  |
+| Element-level result metadata  | Query/search result `offset`; grouped search `group_by_field_values`                                                                                                                                                          | [Query & Search](../operations/data-operations-query), [Data Operations](../api-reference/data)                                                    |
+| Schema and function management | `addCollectionField()`, `addCollectionFields()`, `addCollectionFunction()`, `alterCollectionFunction()`, `dropCollectionFunction()`                                                                                           | [Collection Management](../management/collection-management#dynamic-schema), [Collection Operations](../api-reference/collections#schema-mutation) |
+
+Not all Milvus 3.0 proto additions are public Node SDK APIs yet. Client telemetry, WAL dump/data-salvage APIs, `ComputePhraseMatchSlop`, `BatchUpdateManifest`, and full molecular data helpers are currently proto-level/internal surfaces unless explicitly exposed in a later SDK release.
+
 ## Breaking Changes
+
+### Version 3.0.x <span className="version-tag">Milvus 3.0</span>
+
+- SDK 3.x targets the Milvus 3.0 proto line while keeping the public package name `@zilliz/milvus2-sdk-node`.
+- Milvus 3.0-only APIs require a Milvus 3.0 server; older servers may return unimplemented or unknown-field errors.
+- Legacy replicate/CDC proto fields are deprecated upstream. Avoid building new integrations on them.
 
 ### Version 2.6.x
 
@@ -99,20 +121,37 @@ yarn add @zilliz/milvus2-sdk-node@2.6.9
 
 ### Feature Compatibility
 
-| Feature | Milvus 2.2 | Milvus 2.3 | Milvus 2.4 | Milvus 2.5 | Milvus 2.6 |
-|---------|------------|------------|------------|------------|------------|
-| Basic CRUD | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Index Types | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Dynamic Schema | ✅ | ✅ | ✅ | ✅ | ✅ |
-| RBAC v2 | ❌ | ❌ | ✅ | ✅ | ✅ |
-| Sparse Vectors | ❌ | ❌ | ✅ | ✅ | ✅ |
-| Float16/BFloat16 | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Feature                       | Milvus 2.2 | Milvus 2.3 | Milvus 2.4 | Milvus 2.5 | Milvus 2.6 | Milvus 3.0 |
+| ----------------------------- | ---------- | ---------- | ---------- | ---------- | ---------- | ---------- |
+| Basic CRUD                    | ✅         | ✅         | ✅         | ✅         | ✅         | ✅         |
+| Index Types                   | ✅         | ✅         | ✅         | ✅         | ✅         | ✅         |
+| Dynamic Schema                | ✅         | ✅         | ✅         | ✅         | ✅         | ✅         |
+| RBAC v2                       | ❌         | ❌         | ✅         | ✅         | ✅         | ✅         |
+| Sparse Vectors                | ❌         | ❌         | ✅         | ✅         | ✅         | ✅         |
+| Float16/BFloat16              | ❌         | ❌         | ❌         | ✅         | ✅         | ✅         |
+| External Collections          | ❌         | ❌         | ❌         | ❌         | ❌         | ✅         |
+| Collection Snapshots          | ❌         | ❌         | ❌         | ❌         | ❌         | ✅         |
+| Partial Array Upsert          | ❌         | ❌         | ❌         | ❌         | ❌         | ✅         |
+| Element-Level Result Metadata | ❌         | ❌         | ❌         | ❌         | ❌         | ✅         |
 
 ## Upgrade Paths
+
+### From v2.6.x to v3.0.x <span className="version-tag">Milvus 3.0</span>
+
+1. Upgrade Milvus to 3.0 following the Milvus server upgrade guide.
+2. Update the Node SDK:
+
+```bash
+yarn add @zilliz/milvus2-sdk-node@latest
+```
+
+3. If you use new 3.0 APIs, ensure your deployment is actually connected to a Milvus 3.0 server.
+4. Test collection management, write paths, and query/search result parsing before production rollout.
 
 ### From v2.3.x to v2.6.x
 
 1. Update SDK:
+
 ```bash
 yarn add @zilliz/milvus2-sdk-node@latest
 ```
@@ -125,6 +164,7 @@ yarn add @zilliz/milvus2-sdk-node@latest
 ### From v2.4.x to v2.6.x
 
 1. Update SDK:
+
 ```bash
 yarn add @zilliz/milvus2-sdk-node@latest
 ```
@@ -141,10 +181,14 @@ Some methods may be deprecated in newer versions:
 
 ```javascript
 // Old method (deprecated)
-client.alterCollection({ /* ... */ });
+client.alterCollection({
+  /* ... */
+});
 
 // New method
-client.alterCollectionProperties({ /* ... */ });
+client.alterCollectionProperties({
+  /* ... */
+});
 ```
 
 ### Migration Steps

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -409,6 +409,27 @@ main > .content-panel:first-child h1 {
   font-weight: 680;
 }
 
+.sl-markdown-content .version-tag:not(:where(.not-content *)) {
+  align-items: center;
+  background: color-mix(in srgb, var(--sl-color-accent) 14%, transparent);
+  border: 1px solid var(--doc-border-strong);
+  border-radius: 999px;
+  color: var(--sl-color-text-accent);
+  display: inline-flex;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  margin-inline-start: 0.45rem;
+  padding: 0.22rem 0.48rem;
+  text-transform: uppercase;
+  vertical-align: middle;
+}
+
+.sl-markdown-content p > .version-tag:first-child:not(:where(.not-content *)) {
+  margin-inline-start: 0;
+}
+
 /* Inline code and code blocks */
 .sl-markdown-content
   code:not(:where(pre code, .expressive-code *, .not-content *)) {


### PR DESCRIPTION
## Summary
- Add a reusable `Milvus 3.0` documentation tag style and apply it to Milvus 3.0-only features.
- Update overview and migration docs with SDK 3.x / Milvus 3.0 compatibility and feature coverage.
- Document 3.0 feature surfaces for external collections, snapshots, partial array upsert, schema/function mutation, and element-level result metadata.

## Test plan
- [x] `cd docs && npx prettier --check src/content/docs/index.mdx src/content/docs/reference/migration-compatibility.mdx src/content/docs/management/collection-management.mdx src/content/docs/api-reference/collections.mdx src/content/docs/operations/data-operations-insert.mdx src/content/docs/operations/data-operations-query.mdx src/content/docs/api-reference/data.mdx src/content/docs/api-reference/types-and-enums.mdx src/styles/custom.css`
- [x] `cd docs && npm run build`
