### PR TITLE
Add function field schema wrapper

### DIFF
--- a/milvus/const/error.ts
+++ b/milvus/const/error.ts
@@ -70,6 +70,11 @@ export const ERROR_REASONS = {
     'Target anns field not found, please check your search parameters.',
   FUNCTION_SCHEMA_IS_REQUIRED: 'The `function` property is missing.',
   FUNCTION_NAME_IS_REQUIRED: 'The `function_name` property is missing.',
+  FUNCTION_FIELD_SCHEMA_IS_REQUIRED: 'The `field` property is missing.',
+  ADD_FUNCTION_FIELD_TYPE_NOT_SUPPORTED:
+    'The `function.type` property only supports FunctionType.BM25.',
+  ADD_FUNCTION_FIELD_OUTPUT_TYPE_NOT_SUPPORTED:
+    'The `field.data_type` property only supports DataType.SparseFloatVector.',
 };
 
 export enum ErrorCode {

--- a/milvus/grpc/Collection.ts
+++ b/milvus/grpc/Collection.ts
@@ -55,6 +55,7 @@ import {
   CreateCollectionWithFieldsReq,
   CreateCollectionWithSchemaReq,
   FieldSchema,
+  FieldType,
   DropCollectionPropertiesReq,
   AlterCollectionFieldPropertiesReq,
   RefreshLoadReq,
@@ -67,6 +68,9 @@ import {
   AddCollectionFunctionReq,
   AlterCollectionFunctionReq,
   DropCollectionFunctionReq,
+  AlterCollectionSchemaReq,
+  AlterCollectionSchemaResponse,
+  AddFunctionFieldReq,
   RefreshExternalCollectionReq,
   RefreshExternalCollectionResponse,
   GetRefreshExternalCollectionProgressReq,
@@ -88,7 +92,35 @@ import {
   PinSnapshotDataReq,
   PinSnapshotDataResponse,
   UnpinSnapshotDataReq,
+  FunctionType,
 } from '../';
+
+const formatGrpcFieldSchema = (
+  field: FieldType,
+  schemaTypes: { fieldSchemaType: any }
+): Record<string, any> => {
+  const schema = formatFieldSchema(field, schemaTypes);
+
+  return {
+    fieldID: schema.fieldID,
+    name: schema.name,
+    is_primary_key: schema.isPrimaryKey,
+    description: schema.description,
+    data_type: schema.dataType,
+    type_params: schema.typeParams,
+    index_params: schema.indexParams,
+    autoID: schema.autoID,
+    state: schema.state,
+    element_type: schema.elementType,
+    default_value: schema.defaultValue,
+    is_dynamic: schema.isDynamic,
+    is_partition_key: schema.isPartitionKey,
+    is_clustering_key: schema.isClusteringKey,
+    nullable: schema.nullable,
+    is_function_output: schema.isFunctionOutput,
+    external_field: schema.externalField,
+  };
+};
 
 /**
  * @see [collection operation examples](https://github.com/milvus-io/milvus-sdk-node/blob/main/example/Collection.ts)
@@ -1537,6 +1569,118 @@ export class Collection extends Database {
     }
 
     return pkField;
+  }
+
+  /**
+   * Alter collection schema by adding a function-backed output field.
+   *
+   * Milvus 3.0-beta supports the add path for BM25 function fields through
+   * AlterCollectionSchema. It does not create an index automatically.
+   *
+   * @param {AlterCollectionSchemaReq} data - The request parameters.
+   * @param {string} data.collection_name - The collection name.
+   * @param {FieldType} data.field - The function output field schema.
+   * @param {FunctionObject} data.function - The function schema.
+   * @param {boolean} [data.do_physical_backfill] - Whether to backfill existing data.
+   * @param {string} [data.db_name] - The database name.
+   * @param {number} [data.timeout] - Optional RPC timeout in milliseconds.
+   *
+   * @returns {Promise<AlterCollectionSchemaResponse>} The response from Milvus.
+   */
+  async alterCollectionSchema(
+    data: AlterCollectionSchemaReq
+  ): Promise<AlterCollectionSchemaResponse> {
+    checkCollectionName(data);
+
+    if (!data.field) {
+      throw new Error(ERROR_REASONS.FUNCTION_FIELD_SCHEMA_IS_REQUIRED);
+    }
+
+    if (!data.function) {
+      throw new Error(ERROR_REASONS.FUNCTION_SCHEMA_IS_REQUIRED);
+    }
+
+    const schemaTypes = {
+      fieldSchemaType: this.schemaProto.lookupType(
+        this.protoInternalPath.fieldSchema
+      ),
+    };
+
+    const req: any = {
+      collection_name: data.collection_name,
+      action: {
+        add_request: {
+          field_infos: [
+            {
+              field_schema: formatGrpcFieldSchema(data.field, schemaTypes),
+              index_name: data.index_name || '',
+              extra_params: parseToKeyValue(data.extra_params, true),
+            },
+          ],
+          func_schema: [formatFunctionSchema(data.function)],
+          do_physical_backfill: !!data.do_physical_backfill,
+        },
+      },
+    };
+
+    if (data.db_name) {
+      req.db_name = data.db_name;
+    }
+
+    const result = await promisify(
+      this.channelPool,
+      'AlterCollectionSchema',
+      req,
+      data.timeout || this.timeout
+    );
+
+    this.collectionInfoCache.delete(
+      `${data.db_name || this.metadata.get(METADATA.DATABASE)}:${
+        data.collection_name
+      }`
+    );
+
+    return result;
+  }
+
+  /**
+   * Add a BM25 function-backed sparse vector field to an existing collection.
+   *
+   * This is a convenience wrapper around alterCollectionSchema. Create indexes
+   * separately after the schema change succeeds.
+   *
+   * @param {AddFunctionFieldReq} data - The request parameters.
+   * @returns {Promise<ResStatus>} The AlterCollectionSchema alter status.
+   */
+  async addFunctionField(data: AddFunctionFieldReq): Promise<ResStatus> {
+    if (!data.field) {
+      throw new Error(ERROR_REASONS.FUNCTION_FIELD_SCHEMA_IS_REQUIRED);
+    }
+
+    if (!data.function) {
+      throw new Error(ERROR_REASONS.FUNCTION_SCHEMA_IS_REQUIRED);
+    }
+
+    const functionType =
+      typeof data.function.type === 'number'
+        ? data.function.type
+        : FunctionType[data.function.type as keyof typeof FunctionType];
+    if (functionType !== FunctionType.BM25) {
+      throw new Error(ERROR_REASONS.ADD_FUNCTION_FIELD_TYPE_NOT_SUPPORTED);
+    }
+
+    const fieldType =
+      typeof data.field.data_type === 'number'
+        ? data.field.data_type
+        : DataType[data.field.data_type as keyof typeof DataType];
+    if (fieldType !== DataType.SparseFloatVector) {
+      throw new Error(
+        ERROR_REASONS.ADD_FUNCTION_FIELD_OUTPUT_TYPE_NOT_SUPPORTED
+      );
+    }
+
+    const result = await this.alterCollectionSchema(data);
+    return result.alter_status;
   }
 
   /**

--- a/milvus/types/Collection.ts
+++ b/milvus/types/Collection.ts
@@ -347,6 +347,23 @@ export interface DropCollectionFunctionReq extends collectionNameReq {
   function_name: string; // required, function name
 }
 
+export interface AlterCollectionSchemaReq extends collectionNameReq {
+  collection_name: string; // required, collection name
+  db_name?: string; // optional, db name
+  field: FieldType; // required, function output field schema to add
+  function: FunctionObject; // required, function schema to add
+  do_physical_backfill?: boolean; // optional, whether Milvus should backfill existing data
+  index_name?: string; // optional, index name for the new field
+  extra_params?: Properties; // optional, field info extra params
+}
+
+export interface AlterCollectionSchemaResponse {
+  alter_status: ResStatus;
+  index_status?: ResStatus;
+}
+
+export interface AddFunctionFieldReq extends AlterCollectionSchemaReq {}
+
 export enum RefreshExternalCollectionState {
   RefreshPending = 'RefreshPending',
   RefreshInProgress = 'RefreshInProgress',

--- a/test/grpc/FullTextSearch.spec.ts
+++ b/test/grpc/FullTextSearch.spec.ts
@@ -18,6 +18,7 @@ import {
 const milvusClient = new MilvusClient({ address: IP, logLevel: 'info' });
 const COLLECTION = GENERATE_NAME();
 const COLLECTION_FOR_FUNCTION_OPS = GENERATE_NAME();
+const COLLECTION_FOR_ADD_FUNCTION_FIELD = GENERATE_NAME();
 const dbParam = {
   db_name: 'FullTextSearch',
 };
@@ -92,6 +93,9 @@ describe(`FulltextSearch API`, () => {
     });
     await milvusClient.dropCollection({
       collection_name: COLLECTION_FOR_FUNCTION_OPS,
+    });
+    await milvusClient.dropCollection({
+      collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
     });
     await milvusClient.dropDatabase(dbParam);
   });
@@ -701,6 +705,273 @@ describe(`FulltextSearch API`, () => {
       // Note: Drop operation may be idempotent and return success even if function doesn't exist
       // This is acceptable behavior, so we just verify the operation completes
       expect(dropFunction).toBeDefined();
+    });
+  });
+
+  describe('Add Function Field Operations', () => {
+    beforeAll(async () => {
+      await milvusClient.createCollection({
+        collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+        consistency_level: 'Strong',
+        fields: [
+          {
+            name: 'id',
+            data_type: DataType.Int64,
+            is_primary_key: true,
+            autoID: false,
+          },
+          {
+            name: 'text',
+            data_type: DataType.VarChar,
+            max_length: 128,
+            enable_analyzer: true,
+          },
+          {
+            name: 'vector',
+            data_type: DataType.FloatVector,
+            dim: 4,
+          },
+        ],
+      });
+    });
+
+    it(`Alter collection schema should add BM25 function field`, async () => {
+      const res = await milvusClient.alterCollectionSchema({
+        db_name: dbParam.db_name,
+        collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+        index_name: 'sparse_index',
+        extra_params: { metric_type: MetricType.BM25 },
+        field: {
+          name: 'sparse',
+          data_type: DataType.SparseFloatVector,
+          is_function_output: true,
+        },
+        function: {
+          name: 'bm25_added',
+          description: 'bm25 function added via alter schema',
+          type: FunctionType.BM25,
+          input_field_names: ['text'],
+          output_field_names: ['sparse'],
+          params: {},
+        },
+      });
+
+      expect(res.alter_status.error_code).toEqual(ErrorCode.SUCCESS);
+
+      const describe = await milvusClient.describeCollection({
+        collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+        cache: false,
+      });
+
+      const sparseField = describe.schema.fields.find(f => f.name === 'sparse');
+      expect(sparseField).toBeDefined();
+      expect(sparseField!.is_function_output).toEqual(true);
+      expect(sparseField!.data_type).toEqual('SparseFloatVector');
+
+      const func = describe.schema.functions.find(f => f.name === 'bm25_added');
+      expect(func).toBeDefined();
+      expect(func!.type).toEqual('BM25');
+      expect(func!.input_field_names).toEqual(['text']);
+      expect(func!.output_field_names).toEqual(['sparse']);
+    });
+
+    it(`Add function field should success`, async () => {
+      const res = await milvusClient.addFunctionField({
+        collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+        field: {
+          name: 'sparse2',
+          data_type: DataType.SparseFloatVector,
+          is_function_output: true,
+        },
+        function: {
+          name: 'bm25_added_by_wrapper',
+          description: 'bm25 function added via addFunctionField',
+          type: FunctionType.BM25,
+          input_field_names: ['text'],
+          output_field_names: ['sparse2'],
+          params: {},
+        },
+      });
+
+      expect(res.error_code).toEqual(ErrorCode.SUCCESS);
+
+      const describe = await milvusClient.describeCollection({
+        collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+        cache: false,
+      });
+
+      const sparseField = describe.schema.fields.find(
+        f => f.name === 'sparse2'
+      );
+      expect(sparseField).toBeDefined();
+      expect(sparseField!.is_function_output).toEqual(true);
+
+      const func = describe.schema.functions.find(
+        f => f.name === 'bm25_added_by_wrapper'
+      );
+      expect(func).toBeDefined();
+      expect(func!.type).toEqual('BM25');
+      expect(func!.output_field_names).toEqual(['sparse2']);
+    });
+
+    it(`Add function field should accept string enum values`, async () => {
+      const res = await milvusClient.addFunctionField({
+        collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+        field: {
+          name: 'sparse3',
+          data_type: 'SparseFloatVector' as any,
+          is_function_output: true,
+        },
+        function: {
+          name: 'bm25_added_with_string_enum',
+          description: 'bm25 function added with string enum values',
+          type: 'BM25' as any,
+          input_field_names: ['text'],
+          output_field_names: ['sparse3'],
+          params: {},
+        },
+      });
+
+      expect(res.error_code).toEqual(ErrorCode.SUCCESS);
+
+      const describe = await milvusClient.describeCollection({
+        collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+        cache: false,
+      });
+
+      const sparseField = describe.schema.fields.find(
+        f => f.name === 'sparse3'
+      );
+      expect(sparseField).toBeDefined();
+      expect(sparseField!.is_function_output).toEqual(true);
+    });
+
+    it(`Alter collection schema should reject missing field`, async () => {
+      try {
+        await milvusClient.alterCollectionSchema({
+          collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+          function: {
+            name: 'missing_field',
+            type: FunctionType.BM25,
+            input_field_names: ['text'],
+            output_field_names: ['missing_field'],
+            params: {},
+          },
+        } as any);
+        expect(true).toBe(false);
+      } catch (error) {
+        expect((error as Error).message).toEqual(
+          ERROR_REASONS.FUNCTION_FIELD_SCHEMA_IS_REQUIRED
+        );
+      }
+    });
+
+    it(`Alter collection schema should reject missing function`, async () => {
+      try {
+        await milvusClient.alterCollectionSchema({
+          collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+          field: {
+            name: 'missing_function',
+            data_type: DataType.SparseFloatVector,
+            is_function_output: true,
+          },
+        } as any);
+        expect(true).toBe(false);
+      } catch (error) {
+        expect((error as Error).message).toEqual(
+          ERROR_REASONS.FUNCTION_SCHEMA_IS_REQUIRED
+        );
+      }
+    });
+
+    it(`Add function field should reject missing field`, async () => {
+      try {
+        await milvusClient.addFunctionField({
+          collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+          function: {
+            name: 'missing_field_wrapper',
+            type: FunctionType.BM25,
+            input_field_names: ['text'],
+            output_field_names: ['missing_field_wrapper'],
+            params: {},
+          },
+        } as any);
+        expect(true).toBe(false);
+      } catch (error) {
+        expect((error as Error).message).toEqual(
+          ERROR_REASONS.FUNCTION_FIELD_SCHEMA_IS_REQUIRED
+        );
+      }
+    });
+
+    it(`Add function field should reject missing function`, async () => {
+      try {
+        await milvusClient.addFunctionField({
+          collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+          field: {
+            name: 'missing_function_wrapper',
+            data_type: DataType.SparseFloatVector,
+            is_function_output: true,
+          },
+        } as any);
+        expect(true).toBe(false);
+      } catch (error) {
+        expect((error as Error).message).toEqual(
+          ERROR_REASONS.FUNCTION_SCHEMA_IS_REQUIRED
+        );
+      }
+    });
+
+    it(`Add function field should reject unsupported function type`, async () => {
+      try {
+        await milvusClient.addFunctionField({
+          collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+          field: {
+            name: 'dense',
+            data_type: DataType.FloatVector,
+            dim: 4,
+            is_function_output: true,
+          },
+          function: {
+            name: 'rerank_invalid',
+            type: FunctionType.RERANK,
+            input_field_names: ['text'],
+            output_field_names: ['dense'],
+            params: {},
+          },
+        });
+        expect(true).toBe(false);
+      } catch (error) {
+        expect((error as Error).message).toEqual(
+          ERROR_REASONS.ADD_FUNCTION_FIELD_TYPE_NOT_SUPPORTED
+        );
+      }
+    });
+
+    it(`Add function field should reject unsupported output field type`, async () => {
+      try {
+        await milvusClient.addFunctionField({
+          collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+          field: {
+            name: 'dense',
+            data_type: DataType.FloatVector,
+            dim: 4,
+            is_function_output: true,
+          },
+          function: {
+            name: 'bm25_invalid_output',
+            type: FunctionType.BM25,
+            input_field_names: ['text'],
+            output_field_names: ['dense'],
+            params: {},
+          },
+        });
+        expect(true).toBe(false);
+      } catch (error) {
+        expect((error as Error).message).toEqual(
+          ERROR_REASONS.ADD_FUNCTION_FIELD_OUTPUT_TYPE_NOT_SUPPORTED
+        );
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- add alterCollectionSchema wrapper for Milvus 3.0-beta function field schema changes
- add addFunctionField convenience wrapper with BM25 sparse output validation
- add e2e coverage for success paths, string enum input, and validation failures

## Tests
- NODE_ENV=dev npx jest test/grpc/FullTextSearch.spec.ts --runInBand
- NODE_ENV=dev npx jest test/grpc/FullTextSearch.spec.ts --runInBand --coverage --collectCoverageFrom=milvus/grpc/Collection.ts --collectCoverageFrom=milvus/types/Collection.ts --collectCoverageFrom=milvus/const/error.ts --coverageReporters=json --coverageReporters=json-summary --coverageReporters=text
- changed statements: 28/28 = 100.00%
- changed branches: 17/17 = 100.00%
- npm run build