### PR TITLE
Add file resource wrappers

### DIFF
--- a/milvus/grpc/GrpcClient.ts
+++ b/milvus/grpc/GrpcClient.ts
@@ -29,6 +29,11 @@ import {
   DEFAULT_POOL_MIN,
   RunAnalyzerRequest,
   RunAnalyzerResponse,
+  ResStatus,
+  AddFileResourceReq,
+  RemoveFileResourceReq,
+  ListFileResourcesReq,
+  ListFileResourcesResponse,
   fetchTopology,
   getPrimaryCluster,
   TopologyRefresher,
@@ -493,6 +498,55 @@ export class GRPCClient extends User {
         analyzer_names: data.analyzer_names,
       },
       this.timeout
+    );
+  }
+
+  /**
+   * Adds a file resource to Milvus metadata.
+   * @param {AddFileResourceReq} data - The file resource name and server-visible path.
+   * @returns {Promise<ResStatus>} - A Promise that resolves with the operation status.
+   */
+  async addFileResource(data: AddFileResourceReq): Promise<ResStatus> {
+    return await promisify(
+      this.channelPool,
+      'AddFileResource',
+      {
+        name: data.name,
+        path: data.path,
+      },
+      data.timeout || this.timeout
+    );
+  }
+
+  /**
+   * Removes a file resource from Milvus metadata.
+   * @param {RemoveFileResourceReq} data - The file resource name.
+   * @returns {Promise<ResStatus>} - A Promise that resolves with the operation status.
+   */
+  async removeFileResource(data: RemoveFileResourceReq): Promise<ResStatus> {
+    return await promisify(
+      this.channelPool,
+      'RemoveFileResource',
+      {
+        name: data.name,
+      },
+      data.timeout || this.timeout
+    );
+  }
+
+  /**
+   * Lists file resources registered in Milvus metadata.
+   * @param {ListFileResourcesReq} [data] - Optional request parameters.
+   * @returns {Promise<ListFileResourcesResponse>} - A Promise that resolves with file resources.
+   */
+  async listFileResources(
+    data: ListFileResourcesReq = {}
+  ): Promise<ListFileResourcesResponse> {
+    return await promisify(
+      this.channelPool,
+      'ListFileResources',
+      {},
+      data.timeout || this.timeout
     );
   }
 }

--- a/milvus/types/Client.ts
+++ b/milvus/types/Client.ts
@@ -1,7 +1,7 @@
 import { ChannelOptions } from '@grpc/grpc-js';
 import { Options as LoaderOption } from '@grpc/proto-loader';
 import { Options } from 'generic-pool';
