### PR TITLE
fix: add `types` field to package.json for TypeScript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "milvusVersion": "v3.0-beta-amd64",
   "version": "3.0.3",
   "main": "dist/milvus",
+  "types": "dist/milvus/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Problem

The package emits TypeScript declaration files via `tsc --declaration` during build (see `dist/milvus/index.d.ts`), but `package.json` is missing the `types` field. As a result:

- TypeScript / VSCode cannot resolve types for `@zilliz/milvus2-sdk-node`
- `import { MilvusClient, MetricType } from "@zilliz/milvus2-sdk-node"` works at runtime but provides **no IntelliSense, no auto-completion, no type checking**
- Users have to manually write `declare module` shims or patch `node_modules`

## Fix

Add a single line to `package.json`:

```diff
   "main": "dist/milvus",
+  "types": "dist/milvus/index.d.ts",
   "files": [
     "dist"
   ],
```

`dist/milvus/index.d.ts` is the entry-point declaration file already produced by the existing `build` script (`tsc --declaration && node build.js`), so no source code changes are required.

## Verification

After this change, in any TypeScript project:

```ts
import { MilvusClient, MetricType, DataType, IndexType } from "@zilliz/milvus2-sdk-node";

const client = new MilvusClient({ address: "localhost:19530" });
//    ^? now shows the full MilvusClient type with all available methods
```

Editors will resolve the types automatically.

## Notes

- No runtime behavior change
- No new files added
- The `build` script already produces the referenced `index.d.ts`, so this is a metadata-only fix