### PR TITLE
Fix parquetjs package import

### DIFF
--- a/docs/src/content/docs/operations/bulk-writer.mdx
+++ b/docs/src/content/docs/operations/bulk-writer.mdx
@@ -76,7 +76,7 @@ const writer = new BulkWriter({
 | Write speed    | Fast  | Slower            |
 | Upload speed   | Slow  | **~4x faster**    |
 | Server import  | Slow  | **~2x faster**    |
-| Dependencies   | None  | `@dsnp/parquetjs` |
+| Dependencies   | None  | `@shanghaikid/parquetjs` |
 | Human readable | Yes   | No                |
 
 **Recommendation:** Use Parquet for production, JSON for debugging.

--- a/milvus/bulkwriter/ParquetFormatter.ts
+++ b/milvus/bulkwriter/ParquetFormatter.ts
@@ -1,13 +1,13 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { ParquetSchema, ParquetWriter } from '@dsnp/parquetjs';
+import { ParquetSchema, ParquetWriter } from '@shanghaikid/parquetjs';
 import { DataType, convertToDataType, FieldType } from '../';
 import { Formatter, BulkWriterSchema } from './Types';
 
 const DYNAMIC_FIELD = '$meta';
 
 /**
- * Maps a Milvus DataType to a @dsnp/parquetjs schema field definition.
+ * Maps a Milvus DataType to a @shanghaikid/parquetjs schema field definition.
  * Follows the same mapping as pymilvus ARROW_TYPE_CREATOR.
  */
 function parquetFieldDef(dt: DataType): Record<string, any> {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@zilliz/milvus2-sdk-node",
   "author": "Zilliz",
   "milvusVersion": "v3.0-beta-amd64",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "main": "dist/milvus",
   "files": [
     "dist"
@@ -23,7 +23,7 @@
     "proto:json": "yarn test test/utils/ProtoJson.spec.ts"
   },
   "dependencies": {
-    "@dsnp/parquetjs": "npm:@shanghaikid/parquetjs@1.8.8",
+    "@shanghaikid/parquetjs": "1.8.8",
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
     "@opentelemetry/api": "^1.9.0",

--- a/test/bulkwriter/ParquetFormatter.spec.ts
+++ b/test/bulkwriter/ParquetFormatter.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { ParquetReader } from '@dsnp/parquetjs';
+import { ParquetReader } from '@shanghaikid/parquetjs';
 import { DataType } from '../../milvus';
 import { BulkWriter } from '../../milvus/bulkwriter/BulkWriter';
 import { ParquetFormatter } from '../../milvus/bulkwriter/ParquetFormatter';

--- a/yarn.lock
+++ b/yarn.lock
@@ -695,7 +695,7 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@dsnp/parquetjs@npm:@shanghaikid/parquetjs@1.8.8":
+"@shanghaikid/parquetjs@1.8.8":
   version "1.8.8"
   resolved "https://registry.npmjs.org/@shanghaikid/parquetjs/-/parquetjs-1.8.8.tgz#f7438dbf6f381d2799fef2fbb7e1f48fc8878c62"
   integrity sha512-uaYXx4yP4cipVU8EZR4OZohiklsazyAcIXtfNEEYBcsMlnz5w4gEvv9vw+cP3yZBv7d1+OQYKfCfKI7oK0iUZQ==


### PR DESCRIPTION
## Summary
- replace the parquet dependency alias with the real @shanghaikid/parquetjs package name
- update ParquetFormatter imports, tests, and docs to use @shanghaikid/parquetjs
- bump package version to 3.0.3 for release

## Verification
- yarn build
- yarn test test/bulkwriter/ParquetFormatter.spec.ts --runInBand
- npm_config_cache=/private/tmp/npm-cache-attu-sdk npm pack --dry-run --json