-import { ResStatus } from './';
+import { GrpcTimeOut, ResStatus } from './Common';
 
 /**
  * Configuration options for the Milvus client.
@@ -113,4 +113,26 @@ export type AnalyzerResult = {
 export interface RunAnalyzerResponse {
   status: ResStatus;
   results: AnalyzerResult[];
+}
+
+export interface AddFileResourceReq extends GrpcTimeOut {
+  name: string;
+  path: string;
+}
+
+export interface RemoveFileResourceReq extends GrpcTimeOut {
+  name: string;
+}
+
+export interface ListFileResourcesReq extends GrpcTimeOut {}
+
+export interface FileResourceInfo {
+  id: string;
+  name: string;
+  path: string;
+}
+
+export interface ListFileResourcesResponse {
+  status: ResStatus;
+  resources: FileResourceInfo[];
 }

--- a/test/grpc/FileResource.spec.ts
+++ b/test/grpc/FileResource.spec.ts
@@ -1,0 +1,116 @@
+import { Client as MinioClient } from 'minio';
+import { execSync } from 'child_process';
+import { ErrorCode, MilvusClient } from '../../milvus';
+import { GENERATE_NAME, IP } from '../tools';
+
+const milvusClient = new MilvusClient({ address: IP, logLevel: 'info' });
+let minioClient: MinioClient;
+
+const BUCKET_NAME = 'a-bucket';
+const RESOURCE_NAME = GENERATE_NAME('file_resource');
+const MISSING_RESOURCE_NAME = GENERATE_NAME('missing_file_resource');
+const OBJECT_NAME = `node-sdk-file-resource/${RESOURCE_NAME}.txt`;
+const MISSING_OBJECT_NAME = `node-sdk-file-resource/${MISSING_RESOURCE_NAME}.txt`;
+
+const createMinioClient = (endPoint: string) =>
+  new MinioClient({
+    endPoint,
+    port: 9000,
+    useSSL: false,
+    accessKey: 'minioadmin',
+    secretKey: 'minioadmin',
+  });
+
+const getMilvusMinioContainerIP = () =>
+  execSync(
+    `docker inspect milvus-minio --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'`,
+    { encoding: 'utf8' }
+  ).trim();
+
+const putTestObject = async () => {
+  const candidates = [
+    () => process.env.FILE_RESOURCE_MINIO_ENDPOINT || '127.0.0.1',
+    getMilvusMinioContainerIP,
+  ];
+
+  let lastError: unknown;
+  for (const getEndPoint of candidates) {
+    try {
+      const endPoint = getEndPoint();
+      minioClient = createMinioClient(endPoint);
+      await minioClient.putObject(
+        BUCKET_NAME,
+        OBJECT_NAME,
+        Buffer.from('node sdk file resource test\n')
+      );
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+};
+
+describe('FileResource API', () => {
+  beforeAll(async () => {
+    await putTestObject();
+  });
+
+  afterAll(async () => {
+    try {
+      await milvusClient.removeFileResource({ name: RESOURCE_NAME });
+    } catch {
+      // best-effort cleanup
+    }
+
+    try {
+      await minioClient.removeObject(BUCKET_NAME, OBJECT_NAME);
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  it('should list file resources', async () => {
+    const res = await milvusClient.listFileResources();
+
+    expect(res.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(Array.isArray(res.resources)).toEqual(true);
+  });
+
+  it('should reject add file resource with missing object path', async () => {
+    const res = await milvusClient.addFileResource({
+      name: MISSING_RESOURCE_NAME,
+      path: MISSING_OBJECT_NAME,
+    });
+
+    expect(res.error_code).not.toEqual(ErrorCode.SUCCESS);
+  });
+
+  it('should add, list, and remove file resource', async () => {
+    const add = await milvusClient.addFileResource({
+      name: RESOURCE_NAME,
+      path: OBJECT_NAME,
+      timeout: 10000,
+    });
+    expect(add.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const list = await milvusClient.listFileResources({ timeout: 10000 });
+    expect(list.status.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const resource = list.resources.find(item => item.name === RESOURCE_NAME);
+    expect(resource).toBeDefined();
+    expect(resource!.path).toEqual(OBJECT_NAME);
+
+    const remove = await milvusClient.removeFileResource({
+      name: RESOURCE_NAME,
+      timeout: 10000,
+    });
+    expect(remove.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const listAfterRemove = await milvusClient.listFileResources();
+    expect(
+      listAfterRemove.resources.some(item => item.name === RESOURCE_NAME)
+    ).toEqual(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add gRPC wrappers for AddFileResource, RemoveFileResource, and ListFileResources
- add TypeScript request/response types for file resource APIs
- add FileResource e2e coverage for list, missing object failure, and add/list/remove lifecycle

## Tests
- NODE_ENV=dev npx jest test/grpc/FileResource.spec.ts --runInBand
- NODE_ENV=dev npx jest test/grpc/FileResource.spec.ts --runInBand --coverage --collectCoverageFrom=milvus/grpc/GrpcClient.ts --collectCoverageFrom=milvus/types/Client.ts --coverageReporters=json --coverageReporters=json-summary --coverageReporters=text
- changed statements: 3/3 = 100.00%
- changed branches: 7/7 = 100.00%
- npm run build
- git diff --check