### PR TITLE
feat: support collection schema evolution APIs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,12 @@ jobs:
         env:
           MILVUS_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
+          if [ -n "${MILVUS_OPENAI_API_KEY}" ]; then
+            echo "MILVUS_OPENAI_ENABLED=1" >> "$GITHUB_ENV"
+          else
+            echo "MILVUS_OPENAI_ENABLED=0" >> "$GITHUB_ENV"
+          fi
+
           wget https://raw.githubusercontent.com/milvus-io/milvus/master/deployments/docker/standalone/docker-compose.yml -O docker-compose.yml
           sed -i -e "s/milvusdb.*$/milvusdb\/milvus:${{ steps.info.outputs.milvusVersion }}/g" docker-compose.yml
 
@@ -53,6 +59,9 @@ jobs:
               environment:
                 MQ_TYPE: rocksmq
                 MILVUS_OPENAI_API_KEY: ${MILVUS_OPENAI_API_KEY}
+                COMMON_STORAGE_USELOONFFI: "true"
+                DATACOORD_COMPACTION_BUMPSCHEMAVERSION_ENABLED: "true"
+                DATACOORD_COMPACTION_STORAGEVERSION_ENABLED: "true"
           EOF
 
           mkdir -p volumes/etcd volumes/minio volumes/milvus

--- a/milvus/const/error.ts
+++ b/milvus/const/error.ts
@@ -72,9 +72,21 @@ export const ERROR_REASONS = {
   FUNCTION_NAME_IS_REQUIRED: 'The `function_name` property is missing.',
   FUNCTION_FIELD_SCHEMA_IS_REQUIRED: 'The `field` property is missing.',
   ADD_FUNCTION_FIELD_TYPE_NOT_SUPPORTED:
-    'The `function.type` property only supports FunctionType.BM25.',
+    'The `function.type` property only supports FunctionType.BM25 and FunctionType.MINHASH.',
   ADD_FUNCTION_FIELD_OUTPUT_TYPE_NOT_SUPPORTED:
-    'The `field.data_type` property only supports DataType.SparseFloatVector.',
+    'FunctionType.BM25 requires DataType.SparseFloatVector and FunctionType.MINHASH requires DataType.BinaryVector.',
+  ADD_FUNCTION_FIELD_INDEX_TYPE_IS_REQUIRED:
+    'An explicit `index_type` is required for the bound index.',
+  ADD_FUNCTION_FIELD_AUTOINDEX_NOT_SUPPORTED:
+    'The bound index does not support IndexType.AUTOINDEX.',
+  ADD_FUNCTION_FIELD_DUPLICATED_INDEX_PARAM:
+    'Duplicated bound index parameters are not allowed.',
+  ADD_COLLECTION_FIELD_VECTOR_NULLABLE_REQUIRED:
+    'Adding a vector field to an existing collection requires nullable=true.',
+  DROP_COLLECTION_FIELD_IDENTIFIER_IS_REQUIRED:
+    'Specify exactly one valid `field_name` or `field_id`.',
+  ALTER_COLLECTION_SCHEMA_STATUS_IS_REQUIRED:
+    'The AlterCollectionSchema response is missing `alter_status`.',
 };
 
 export enum ErrorCode {

--- a/milvus/const/milvus.ts
+++ b/milvus/const/milvus.ts
@@ -334,6 +334,8 @@ export enum FunctionType {
   BM25 = 1,
   TEXTEMBEDDING = 2,
   RERANK = 3,
+  MINHASH = 4,
+  MOLFINGERPRINT = 5,
 }
 
 export const VectorDataTypes = [

--- a/milvus/grpc/Collection.ts
+++ b/milvus/grpc/Collection.ts
@@ -1,5 +1,6 @@
 import { Database } from './Database';
 import { LRUCache } from 'lru-cache';
+import { status as grpcStatus } from '@grpc/grpc-js';
 import {
   ERROR_REASONS,
   ConsistencyLevelEnum,
@@ -47,6 +48,7 @@ import {
   sleep,
   formatCollectionSchema,
   formatDescribedCol,
+  getDataKey,
   validatePartitionNumbers,
   METADATA,
   AlterCollectionReq,
@@ -60,6 +62,7 @@ import {
   AlterCollectionFieldPropertiesReq,
   RefreshLoadReq,
   isVectorType,
+  convertToDataType,
   AddCollectionFieldReq,
   AddCollectionFieldsReq,
   checkCollectionFieldsWithOptions,
@@ -71,6 +74,8 @@ import {
   AlterCollectionSchemaReq,
   AlterCollectionSchemaResponse,
   AddFunctionFieldReq,
+  DropCollectionFieldReq,
+  DropFunctionFieldReq,
   RefreshExternalCollectionReq,
   RefreshExternalCollectionResponse,
   GetRefreshExternalCollectionProgressReq,
@@ -93,6 +98,8 @@ import {
   PinSnapshotDataResponse,
   UnpinSnapshotDataReq,
   FunctionType,
+  IndexType,
+  collectionNameReq,
 } from '../';
 
 const formatGrpcFieldSchema = (
@@ -100,6 +107,13 @@ const formatGrpcFieldSchema = (
   schemaTypes: { fieldSchemaType: any }
 ): Record<string, any> => {
   const schema = formatFieldSchema(field, schemaTypes);
+  let defaultValue = schema.defaultValue;
+  if (defaultValue) {
+    defaultValue = {
+      [getDataKey(schema.dataType)]:
+        defaultValue[getDataKey(schema.dataType, true)],
+    };
+  }
 
   return {
     fieldID: schema.fieldID,
@@ -112,7 +126,7 @@ const formatGrpcFieldSchema = (
     autoID: schema.autoID,
     state: schema.state,
     element_type: schema.elementType,
-    default_value: schema.defaultValue,
+    default_value: defaultValue,
     is_dynamic: schema.isDynamic,
     is_partition_key: schema.isPartitionKey,
     is_clustering_key: schema.isClusteringKey,
@@ -142,6 +156,50 @@ export class Collection extends Database {
     updateAgeOnGet: false,
     updateAgeOnHas: false,
   });
+
+  private getCollectionInfoCacheKey(data: collectionNameReq): string {
+    return `${data.db_name || this.metadata.get(METADATA.DATABASE)}:${
+      data.collection_name
+    }`;
+  }
+
+  private invalidateCollectionInfo(data: collectionNameReq): void {
+    this.collectionInfoCache.delete(this.getCollectionInfoCacheKey(data));
+  }
+
+  private async callAlterCollectionSchema(
+    data: collectionNameReq,
+    action: Record<string, any>
+  ): Promise<AlterCollectionSchemaResponse> {
+    checkCollectionName(data);
+
+    const req: any = {
+      collection_name: data.collection_name,
+      action,
+    };
+
+    if (data.db_name) {
+      req.db_name = data.db_name;
+    }
+
+    const result = await promisify(
+      this.channelPool,
+      'AlterCollectionSchema',
+      req,
+      data.timeout || this.timeout,
+      data
+    );
+
+    if (!result?.alter_status) {
+      throw new Error(ERROR_REASONS.ALTER_COLLECTION_SCHEMA_STATUS_IS_REQUIRED);
+    }
+
+    if (result.alter_status.error_code === ErrorCode.SUCCESS) {
+      this.invalidateCollectionInfo(data);
+    }
+
+    return result;
+  }
 
   /**
    * Creates a new collection in Milvus.
@@ -310,6 +368,17 @@ export class Collection extends Database {
    * ```
    */
   async addCollectionField(data: AddCollectionFieldReq): Promise<ResStatus> {
+    checkCollectionName(data);
+
+    if (
+      isVectorType(convertToDataType(data.field.data_type)) &&
+      data.field.nullable !== true
+    ) {
+      throw new Error(
+        ERROR_REASONS.ADD_COLLECTION_FIELD_VECTOR_NULLABLE_REQUIRED
+      );
+    }
+
     // Get the CollectionSchemaType and FieldSchemaType from the schemaProto object.
     const schemaTypes = {
       fieldSchemaType: this.schemaProto.lookupType(
@@ -317,13 +386,30 @@ export class Collection extends Database {
       ),
     };
 
+    try {
+      const result = await this.callAlterCollectionSchema(data, {
+        add_request: {
+          field_infos: [
+            {
+              field_schema: formatGrpcFieldSchema(data.field, schemaTypes),
+            },
+          ],
+        },
+      });
+      return result.alter_status;
+    } catch (error) {
+      if ((error as { code?: number })?.code !== grpcStatus.UNIMPLEMENTED) {
+        throw error;
+      }
+    }
+
     // Create the payload object with the collection_name, description, and fields.
     // it should follow CollectionSchema in schema.proto
     const payload = formatFieldSchema(data.field, schemaTypes);
     const schema = schemaTypes.fieldSchemaType.create(payload);
     const schemaBytes = schemaTypes.fieldSchemaType.encode(schema).finish();
 
-    return await promisify(
+    const result = await promisify(
       this.channelPool,
       'AddCollectionField',
       {
@@ -332,6 +418,12 @@ export class Collection extends Database {
       },
       data.timeout || this.timeout
     );
+
+    if (result.error_code === ErrorCode.SUCCESS) {
+      this.invalidateCollectionInfo(data);
+    }
+
+    return result;
   }
 
   /**
@@ -668,9 +760,7 @@ export class Collection extends Database {
   ): Promise<DescribeCollectionResponse> {
     checkCollectionName(data);
 
-    const key = `${this.metadata.get(METADATA.DATABASE)}:${
-      data.collection_name
-    }`;
+    const key = this.getCollectionInfoCacheKey(data);
 
     // if we have cache return cache data
     if (this.collectionInfoCache.has(key) && data.cache === true) {
@@ -1003,9 +1093,7 @@ export class Collection extends Database {
       data.timeout || this.timeout
     );
 
-    this.collectionInfoCache.delete(
-      `${this.metadata.get(METADATA.DATABASE)}:${data.collection_name}`
-    );
+    this.invalidateCollectionInfo(data);
     return promise;
   }
   // alias
@@ -1574,8 +1662,8 @@ export class Collection extends Database {
   /**
    * Alter collection schema by adding a function-backed output field.
    *
-   * Milvus 3.0-beta supports the add path for BM25 function fields through
-   * AlterCollectionSchema. It does not create an index automatically.
+   * For vector function outputs, provide bound-index metadata with an explicit
+   * index_type. Milvus creates the bound index atomically with the schema change.
    *
    * @param {AlterCollectionSchemaReq} data - The request parameters.
    * @param {string} data.collection_name - The collection name.
@@ -1606,48 +1694,27 @@ export class Collection extends Database {
       ),
     };
 
-    const req: any = {
-      collection_name: data.collection_name,
-      action: {
-        add_request: {
-          field_infos: [
-            {
-              field_schema: formatGrpcFieldSchema(data.field, schemaTypes),
-              index_name: data.index_name || '',
-              extra_params: parseToKeyValue(data.extra_params, true),
-            },
-          ],
-          func_schema: [formatFunctionSchema(data.function)],
-          do_physical_backfill: !!data.do_physical_backfill,
-        },
+    return await this.callAlterCollectionSchema(data, {
+      add_request: {
+        field_infos: [
+          {
+            field_schema: formatGrpcFieldSchema(data.field, schemaTypes),
+            index_name: data.index_name || '',
+            extra_params: parseToKeyValue(data.extra_params, true),
+          },
+        ],
+        func_schema: [formatFunctionSchema(data.function)],
+        do_physical_backfill: !!data.do_physical_backfill,
       },
-    };
-
-    if (data.db_name) {
-      req.db_name = data.db_name;
-    }
-
-    const result = await promisify(
-      this.channelPool,
-      'AlterCollectionSchema',
-      req,
-      data.timeout || this.timeout
-    );
-
-    this.collectionInfoCache.delete(
-      `${data.db_name || this.metadata.get(METADATA.DATABASE)}:${
-        data.collection_name
-      }`
-    );
-
-    return result;
+    });
   }
 
   /**
-   * Add a BM25 function-backed sparse vector field to an existing collection.
+   * Add a function-backed vector field and its bound index to an existing collection.
    *
-   * This is a convenience wrapper around alterCollectionSchema. Create indexes
-   * separately after the schema change succeeds.
+   * BM25 requires a SparseFloatVector output field. MinHash requires a
+   * BinaryVector output field. The bound index must provide an explicit
+   * index_type and cannot use AUTOINDEX.
    *
    * @param {AddFunctionFieldReq} data - The request parameters.
    * @returns {Promise<ResStatus>} The AlterCollectionSchema alter status.
@@ -1664,27 +1731,140 @@ export class Collection extends Database {
     const functionType =
       typeof data.function.type === 'number'
         ? data.function.type
-        : FunctionType[data.function.type as keyof typeof FunctionType];
-    if (functionType !== FunctionType.BM25) {
+        : (FunctionType[data.function.type as keyof typeof FunctionType] ??
+          FunctionType[
+            String(
+              data.function.type
+            ).toUpperCase() as keyof typeof FunctionType
+          ]);
+    if (
+      functionType !== FunctionType.BM25 &&
+      functionType !== FunctionType.MINHASH
+    ) {
       throw new Error(ERROR_REASONS.ADD_FUNCTION_FIELD_TYPE_NOT_SUPPORTED);
     }
 
-    const fieldType =
-      typeof data.field.data_type === 'number'
-        ? data.field.data_type
-        : DataType[data.field.data_type as keyof typeof DataType];
-    if (fieldType !== DataType.SparseFloatVector) {
+    const fieldType = convertToDataType(data.field.data_type);
+    if (
+      (functionType === FunctionType.BM25 &&
+        fieldType !== DataType.SparseFloatVector) ||
+      (functionType === FunctionType.MINHASH &&
+        fieldType !== DataType.BinaryVector)
+    ) {
       throw new Error(
         ERROR_REASONS.ADD_FUNCTION_FIELD_OUTPUT_TYPE_NOT_SUPPORTED
       );
     }
 
-    const result = await this.alterCollectionSchema(data);
+    const extraParams = { ...(data.extra_params || {}) };
+    for (const key of Object.keys(extraParams)) {
+      if (typeof extraParams[key] === 'undefined') {
+        delete extraParams[key];
+      }
+    }
+
+    const nestedParams = extraParams.params;
+    let nestedIndexParams: Record<string, any> | undefined;
+    if (
+      nestedParams &&
+      typeof nestedParams === 'object' &&
+      !Array.isArray(nestedParams)
+    ) {
+      nestedIndexParams = nestedParams;
+    } else if (typeof nestedParams === 'string') {
+      try {
+        const parsed = JSON.parse(nestedParams);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          nestedIndexParams = parsed;
+        }
+      } catch {
+        // Leave malformed params for Milvus to validate.
+      }
+    }
+
+    if (
+      nestedIndexParams &&
+      Object.keys(nestedIndexParams).some(key =>
+        Object.prototype.hasOwnProperty.call(extraParams, key)
+      )
+    ) {
+      throw new Error(ERROR_REASONS.ADD_FUNCTION_FIELD_DUPLICATED_INDEX_PARAM);
+    }
+
+    const indexType = extraParams.index_type || nestedIndexParams?.index_type;
+    if (typeof indexType !== 'string' || indexType.length === 0) {
+      throw new Error(ERROR_REASONS.ADD_FUNCTION_FIELD_INDEX_TYPE_IS_REQUIRED);
+    }
+    if (indexType === IndexType.AUTOINDEX) {
+      throw new Error(ERROR_REASONS.ADD_FUNCTION_FIELD_AUTOINDEX_NOT_SUPPORTED);
+    }
+
+    const result = await this.alterCollectionSchema({
+      ...data,
+      extra_params: extraParams,
+    });
+    return result.alter_status;
+  }
+
+  /**
+   * Drop a field from an existing collection by name or ID.
+   *
+   * @param {DropCollectionFieldReq} data - The request parameters.
+   * @returns {Promise<ResStatus>} The AlterCollectionSchema alter status.
+   */
+  async dropCollectionField(data: DropCollectionFieldReq): Promise<ResStatus> {
+    checkCollectionName(data);
+
+    const validFieldName =
+      typeof data.field_name === 'string' && data.field_name.length > 0;
+    const validFieldID =
+      (typeof data.field_id === 'number' &&
+        Number.isSafeInteger(data.field_id) &&
+        data.field_id > 0) ||
+      (typeof data.field_id === 'string' &&
+        /^[1-9]\d*$/.test(data.field_id) &&
+        BigInt(data.field_id) <= BigInt('9223372036854775807'));
+
+    if (validFieldName === validFieldID) {
+      throw new Error(
+        ERROR_REASONS.DROP_COLLECTION_FIELD_IDENTIFIER_IS_REQUIRED
+      );
+    }
+
+    const result = await this.callAlterCollectionSchema(data, {
+      drop_request: validFieldName
+        ? { field_name: data.field_name }
+        : { field_id: data.field_id },
+    });
+    return result.alter_status;
+  }
+
+  /**
+   * Drop a function and its output fields and indexes from a collection.
+   *
+   * @param {DropFunctionFieldReq} data - The request parameters.
+   * @returns {Promise<ResStatus>} The AlterCollectionSchema alter status.
+   */
+  async dropFunctionField(data: DropFunctionFieldReq): Promise<ResStatus> {
+    checkCollectionName(data);
+
+    if (!data.function_name) {
+      throw new Error(ERROR_REASONS.FUNCTION_NAME_IS_REQUIRED);
+    }
+
+    const result = await this.callAlterCollectionSchema(data, {
+      drop_request: {
+        function_name: data.function_name,
+        drop_function_output_fields: true,
+      },
+    });
     return result.alter_status;
   }
 
   /**
    * Add a function to a collection.
+   *
+   * @deprecated Use addFunctionField instead.
    *
    * @param {AddCollectionFunctionReq} data - The request parameters.
    * @param {string} data.collection_name - The name of the collection.
@@ -1806,6 +1986,8 @@ export class Collection extends Database {
 
   /**
    * Drop a function from a collection.
+   *
+   * @deprecated Use dropFunctionField instead.
    *
    * @param {DropCollectionFunctionReq} data - The request parameters.
    * @param {string} data.collection_name - The name of the collection.

--- a/milvus/proto-json/milvus.base.ts
+++ b/milvus/proto-json/milvus.base.ts
@@ -216,6 +216,10 @@ export default {
                       "requestType": "AddCollectionFieldRequest",
                       "responseType": "common.Status"
                     },
+                    "AddCollectionStructField": {
+                      "requestType": "AddCollectionStructFieldRequest",
+                      "responseType": "common.Status"
+                    },
                     "GetFlushState": {
                       "requestType": "GetFlushStateRequest",
                       "responseType": "GetFlushStateResponse"
@@ -530,6 +534,14 @@ export default {
                     "RestoreSnapshot": {
                       "requestType": "RestoreSnapshotRequest",
                       "responseType": "RestoreSnapshotResponse"
+                    },
+                    "RestoreExternalSnapshot": {
+                      "requestType": "RestoreExternalSnapshotRequest",
+                      "responseType": "RestoreExternalSnapshotResponse"
+                    },
+                    "ExportSnapshot": {
+                      "requestType": "ExportSnapshotRequest",
+                      "responseType": "ExportSnapshotResponse"
                     },
                     "GetRestoreSnapshotState": {
                       "requestType": "GetRestoreSnapshotStateRequest",
@@ -1997,6 +2009,35 @@ export default {
                     }
                   }
                 },
+                "AddCollectionStructFieldRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeAddCollectionField",
+                    "(common.privilege_ext_obj).object_name_index": 3
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "dbName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "collectionName": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collectionID": {
+                      "type": "int64",
+                      "id": 4
+                    },
+                    "structArrayFieldSchema": {
+                      "type": "schema.StructArrayFieldSchema",
+                      "id": 5
+                    }
+                  }
+                },
                 "AddCollectionFunctionRequest": {
                   "options": {
                     "(common.privilege_ext_obj).object_type": "Global",
@@ -2202,6 +2243,13 @@ export default {
                     "(common.privilege_ext_obj).object_privilege": "PrivilegeDelete",
                     "(common.privilege_ext_obj).object_name_index": 3
                   },
+                  "oneofs": {
+                    "_namespace": {
+                      "oneof": [
+                        "namespace"
+                      ]
+                    }
+                  },
                   "fields": {
                     "base": {
                       "type": "common.MsgBase",
@@ -2236,6 +2284,13 @@ export default {
                       "keyType": "string",
                       "type": "schema.TemplateValue",
                       "id": 8
+                    },
+                    "namespace": {
+                      "type": "string",
+                      "id": 9,
+                      "options": {
+                        "proto3_optional": true
+                      }
                     }
                   }
                 },
@@ -2401,6 +2456,10 @@ export default {
                     "highlighter": {
                       "type": "common.Highlighter",
                       "id": 21
+                    },
+                    "searchAggregation": {
+                      "type": "common.SearchAggregationSpec",
+                      "id": 23
                     }
                   }
                 },
@@ -5926,6 +5985,92 @@ export default {
                     }
                   }
                 },
+                "RestoreExternalSnapshotRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Global",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeRestoreExternalSnapshot",
+                    "(common.privilege_ext_obj).object_name_index": -1
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "dbName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "targetCollectionName": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "snapshotMetadataUri": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "externalSpec": {
+                      "type": "string",
+                      "id": 5
+                    }
+                  }
+                },
+                "RestoreExternalSnapshotResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "jobId": {
+                      "type": "int64",
+                      "id": 2
+                    }
+                  }
+                },
+                "ExportSnapshotRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Global",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeExportSnapshot",
+                    "(common.privilege_ext_obj).object_name_index": -1
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "dbName": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collectionName": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "targetS3Path": {
+                      "type": "string",
+                      "id": 5
+                    },
+                    "externalSpec": {
+                      "type": "string",
+                      "id": 6
+                    }
+                  }
+                },
+                "ExportSnapshotResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "snapshotMetadataUri": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                },
                 "RestoreSnapshotState": {
                   "values": {
                     "RestoreSnapshotNone": 0,
@@ -6177,6 +6322,10 @@ export default {
                         "functionName": {
                           "type": "string",
                           "id": 3
+                        },
+                        "dropFunctionOutputFields": {
+                          "type": "bool",
+                          "id": 4
                         }
                       }
                     },
@@ -6207,10 +6356,6 @@ export default {
                     "alterStatus": {
                       "type": "common.Status",
                       "id": 1
-                    },
-                    "indexStatus": {
-                      "type": "common.Status",
-                      "id": 2
                     }
                   }
                 },
@@ -6938,6 +7083,8 @@ export default {
                     "ListRestoreSnapshotJobs": 2106,
                     "PinSnapshotData": 2107,
                     "UnpinSnapshotData": 2108,
+                    "RestoreExternalSnapshot": 2109,
+                    "ExportSnapshot": 2110,
                     "AlterCollectionSchema": 2200,
                     "RefreshExternalCollection": 2300,
                     "GetRefreshExternalCollectionProgress": 2301,
@@ -7146,7 +7293,9 @@ export default {
                     "PrivilegeGetReplicateConfiguration": 85,
                     "PrivilegeRefreshExternalCollection": 86,
                     "PrivilegePinSnapshotData": 87,
-                    "PrivilegeUnpinSnapshotData": 88
+                    "PrivilegeUnpinSnapshotData": 88,
+                    "PrivilegeRestoreExternalSnapshot": 89,
+                    "PrivilegeExportSnapshot": 90
                   }
                 },
                 "PrivilegeExt": {
@@ -7533,6 +7682,98 @@ export default {
                       "rule": "repeated",
                       "type": "KeyValuePair",
                       "id": 2
+                    }
+                  }
+                },
+                "MetricAggSpec": {
+                  "fields": {
+                    "op": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "fieldName": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                },
+                "SortSpec": {
+                  "fields": {
+                    "fieldName": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "direction": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "nullFirst": {
+                      "type": "bool",
+                      "id": 3
+                    }
+                  }
+                },
+                "TopHitsSpec": {
+                  "fields": {
+                    "size": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "sort": {
+                      "rule": "repeated",
+                      "type": "SortSpec",
+                      "id": 2
+                    }
+                  }
+                },
+                "OrderSpec": {
+                  "fields": {
+                    "key": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "direction": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "nullFirst": {
+                      "type": "bool",
+                      "id": 3
+                    }
+                  }
+                },
+                "SearchAggregationSpec": {
+                  "fields": {
+                    "fields": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 1
+                    },
+                    "size": {
+                      "type": "int64",
+                      "id": 2
+                    },
+                    "metrics": {
+                      "keyType": "string",
+                      "type": "MetricAggSpec",
+                      "id": 3
+                    },
+                    "order": {
+                      "rule": "repeated",
+                      "type": "OrderSpec",
+                      "id": 4
+                    },
+                    "topHits": {
+                      "type": "TopHitsSpec",
+                      "id": 5
+                    },
+                    "subAggregation": {
+                      "type": "SearchAggregationSpec",
+                      "id": 6
+                    },
+                    "searchSize": {
+                      "type": "int64",
+                      "id": 7
                     }
                   }
                 }
@@ -8423,6 +8664,16 @@ export default {
                       "rule": "repeated",
                       "type": "FieldData",
                       "id": 17
+                    },
+                    "aggBuckets": {
+                      "rule": "repeated",
+                      "type": "AggBucket",
+                      "id": 18
+                    },
+                    "aggTopks": {
+                      "rule": "repeated",
+                      "type": "int64",
+                      "id": 19
                     }
                   },
                   "reserved": [
@@ -8431,6 +8682,174 @@ export default {
                       16
                     ]
                   ]
+                },
+                "AggBucket": {
+                  "fields": {
+                    "key": {
+                      "rule": "repeated",
+                      "type": "BucketKeyEntry",
+                      "id": 1
+                    },
+                    "count": {
+                      "type": "int64",
+                      "id": 2
+                    },
+                    "metrics": {
+                      "keyType": "string",
+                      "type": "MetricValue",
+                      "id": 3
+                    },
+                    "hits": {
+                      "rule": "repeated",
+                      "type": "AggHit",
+                      "id": 4
+                    },
+                    "subGroups": {
+                      "rule": "repeated",
+                      "type": "AggBucket",
+                      "id": 5
+                    }
+                  }
+                },
+                "MetricValue": {
+                  "oneofs": {
+                    "value": {
+                      "oneof": [
+                        "intVal",
+                        "doubleVal",
+                        "stringVal",
+                        "boolVal"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "intVal": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "doubleVal": {
+                      "type": "double",
+                      "id": 2
+                    },
+                    "stringVal": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "boolVal": {
+                      "type": "bool",
+                      "id": 4
+                    }
+                  }
+                },
+                "BucketKeyEntry": {
+                  "oneofs": {
+                    "value": {
+                      "oneof": [
+                        "intVal",
+                        "stringVal",
+                        "boolVal"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "fieldId": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "fieldName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "intVal": {
+                      "type": "int64",
+                      "id": 3
+                    },
+                    "stringVal": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "boolVal": {
+                      "type": "bool",
+                      "id": 5
+                    }
+                  }
+                },
+                "AggHit": {
+                  "oneofs": {
+                    "pk": {
+                      "oneof": [
+                        "intPk",
+                        "strPk"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "intPk": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "strPk": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "score": {
+                      "type": "float",
+                      "id": 3
+                    },
+                    "fields": {
+                      "rule": "repeated",
+                      "type": "AggHitField",
+                      "id": 4
+                    }
+                  }
+                },
+                "AggHitField": {
+                  "oneofs": {
+                    "value": {
+                      "oneof": [
+                        "intVal",
+                        "boolVal",
+                        "floatVal",
+                        "doubleVal",
+                        "stringVal",
+                        "bytesVal"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "fieldId": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "fieldName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "intVal": {
+                      "type": "int64",
+                      "id": 3
+                    },
+                    "boolVal": {
+                      "type": "bool",
+                      "id": 4
+                    },
+                    "floatVal": {
+                      "type": "float",
+                      "id": 5
+                    },
+                    "doubleVal": {
+                      "type": "double",
+                      "id": 6
+                    },
+                    "stringVal": {
+                      "type": "string",
+                      "id": 7
+                    },
+                    "bytesVal": {
+                      "type": "bytes",
+                      "id": 8
+                    }
+                  }
                 },
                 "VectorClusteringInfo": {
                   "fields": {

--- a/milvus/proto-json/milvus.ts
+++ b/milvus/proto-json/milvus.ts
@@ -216,6 +216,10 @@ export default {
                       "requestType": "AddCollectionFieldRequest",
                       "responseType": "common.Status"
                     },
+                    "AddCollectionStructField": {
+                      "requestType": "AddCollectionStructFieldRequest",
+                      "responseType": "common.Status"
+                    },
                     "GetFlushState": {
                       "requestType": "GetFlushStateRequest",
                       "responseType": "GetFlushStateResponse"
@@ -530,6 +534,14 @@ export default {
                     "RestoreSnapshot": {
                       "requestType": "RestoreSnapshotRequest",
                       "responseType": "RestoreSnapshotResponse"
+                    },
+                    "RestoreExternalSnapshot": {
+                      "requestType": "RestoreExternalSnapshotRequest",
+                      "responseType": "RestoreExternalSnapshotResponse"
+                    },
+                    "ExportSnapshot": {
+                      "requestType": "ExportSnapshotRequest",
+                      "responseType": "ExportSnapshotResponse"
                     },
                     "GetRestoreSnapshotState": {
                       "requestType": "GetRestoreSnapshotStateRequest",
@@ -1997,6 +2009,35 @@ export default {
                     }
                   }
                 },
+                "AddCollectionStructFieldRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Collection",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeAddCollectionField",
+                    "(common.privilege_ext_obj).object_name_index": 3
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "db_name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "collection_name": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collectionID": {
+                      "type": "int64",
+                      "id": 4
+                    },
+                    "struct_array_field_schema": {
+                      "type": "schema.StructArrayFieldSchema",
+                      "id": 5
+                    }
+                  }
+                },
                 "AddCollectionFunctionRequest": {
                   "options": {
                     "(common.privilege_ext_obj).object_type": "Global",
@@ -2202,6 +2243,13 @@ export default {
                     "(common.privilege_ext_obj).object_privilege": "PrivilegeDelete",
                     "(common.privilege_ext_obj).object_name_index": 3
                   },
+                  "oneofs": {
+                    "_namespace": {
+                      "oneof": [
+                        "namespace"
+                      ]
+                    }
+                  },
                   "fields": {
                     "base": {
                       "type": "common.MsgBase",
@@ -2236,6 +2284,13 @@ export default {
                       "keyType": "string",
                       "type": "schema.TemplateValue",
                       "id": 8
+                    },
+                    "namespace": {
+                      "type": "string",
+                      "id": 9,
+                      "options": {
+                        "proto3_optional": true
+                      }
                     }
                   }
                 },
@@ -2401,6 +2456,10 @@ export default {
                     "highlighter": {
                       "type": "common.Highlighter",
                       "id": 21
+                    },
+                    "search_aggregation": {
+                      "type": "common.SearchAggregationSpec",
+                      "id": 23
                     }
                   }
                 },
@@ -5926,6 +5985,92 @@ export default {
                     }
                   }
                 },
+                "RestoreExternalSnapshotRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Global",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeRestoreExternalSnapshot",
+                    "(common.privilege_ext_obj).object_name_index": -1
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "db_name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "target_collection_name": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "snapshot_metadata_uri": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "external_spec": {
+                      "type": "string",
+                      "id": 5
+                    }
+                  }
+                },
+                "RestoreExternalSnapshotResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "job_id": {
+                      "type": "int64",
+                      "id": 2
+                    }
+                  }
+                },
+                "ExportSnapshotRequest": {
+                  "options": {
+                    "(common.privilege_ext_obj).object_type": "Global",
+                    "(common.privilege_ext_obj).object_privilege": "PrivilegeExportSnapshot",
+                    "(common.privilege_ext_obj).object_name_index": -1
+                  },
+                  "fields": {
+                    "base": {
+                      "type": "common.MsgBase",
+                      "id": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "db_name": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "collection_name": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "target_s3_path": {
+                      "type": "string",
+                      "id": 5
+                    },
+                    "external_spec": {
+                      "type": "string",
+                      "id": 6
+                    }
+                  }
+                },
+                "ExportSnapshotResponse": {
+                  "fields": {
+                    "status": {
+                      "type": "common.Status",
+                      "id": 1
+                    },
+                    "snapshot_metadata_uri": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                },
                 "RestoreSnapshotState": {
                   "values": {
                     "RestoreSnapshotNone": 0,
@@ -6177,6 +6322,10 @@ export default {
                         "function_name": {
                           "type": "string",
                           "id": 3
+                        },
+                        "drop_function_output_fields": {
+                          "type": "bool",
+                          "id": 4
                         }
                       }
                     },
@@ -6207,10 +6356,6 @@ export default {
                     "alter_status": {
                       "type": "common.Status",
                       "id": 1
-                    },
-                    "index_status": {
-                      "type": "common.Status",
-                      "id": 2
                     }
                   }
                 },
@@ -6938,6 +7083,8 @@ export default {
                     "ListRestoreSnapshotJobs": 2106,
                     "PinSnapshotData": 2107,
                     "UnpinSnapshotData": 2108,
+                    "RestoreExternalSnapshot": 2109,
+                    "ExportSnapshot": 2110,
                     "AlterCollectionSchema": 2200,
                     "RefreshExternalCollection": 2300,
                     "GetRefreshExternalCollectionProgress": 2301,
@@ -7146,7 +7293,9 @@ export default {
                     "PrivilegeGetReplicateConfiguration": 85,
                     "PrivilegeRefreshExternalCollection": 86,
                     "PrivilegePinSnapshotData": 87,
-                    "PrivilegeUnpinSnapshotData": 88
+                    "PrivilegeUnpinSnapshotData": 88,
+                    "PrivilegeRestoreExternalSnapshot": 89,
+                    "PrivilegeExportSnapshot": 90
                   }
                 },
                 "PrivilegeExt": {
@@ -7533,6 +7682,98 @@ export default {
                       "rule": "repeated",
                       "type": "KeyValuePair",
                       "id": 2
+                    }
+                  }
+                },
+                "MetricAggSpec": {
+                  "fields": {
+                    "op": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "field_name": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                },
+                "SortSpec": {
+                  "fields": {
+                    "field_name": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "direction": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "null_first": {
+                      "type": "bool",
+                      "id": 3
+                    }
+                  }
+                },
+                "TopHitsSpec": {
+                  "fields": {
+                    "size": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "sort": {
+                      "rule": "repeated",
+                      "type": "SortSpec",
+                      "id": 2
+                    }
+                  }
+                },
+                "OrderSpec": {
+                  "fields": {
+                    "key": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "direction": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "null_first": {
+                      "type": "bool",
+                      "id": 3
+                    }
+                  }
+                },
+                "SearchAggregationSpec": {
+                  "fields": {
+                    "fields": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 1
+                    },
+                    "size": {
+                      "type": "int64",
+                      "id": 2
+                    },
+                    "metrics": {
+                      "keyType": "string",
+                      "type": "MetricAggSpec",
+                      "id": 3
+                    },
+                    "order": {
+                      "rule": "repeated",
+                      "type": "OrderSpec",
+                      "id": 4
+                    },
+                    "top_hits": {
+                      "type": "TopHitsSpec",
+                      "id": 5
+                    },
+                    "sub_aggregation": {
+                      "type": "SearchAggregationSpec",
+                      "id": 6
+                    },
+                    "search_size": {
+                      "type": "int64",
+                      "id": 7
                     }
                   }
                 }
@@ -8423,6 +8664,16 @@ export default {
                       "rule": "repeated",
                       "type": "FieldData",
                       "id": 17
+                    },
+                    "agg_buckets": {
+                      "rule": "repeated",
+                      "type": "AggBucket",
+                      "id": 18
+                    },
+                    "agg_topks": {
+                      "rule": "repeated",
+                      "type": "int64",
+                      "id": 19
                     }
                   },
                   "reserved": [
@@ -8431,6 +8682,174 @@ export default {
                       16
                     ]
                   ]
+                },
+                "AggBucket": {
+                  "fields": {
+                    "key": {
+                      "rule": "repeated",
+                      "type": "BucketKeyEntry",
+                      "id": 1
+                    },
+                    "count": {
+                      "type": "int64",
+                      "id": 2
+                    },
+                    "metrics": {
+                      "keyType": "string",
+                      "type": "MetricValue",
+                      "id": 3
+                    },
+                    "hits": {
+                      "rule": "repeated",
+                      "type": "AggHit",
+                      "id": 4
+                    },
+                    "sub_groups": {
+                      "rule": "repeated",
+                      "type": "AggBucket",
+                      "id": 5
+                    }
+                  }
+                },
+                "MetricValue": {
+                  "oneofs": {
+                    "value": {
+                      "oneof": [
+                        "int_val",
+                        "double_val",
+                        "string_val",
+                        "bool_val"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "int_val": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "double_val": {
+                      "type": "double",
+                      "id": 2
+                    },
+                    "string_val": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "bool_val": {
+                      "type": "bool",
+                      "id": 4
+                    }
+                  }
+                },
+                "BucketKeyEntry": {
+                  "oneofs": {
+                    "value": {
+                      "oneof": [
+                        "int_val",
+                        "string_val",
+                        "bool_val"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "field_id": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "field_name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "int_val": {
+                      "type": "int64",
+                      "id": 3
+                    },
+                    "string_val": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "bool_val": {
+                      "type": "bool",
+                      "id": 5
+                    }
+                  }
+                },
+                "AggHit": {
+                  "oneofs": {
+                    "pk": {
+                      "oneof": [
+                        "int_pk",
+                        "str_pk"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "int_pk": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "str_pk": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "score": {
+                      "type": "float",
+                      "id": 3
+                    },
+                    "fields": {
+                      "rule": "repeated",
+                      "type": "AggHitField",
+                      "id": 4
+                    }
+                  }
+                },
+                "AggHitField": {
+                  "oneofs": {
+                    "value": {
+                      "oneof": [
+                        "int_val",
+                        "bool_val",
+                        "float_val",
+                        "double_val",
+                        "string_val",
+                        "bytes_val"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "field_id": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "field_name": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "int_val": {
+                      "type": "int64",
+                      "id": 3
+                    },
+                    "bool_val": {
+                      "type": "bool",
+                      "id": 4
+                    },
+                    "float_val": {
+                      "type": "float",
+                      "id": 5
+                    },
+                    "double_val": {
+                      "type": "double",
+                      "id": 6
+                    },
+                    "string_val": {
+                      "type": "string",
+                      "id": 7
+                    },
+                    "bytes_val": {
+                      "type": "bytes",
+                      "id": 8
+                    }
+                  }
                 },
                 "VectorClusteringInfo": {
                   "fields": {

--- a/milvus/proto-json/schema.base.ts
+++ b/milvus/proto-json/schema.base.ts
@@ -826,6 +826,16 @@ export default {
                       "rule": "repeated",
                       "type": "FieldData",
                       "id": 17
+                    },
+                    "aggBuckets": {
+                      "rule": "repeated",
+                      "type": "AggBucket",
+                      "id": 18
+                    },
+                    "aggTopks": {
+                      "rule": "repeated",
+                      "type": "int64",
+                      "id": 19
                     }
                   },
                   "reserved": [
@@ -834,6 +844,174 @@ export default {
                       16
                     ]
                   ]
+                },
+                "AggBucket": {
+                  "fields": {
+                    "key": {
+                      "rule": "repeated",
+                      "type": "BucketKeyEntry",
+                      "id": 1
+                    },
+                    "count": {
+                      "type": "int64",
+                      "id": 2
+                    },
+                    "metrics": {
+                      "keyType": "string",
+                      "type": "MetricValue",
+                      "id": 3
+                    },
+                    "hits": {
+                      "rule": "repeated",
+                      "type": "AggHit",
+                      "id": 4
+                    },
+                    "subGroups": {
+                      "rule": "repeated",
+                      "type": "AggBucket",
+                      "id": 5
+                    }
+                  }
+                },
+                "MetricValue": {
+                  "oneofs": {
+                    "value": {
+                      "oneof": [
+                        "intVal",
+                        "doubleVal",
+                        "stringVal",
+                        "boolVal"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "intVal": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "doubleVal": {
+                      "type": "double",
+                      "id": 2
+                    },
+                    "stringVal": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "boolVal": {
+                      "type": "bool",
+                      "id": 4
+                    }
+                  }
+                },
+                "BucketKeyEntry": {
+                  "oneofs": {
+                    "value": {
+                      "oneof": [
+                        "intVal",
+                        "stringVal",
+                        "boolVal"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "fieldId": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "fieldName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "intVal": {
+                      "type": "int64",
+                      "id": 3
+                    },
+                    "stringVal": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "boolVal": {
+                      "type": "bool",
+                      "id": 5
+                    }
+                  }
+                },
+                "AggHit": {
+                  "oneofs": {
+                    "pk": {
+                      "oneof": [
+                        "intPk",
+                        "strPk"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "intPk": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "strPk": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "score": {
+                      "type": "float",
+                      "id": 3
+                    },
+                    "fields": {
+                      "rule": "repeated",
+                      "type": "AggHitField",
+                      "id": 4
+                    }
+                  }
+                },
+                "AggHitField": {
+                  "oneofs": {
+                    "value": {
+                      "oneof": [
+                        "intVal",
+                        "boolVal",
+                        "floatVal",
+                        "doubleVal",
+                        "stringVal",
+                        "bytesVal"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "fieldId": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "fieldName": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "intVal": {
+                      "type": "int64",
+                      "id": 3
+                    },
+                    "boolVal": {
+                      "type": "bool",
+                      "id": 4
+                    },
+                    "floatVal": {
+                      "type": "float",
+                      "id": 5
+                    },
+                    "doubleVal": {
+                      "type": "double",
+                      "id": 6
+                    },
+                    "stringVal": {
+                      "type": "string",
+                      "id": 7
+                    },
+                    "bytesVal": {
+                      "type": "bytes",
+                      "id": 8
+                    }
+                  }
                 },
                 "VectorClusteringInfo": {
                   "fields": {
@@ -1330,6 +1508,8 @@ export default {
                     "ListRestoreSnapshotJobs": 2106,
                     "PinSnapshotData": 2107,
                     "UnpinSnapshotData": 2108,
+                    "RestoreExternalSnapshot": 2109,
+                    "ExportSnapshot": 2110,
                     "AlterCollectionSchema": 2200,
                     "RefreshExternalCollection": 2300,
                     "GetRefreshExternalCollectionProgress": 2301,
@@ -1538,7 +1718,9 @@ export default {
                     "PrivilegeGetReplicateConfiguration": 85,
                     "PrivilegeRefreshExternalCollection": 86,
                     "PrivilegePinSnapshotData": 87,
-                    "PrivilegeUnpinSnapshotData": 88
+                    "PrivilegeUnpinSnapshotData": 88,
+                    "PrivilegeRestoreExternalSnapshot": 89,
+                    "PrivilegeExportSnapshot": 90
                   }
                 },
                 "PrivilegeExt": {
@@ -1925,6 +2107,98 @@ export default {
                       "rule": "repeated",
                       "type": "KeyValuePair",
                       "id": 2
+                    }
+                  }
+                },
+                "MetricAggSpec": {
+                  "fields": {
+                    "op": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "fieldName": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                },
+                "SortSpec": {
+                  "fields": {
+                    "fieldName": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "direction": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "nullFirst": {
+                      "type": "bool",
+                      "id": 3
+                    }
+                  }
+                },
+                "TopHitsSpec": {
+                  "fields": {
+                    "size": {
+                      "type": "int64",
+                      "id": 1
+                    },
+                    "sort": {
+                      "rule": "repeated",
+                      "type": "SortSpec",
+                      "id": 2
+                    }
+                  }
+                },
+                "OrderSpec": {
+                  "fields": {
+                    "key": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "direction": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "nullFirst": {
+                      "type": "bool",
+                      "id": 3
+                    }
+                  }
+                },
+                "SearchAggregationSpec": {
+                  "fields": {
+                    "fields": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 1
+                    },
+                    "size": {
+                      "type": "int64",
+                      "id": 2
+                    },
+                    "metrics": {
+                      "keyType": "string",
+                      "type": "MetricAggSpec",
+                      "id": 3
+                    },
+                    "order": {
+                      "rule": "repeated",
+                      "type": "OrderSpec",
+                      "id": 4
+                    },
+                    "topHits": {
+                      "type": "TopHitsSpec",
+                      "id": 5
+                    },
+                    "subAggregation": {
+                      "type": "SearchAggregationSpec",
+                      "id": 6
+                    },
+                    "searchSize": {
+                      "type": "int64",
+                      "id": 7
                     }
                   }
                 }

--- a/milvus/types/Collection.ts
+++ b/milvus/types/Collection.ts
@@ -100,10 +100,18 @@ export interface ShowCollectionsReq extends GrpcTimeOut {
 
 export type Properties = Record<string, string | number | boolean>;
 
+export type FunctionTypeName =
+  | 'Unknown'
+  | 'BM25'
+  | 'TextEmbedding'
+  | 'Rerank'
+  | 'MinHash'
+  | 'MolFingerprint';
+
 export type FunctionObject = {
   name: string;
   description?: string;
-  type: FunctionType;
+  type: FunctionType | FunctionTypeName;
   input_field_names: string[];
   output_field_names?: string[];
   params: Record<string, any>;
@@ -138,8 +146,7 @@ export interface CreateCollectionWithSchemaReq extends BaseCreateCollectionReq {
 
 // create collection with schema requests
 export type CreateCollectionReq =
-  | CreateCollectionWithFieldsReq
-  | CreateCollectionWithSchemaReq;
+  CreateCollectionWithFieldsReq | CreateCollectionWithSchemaReq;
 
 // add collection field req
 export interface AddCollectionFieldReq extends collectionNameReq {
@@ -354,15 +361,43 @@ export interface AlterCollectionSchemaReq extends collectionNameReq {
   function: FunctionObject; // required, function schema to add
   do_physical_backfill?: boolean; // optional, whether Milvus should backfill existing data
   index_name?: string; // optional, index name for the new field
-  extra_params?: Properties; // optional, field info extra params
+  extra_params?: Record<string, any>; // optional, field info extra params
 }
 
 export interface AlterCollectionSchemaResponse {
   alter_status: ResStatus;
+  /** @deprecated Removed from the AlterCollectionSchema wire response. */
   index_status?: ResStatus;
 }
 
-export interface AddFunctionFieldReq extends AlterCollectionSchemaReq {}
+export type FunctionFieldIndexParams = Record<string, any> &
+  (
+    | { index_type: string }
+    | {
+        index_type?: never;
+        params: (Record<string, any> & { index_type: string }) | string;
+      }
+  );
+
+export interface AddFunctionFieldReq extends AlterCollectionSchemaReq {
+  extra_params: FunctionFieldIndexParams;
+}
+
+export type DropCollectionFieldReq = collectionNameReq &
+  (
+    | {
+        field_name: string;
+        field_id?: never;
+      }
+    | {
+        field_name?: never;
+        field_id: number | string;
+      }
+  );
+
+export interface DropFunctionFieldReq extends collectionNameReq {
+  function_name: string;
+}
 
 export enum RefreshExternalCollectionState {
   RefreshPending = 'RefreshPending',

--- a/milvus/utils/Grpc.ts
+++ b/milvus/utils/Grpc.ts
@@ -155,12 +155,15 @@ export const getRetryInterceptor = ({
               savedStatusNext = next;
             }
 
-            // transform code and message if needed(for compatibility with old version of milvus)
-            switch (status.code) {
-              case grpcStatus.UNIMPLEMENTED:
-                savedReceiveMessage = {};
-                status.code = grpcStatus.OK;
-                break;
+            // Keep the existing compatibility behavior for older RPCs, but
+            // let AlterCollectionSchema observe UNIMPLEMENTED so add field can
+            // fall back to the legacy AddCollectionField RPC.
+            if (
+              status.code === grpcStatus.UNIMPLEMENTED &&
+              methodName !== 'AlterCollectionSchema'
+            ) {
+              savedReceiveMessage = {};
+              status.code = grpcStatus.OK;
             }
 
             // check message if need retry
@@ -212,7 +215,7 @@ export const getRetryInterceptor = ({
                 newCall.sendMessage(savedSendMessage);
               }, _retryDelay);
             } else {
-              const string = JSON.stringify(savedReceiveMessage);
+              const string = JSON.stringify(savedReceiveMessage) || '';
               const msg =
                 string.length > 4096 ? string.slice(0, 4096) + '...' : string;
 
@@ -234,7 +237,9 @@ export const getRetryInterceptor = ({
                 );
               }
 
-              savedMessageNext(savedReceiveMessage);
+              if (savedMessageNext) {
+                savedMessageNext(savedReceiveMessage);
+              }
               savedStatusNext(status);
             }
           },

--- a/milvus/utils/Schema.ts
+++ b/milvus/utils/Schema.ts
@@ -114,6 +114,18 @@ export const getDataKey = (type: DataType, camelCase: boolean = false) => {
   return camelCase ? convertToCamelCase(dataKey) : dataKey;
 };
 
+const normalizeFunctionType = (type: FunctionObject['type']) => {
+  if (typeof type !== 'string') {
+    return type;
+  }
+
+  return (
+    FunctionType[type as keyof typeof FunctionType] ??
+    FunctionType[type.toUpperCase() as keyof typeof FunctionType] ??
+    type
+  );
+};
+
 /**
  * Assigns specified properties from the `field` object to `type_params` within the `FieldType` object.
  * Converts properties to strings, serializing objects as JSON strings if needed, then removes them from `field`.
@@ -239,28 +251,26 @@ export const formatFieldSchema = (
 
   if (typeof field.default_value !== 'undefined') {
     const dataKey = getDataKey(createObj.dataType, true);
+    let defaultValue = field.default_value;
 
     // Convert TIMESTAMPTZ default value to UTC microseconds (int64)
     // Milvus stores TIMESTAMPTZ default values internally as int64 (UTC microsecond)
     // Users can pass either a string (RFC3339 format) or a number (microseconds)
     if (createObj.dataType === DataType.Timestamptz) {
-      if (typeof field.default_value === 'string') {
+      if (typeof defaultValue === 'string') {
         // Convert RFC3339 string to UTC microseconds
-        const date = new Date(field.default_value);
-        field.default_value = (date.getTime() * 1000).toString();
-      } else if (typeof field.default_value === 'number') {
+        const date = new Date(defaultValue);
+        defaultValue = (date.getTime() * 1000).toString();
+      } else if (typeof defaultValue === 'number') {
         // If already a number, assume it's microseconds (or milliseconds if < 1e12)
         // Convert to microseconds if it looks like milliseconds (< year 2286)
-        const value =
-          field.default_value < 1e12
-            ? field.default_value * 1000
-            : field.default_value;
-        field.default_value = Math.floor(value).toString();
+        const value = defaultValue < 1e12 ? defaultValue * 1000 : defaultValue;
+        defaultValue = Math.floor(value).toString();
       }
     }
 
     createObj.defaultValue = {
-      [dataKey]: field.default_value,
+      [dataKey]: defaultValue,
     };
   }
   return schemaTypes.fieldSchemaType.create(createObj);
@@ -279,17 +289,11 @@ export const formatFunctionSchema = (
 ): { [k: string]: any } => {
   const { input_field_names, output_field_names, type, ...rest } = func;
 
-  // Ensure type is a number (enum value), not a string
-  const typeValue =
-    typeof type === 'number'
-      ? type
-      : (FunctionType[type as keyof typeof FunctionType] ?? type);
-
   // Return a plain object with snake_case field names for gRPC
   // The @grpc/proto-loader uses milvus.ts which has snake_case field names
   return {
     ...rest,
-    type: typeValue,
+    type: normalizeFunctionType(type),
     input_field_names: input_field_names || [],
     output_field_names: output_field_names || [],
     params: parseToKeyValue(func.params, true),
@@ -363,12 +367,13 @@ export const formatCollectionSchema = (
   // if functions is set, parse its params to key-value pairs, and delete inputs and outputs
   if (functions) {
     payload.functions = functions.map((func: FunctionObject) => {
-      const { input_field_names, output_field_names, ...rest } = func;
+      const { input_field_names, output_field_names, type, ...rest } = func;
 
       functionOutputFields.push(...(output_field_names || []));
 
       return schemaTypes.functionSchemaType.create({
         ...rest,
+        type: normalizeFunctionType(type),
         inputFieldNames: input_field_names || [],
         outputFieldNames: output_field_names || [],
         params: parseToKeyValue(func.params, true),

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "repository": "github:milvus-io/milvus-sdk-node",
   "scripts": {
-    "pre": "git submodule update --remote && rm -rf proto/proto/google && mkdir -p proto/proto/google/protobuf && cp node_modules/protobufjs/google/protobuf/descriptor.proto proto/proto/google/protobuf/descriptor.proto",
+    "pre": "git submodule update --init --recursive && rm -rf proto/proto/google && mkdir -p proto/proto/google/protobuf && cp node_modules/protobufjs/google/protobuf/descriptor.proto proto/proto/google/protobuf/descriptor.proto",
     "build": "rm -rf dist && tsc --declaration && node build.js",
     "test": "NODE_ENV=dev jest",
     "test-cloud": "NODE_ENV=dev jest test/http --testPathIgnorePatterns=none",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zilliz/milvus2-sdk-node",
   "author": "Zilliz",
-  "milvusVersion": "v3.0-beta-amd64",
+  "milvusVersion": "3.0-20260722-eceae105-amd64",
   "version": "3.0.3",
   "main": "dist/milvus",
   "files": [

--- a/test/grpc/Collection.spec.ts
+++ b/test/grpc/Collection.spec.ts
@@ -28,6 +28,7 @@ const LOAD_COLLECTION_NAME_SYNC = GENERATE_NAME();
 const COLLECTION_WITH_PROPERTY = GENERATE_NAME();
 const COLLECTION_WITH_ENTITY_TTL = GENERATE_NAME();
 const COLLECTION_ENTITY_TTL_ALTER = GENERATE_NAME();
+const COLLECTION_FIELD_DROP = GENERATE_NAME();
 const NON_EXISTENT_COLLECTION_NAME = 'none_existent';
 
 const dbParam = {
@@ -301,6 +302,74 @@ describe(`Collection API`, () => {
     await milvusClient.dropCollection({
       collection_name: COLLECTION_ENTITY_TTL_ALTER,
     });
+  });
+
+  it(`Add and drop collection fields by name and ID`, async () => {
+    try {
+      const create = await milvusClient.createCollection({
+        collection_name: COLLECTION_FIELD_DROP,
+        fields: [
+          {
+            name: 'id',
+            data_type: DataType.Int64,
+            is_primary_key: true,
+          },
+          {
+            name: 'vector',
+            data_type: DataType.FloatVector,
+            dim: 4,
+          },
+        ],
+      });
+      expect(create.error_code).toEqual(ErrorCode.SUCCESS);
+
+      for (const fieldName of ['drop_by_name', 'drop_by_id']) {
+        const add = await milvusClient.addCollectionField({
+          collection_name: COLLECTION_FIELD_DROP,
+          field: {
+            name: fieldName,
+            data_type: DataType.Int64,
+            nullable: true,
+          },
+        });
+        expect(add.error_code).toEqual(ErrorCode.SUCCESS);
+      }
+
+      const dropByName = await milvusClient.dropCollectionField({
+        collection_name: COLLECTION_FIELD_DROP,
+        field_name: 'drop_by_name',
+      });
+      expect(dropByName.error_code).toEqual(ErrorCode.SUCCESS);
+
+      const describe = await milvusClient.describeCollection({
+        collection_name: COLLECTION_FIELD_DROP,
+        cache: false,
+      });
+      const fieldToDrop = describe.schema.fields.find(
+        field => field.name === 'drop_by_id'
+      );
+      expect(fieldToDrop).toBeDefined();
+
+      const dropByID = await milvusClient.dropCollectionField({
+        collection_name: COLLECTION_FIELD_DROP,
+        field_id: fieldToDrop!.fieldID,
+      });
+      expect(dropByID.error_code).toEqual(ErrorCode.SUCCESS);
+
+      const describeAfterDrop = await milvusClient.describeCollection({
+        collection_name: COLLECTION_FIELD_DROP,
+        cache: false,
+      });
+      expect(
+        describeAfterDrop.schema.fields.some(field =>
+          ['drop_by_name', 'drop_by_id'].includes(field.name)
+        )
+      ).toEqual(false);
+    } finally {
+      await milvusClient.dropCollection({
+        collection_name: COLLECTION_FIELD_DROP,
+      });
+    }
   });
 
   it(`Should get pk fieldname successfully`, async () => {

--- a/test/grpc/Database.spec.ts
+++ b/test/grpc/Database.spec.ts
@@ -161,7 +161,6 @@ describe(`Database API`, () => {
         { key: 'timezone', value: 'UTC' },
       ])
     );
-    expect(describeCollectionAfterAlter.properties).toHaveLength(2);
 
     // drop collection properties
     const dropCollectionProperties =
@@ -176,9 +175,14 @@ describe(`Database API`, () => {
       collection_name: COLLECTION_NAME2,
       db_name: DB_NAME2,
     });
-    expect(describeCollectionAfterDrop.properties).toEqual([
-      { key: 'timezone', value: 'UTC' },
-    ]);
+    expect(describeCollectionAfterDrop.properties).toEqual(
+      expect.arrayContaining([{ key: 'timezone', value: 'UTC' }])
+    );
+    expect(
+      describeCollectionAfterDrop.properties.some(
+        property => property.key === 'collection.segment.rowLimit'
+      )
+    ).toEqual(false);
 
     // show collections
     const showCollections = await milvusClient.showCollections({

--- a/test/grpc/FullTextSearch.spec.ts
+++ b/test/grpc/FullTextSearch.spec.ts
@@ -6,6 +6,7 @@ import {
   ConsistencyLevelEnum,
   FunctionType,
   ERROR_REASONS,
+  IndexType,
 } from '../../milvus';
 import {
   IP,
@@ -740,7 +741,10 @@ describe(`FulltextSearch API`, () => {
         db_name: dbParam.db_name,
         collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
         index_name: 'sparse_index',
-        extra_params: { metric_type: MetricType.BM25 },
+        extra_params: {
+          index_type: IndexType.SPARSE_INVERTED_INDEX,
+          metric_type: MetricType.BM25,
+        },
         field: {
           name: 'sparse',
           data_type: DataType.SparseFloatVector,
@@ -778,6 +782,11 @@ describe(`FulltextSearch API`, () => {
     it(`Add function field should success`, async () => {
       const res = await milvusClient.addFunctionField({
         collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+        index_name: 'sparse2_index',
+        extra_params: {
+          index_type: IndexType.SPARSE_INVERTED_INDEX,
+          metric_type: MetricType.BM25,
+        },
         field: {
           name: 'sparse2',
           data_type: DataType.SparseFloatVector,
@@ -817,6 +826,11 @@ describe(`FulltextSearch API`, () => {
     it(`Add function field should accept string enum values`, async () => {
       const res = await milvusClient.addFunctionField({
         collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+        index_name: 'sparse3_index',
+        extra_params: {
+          index_type: IndexType.SPARSE_INVERTED_INDEX,
+          metric_type: MetricType.BM25,
+        },
         field: {
           name: 'sparse3',
           data_type: 'SparseFloatVector' as any,
@@ -844,6 +858,71 @@ describe(`FulltextSearch API`, () => {
       );
       expect(sparseField).toBeDefined();
       expect(sparseField!.is_function_output).toEqual(true);
+    });
+
+    it(`Add and drop MinHash function field should success`, async () => {
+      const add = await milvusClient.addFunctionField({
+        collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+        index_name: 'minhash_index',
+        extra_params: {
+          index_type: IndexType.MINHASH_LSH,
+          metric_type: MetricType.MHJACCARD,
+          params: { mh_lsh_band: 8 },
+        },
+        field: {
+          name: 'minhash_vector',
+          data_type: DataType.BinaryVector,
+          dim: 512,
+          is_function_output: true,
+        },
+        function: {
+          name: 'minhash_added_by_wrapper',
+          type: FunctionType.MINHASH,
+          input_field_names: ['text'],
+          output_field_names: ['minhash_vector'],
+          params: { num_hashes: 16, shingle_size: 3 },
+        },
+      });
+      expect(add.error_code).toEqual(ErrorCode.SUCCESS);
+
+      const describe = await milvusClient.describeCollection({
+        collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+        cache: false,
+      });
+      expect(
+        describe.schema.fields.some(field => field.name === 'minhash_vector')
+      ).toEqual(true);
+      expect(
+        describe.schema.functions.some(
+          func => func.name === 'minhash_added_by_wrapper'
+        )
+      ).toEqual(true);
+      expect(
+        describe.schema.functions.find(
+          func => func.name === 'minhash_added_by_wrapper'
+        )?.type
+      ).toEqual('MinHash');
+
+      const drop = await milvusClient.dropFunctionField({
+        collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+        function_name: 'minhash_added_by_wrapper',
+      });
+      expect(drop.error_code).toEqual(ErrorCode.SUCCESS);
+
+      const describeAfterDrop = await milvusClient.describeCollection({
+        collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+        cache: false,
+      });
+      expect(
+        describeAfterDrop.schema.fields.some(
+          field => field.name === 'minhash_vector'
+        )
+      ).toEqual(false);
+      expect(
+        describeAfterDrop.schema.functions.some(
+          func => func.name === 'minhash_added_by_wrapper'
+        )
+      ).toEqual(false);
     });
 
     it(`Alter collection schema should reject missing field`, async () => {
@@ -908,6 +987,9 @@ describe(`FulltextSearch API`, () => {
       try {
         await milvusClient.addFunctionField({
           collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+          extra_params: {
+            index_type: IndexType.SPARSE_INVERTED_INDEX,
+          },
           field: {
             name: 'missing_function_wrapper',
             data_type: DataType.SparseFloatVector,
@@ -926,6 +1008,9 @@ describe(`FulltextSearch API`, () => {
       try {
         await milvusClient.addFunctionField({
           collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+          extra_params: {
+            index_type: IndexType.SPARSE_INVERTED_INDEX,
+          },
           field: {
             name: 'dense',
             data_type: DataType.FloatVector,
@@ -952,6 +1037,9 @@ describe(`FulltextSearch API`, () => {
       try {
         await milvusClient.addFunctionField({
           collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+          extra_params: {
+            index_type: IndexType.SPARSE_INVERTED_INDEX,
+          },
           field: {
             name: 'dense',
             data_type: DataType.FloatVector,

--- a/test/grpc/FullTextSearch.spec.ts
+++ b/test/grpc/FullTextSearch.spec.ts
@@ -7,6 +7,7 @@ import {
   FunctionType,
   ERROR_REASONS,
   IndexType,
+  findKeyValue,
 } from '../../milvus';
 import {
   IP,
@@ -267,8 +268,8 @@ describe(`FulltextSearch API`, () => {
       consistency_level: ConsistencyLevelEnum.Strong,
     });
 
-    expect(query.status.error_code).toEqual(ErrorCode.UnexpectedError);
-    expect(query.status.reason).toEqual(
+    expect(query.status.error_code).toEqual(ErrorCode.IllegalArgument);
+    expect(query.status.reason).toContain(
       'not allowed to retrieve raw data of field sparse'
     );
 
@@ -559,7 +560,7 @@ describe(`FulltextSearch API`, () => {
       }
     });
 
-    it(`Add collection function should success`, async () => {
+    it(`Add collection function should be rejected by current server`, async () => {
       const addFunction = await milvusClient.addCollectionFunction({
         collection_name: COLLECTION_FOR_FUNCTION_OPS,
         function: {
@@ -575,104 +576,22 @@ describe(`FulltextSearch API`, () => {
         },
       });
 
-      if (addFunction.error_code !== ErrorCode.SUCCESS) {
-        console.log(
-          'Add function error:',
-          JSON.stringify(addFunction, null, 2)
-        );
-      }
-      expect(addFunction.error_code).toEqual(ErrorCode.SUCCESS);
-
-      // Verify function was added
-      const describe = await milvusClient.describeCollection({
-        collection_name: COLLECTION_FOR_FUNCTION_OPS,
-      });
-
-      expect(describe.schema.functions.length).toBeGreaterThanOrEqual(1);
-      const addedFunction = describe.schema.functions.find(
-        f => f.name === 'embedding_new'
-      );
-      expect(addedFunction).toBeDefined();
-      expect(addedFunction!.input_field_names).toEqual(['text']);
-      expect(addedFunction!.type).toEqual('TextEmbedding');
-    });
-
-    it(`Alter collection function should success`, async () => {
-      // Alter the function
-      const alterFunction = await milvusClient.alterCollectionFunction({
-        collection_name: COLLECTION_FOR_FUNCTION_OPS,
-        function_name: 'embedding_new',
-        function: {
-          name: 'embedding_new',
-          description: 'text embedding function altered via API',
-          type: FunctionType.TEXTEMBEDDING,
-          input_field_names: ['text'],
-          output_field_names: ['vector'],
-          params: {
-            provider: 'openai',
-            model_name: 'text-embedding-3-small',
-          },
-        },
-      });
-
-      expect(alterFunction.error_code).toEqual(ErrorCode.SUCCESS);
-
-      // Verify function was altered
-      const describe = await milvusClient.describeCollection({
-        collection_name: COLLECTION_FOR_FUNCTION_OPS,
-      });
-
-      const alteredFunction = describe.schema.functions.find(
-        f => f.name === 'embedding_new'
-      );
-      expect(alteredFunction).toBeDefined();
-      expect(alteredFunction!.description).toEqual(
-        'text embedding function altered via API'
+      expect(addFunction.error_code).not.toEqual(ErrorCode.SUCCESS);
+      expect(addFunction.reason).toContain(
+        'AddCollectionFunction RPC is no longer supported'
       );
     });
 
-    it(`Drop collection function should success`, async () => {
-      // Drop the function
+    it(`Drop collection function should be rejected by current server`, async () => {
       const dropFunction = await milvusClient.dropCollectionFunction({
         collection_name: COLLECTION_FOR_FUNCTION_OPS,
         function_name: 'embedding_new',
       });
 
-      expect(dropFunction.error_code).toEqual(ErrorCode.SUCCESS);
-
-      // Verify function was dropped
-      const describeAfter = await milvusClient.describeCollection({
-        collection_name: COLLECTION_FOR_FUNCTION_OPS,
-        cache: false,
-      });
-      const functionAfter = describeAfter.schema.functions.find(
-        f => f.name === 'embedding_new'
+      expect(dropFunction.error_code).not.toEqual(ErrorCode.SUCCESS);
+      expect(dropFunction.reason).toContain(
+        'DropCollectionFunction RPC is no longer supported'
       );
-      expect(functionAfter).toBeUndefined();
-    });
-
-    it(`Add collection function with invalid collection name should fail`, async () => {
-      try {
-        await milvusClient.addCollectionFunction({
-          collection_name: 'non_existent_collection',
-          function: {
-            name: 'test_embedding_function',
-            description: 'test text embedding function',
-            type: FunctionType.TEXTEMBEDDING,
-            input_field_names: ['text'],
-            output_field_names: ['vector'],
-            params: {
-              provider: 'openai',
-              model_name: 'text-embedding-3-small',
-              api_key: 'yourkey',
-            },
-          },
-        });
-        // Should not reach here
-        expect(true).toBe(false);
-      } catch (error) {
-        expect(error).toBeDefined();
-      }
     });
 
     it(`Alter collection function with invalid function name should fail`, async () => {
@@ -693,19 +612,10 @@ describe(`FulltextSearch API`, () => {
         },
       });
 
-      // Should return error
-      expect(alterFunction.error_code).not.toEqual(ErrorCode.SUCCESS);
-    });
-
-    it(`Drop collection function with invalid function name should fail`, async () => {
-      const dropFunction = await milvusClient.dropCollectionFunction({
-        collection_name: COLLECTION_FOR_FUNCTION_OPS,
-        function_name: 'non_existent_embedding_function',
-      });
-
-      // Note: Drop operation may be idempotent and return success even if function doesn't exist
-      // This is acceptable behavior, so we just verify the operation completes
-      expect(dropFunction).toBeDefined();
+      expect(alterFunction.error_code).toEqual(ErrorCode.IllegalArgument);
+      expect(alterFunction.reason).toContain(
+        'function non_existent_embedding_function not found'
+      );
     });
   });
 
@@ -777,6 +687,24 @@ describe(`FulltextSearch API`, () => {
       expect(func!.type).toEqual('BM25');
       expect(func!.input_field_names).toEqual(['text']);
       expect(func!.output_field_names).toEqual(['sparse']);
+
+      const index = await milvusClient.describeIndex({
+        db_name: dbParam.db_name,
+        collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+        index_name: 'sparse_index',
+      });
+      expect(index.status.error_code).toEqual(ErrorCode.SUCCESS);
+      const indexDescription = index.index_descriptions.find(
+        description => description.index_name === 'sparse_index'
+      );
+      expect(indexDescription).toBeDefined();
+      expect(indexDescription!.field_name).toEqual('sparse');
+      expect(findKeyValue(indexDescription!.params, 'index_type')).toEqual(
+        IndexType.SPARSE_INVERTED_INDEX
+      );
+      expect(findKeyValue(indexDescription!.params, 'metric_type')).toEqual(
+        MetricType.BM25
+      );
     });
 
     it(`Add function field should success`, async () => {
@@ -903,6 +831,23 @@ describe(`FulltextSearch API`, () => {
         )?.type
       ).toEqual('MinHash');
 
+      const index = await milvusClient.describeIndex({
+        collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+        index_name: 'minhash_index',
+      });
+      expect(index.status.error_code).toEqual(ErrorCode.SUCCESS);
+      const indexDescription = index.index_descriptions.find(
+        description => description.index_name === 'minhash_index'
+      );
+      expect(indexDescription).toBeDefined();
+      expect(indexDescription!.field_name).toEqual('minhash_vector');
+      expect(findKeyValue(indexDescription!.params, 'index_type')).toEqual(
+        IndexType.MINHASH_LSH
+      );
+      expect(findKeyValue(indexDescription!.params, 'metric_type')).toEqual(
+        MetricType.MHJACCARD
+      );
+
       const drop = await milvusClient.dropFunctionField({
         collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
         function_name: 'minhash_added_by_wrapper',
@@ -923,6 +868,12 @@ describe(`FulltextSearch API`, () => {
           func => func.name === 'minhash_added_by_wrapper'
         )
       ).toEqual(false);
+
+      const indexAfterDrop = await milvusClient.describeIndex({
+        collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+        index_name: 'minhash_index',
+      });
+      expect(indexAfterDrop.status.error_code).toEqual(ErrorCode.IndexNotExist);
     });
 
     it(`Alter collection schema should reject missing field`, async () => {

--- a/test/grpc/Index.spec.ts
+++ b/test/grpc/Index.spec.ts
@@ -129,7 +129,7 @@ describe(`Milvus Index API`, () => {
       },
     ]);
 
-    expect(createsError.error_code).toEqual(ErrorCode.UnexpectedError);
+    expect(createsError.error_code).toEqual(ErrorCode.IllegalArgument);
   });
 
   it(`Create IVF_FLAT index should success`, async () => {
@@ -304,7 +304,7 @@ describe(`Milvus Index API`, () => {
         params: JSON.stringify({ nlist: 1024 }),
       },
     });
-    expect(res.error_code).toEqual(ErrorCode.UnexpectedError);
+    expect(res.error_code).toEqual(ErrorCode.IllegalArgument);
   });
 
   it(`Describe Index with index name`, async () => {

--- a/test/grpc/NullableVector.spec.ts
+++ b/test/grpc/NullableVector.spec.ts
@@ -2,6 +2,7 @@ import {
   MilvusClient,
   ErrorCode,
   DataType,
+  ERROR_REASONS,
   IndexType,
   MetricType,
 } from '../../milvus';
@@ -292,15 +293,18 @@ describe('Nullable vector API testing', () => {
         true
       );
 
-      const addNonNullableVector = await milvusClient.addCollectionField({
-        collection_name: collectionName,
-        field: {
-          name: 'non_nullable_vector',
-          data_type: DataType.FloatVector,
-          dim: 2,
-        },
-      });
-      expect(addNonNullableVector.error_code).not.toEqual(ErrorCode.SUCCESS);
+      await expect(
+        milvusClient.addCollectionField({
+          collection_name: collectionName,
+          field: {
+            name: 'non_nullable_vector',
+            data_type: DataType.FloatVector,
+            dim: 2,
+          },
+        })
+      ).rejects.toThrow(
+        ERROR_REASONS.ADD_COLLECTION_FIELD_VECTOR_NULLABLE_REQUIRED
+      );
     } finally {
       await cleanupCollection(collectionName);
     }

--- a/test/grpc/PartitionKey.spec.ts
+++ b/test/grpc/PartitionKey.spec.ts
@@ -12,7 +12,7 @@ import {
   generateInsertData,
 } from '../tools';
 
-const milvusClient = new MilvusClient({ address: IP , logLevel: 'info' });
+const milvusClient = new MilvusClient({ address: IP, logLevel: 'info' });
 const COLLECTION_NAME = GENERATE_NAME();
 const COLLECTION_NAME2 = GENERATE_NAME();
 const COLLECTION_NAME3 = GENERATE_NAME();
@@ -161,7 +161,7 @@ describe(`Partition key API`, () => {
       partition_name: 'p',
     });
 
-    expect(res.error_code).toEqual(ErrorCode.UnexpectedError);
+    expect(res.error_code).toEqual(ErrorCode.IllegalArgument);
   });
 
   it(`Describe Collection should be successful`, async () => {
@@ -219,6 +219,6 @@ describe(`Partition key API`, () => {
       output_fields: ['varChar'],
     });
 
-    expect(search.status.error_code).toEqual(ErrorCode.UnexpectedError);
+    expect(search.status.error_code).toEqual(ErrorCode.IllegalArgument);
   });
 });

--- a/test/grpc/TextEmbedding.spec.ts
+++ b/test/grpc/TextEmbedding.spec.ts
@@ -8,14 +8,21 @@ import {
 } from '../../milvus';
 import { IP, GENERATE_NAME } from '../tools';
 
-const milvusClient = new MilvusClient({ address: IP, logLevel: 'info' });
+let milvusClient: MilvusClient;
 const COLLECTION = GENERATE_NAME();
 const dbParam = {
   db_name: 'TextEmbedding',
 };
+const hasOpenAICredentials =
+  process.env.MILVUS_OPENAI_ENABLED === '1' ||
+  Boolean(process.env.MILVUS_OPENAI_API_KEY);
+const describeIfOpenAIConfigured = hasOpenAICredentials
+  ? describe
+  : describe.skip;
 
-describe(`Text Embedding Function API`, () => {
+describeIfOpenAIConfigured(`Text Embedding Function API`, () => {
   beforeAll(async () => {
+    milvusClient = new MilvusClient({ address: IP, logLevel: 'info' });
     await milvusClient.createDatabase(dbParam);
     await milvusClient.use(dbParam);
   });
@@ -77,6 +84,35 @@ describe(`Text Embedding Function API`, () => {
     expect(func!.input_field_names).toEqual(['text']);
     expect(func!.output_field_names).toEqual(['dense']);
     expect(func!.type).toEqual('TextEmbedding');
+  });
+
+  it(`Alter text embedding function should success`, async () => {
+    const alter = await milvusClient.alterCollectionFunction({
+      collection_name: COLLECTION,
+      function_name: 'openai',
+      function: {
+        name: 'openai',
+        description: 'openai text embedding function altered via API',
+        type: FunctionType.TEXTEMBEDDING,
+        input_field_names: ['text'],
+        output_field_names: ['dense'],
+        params: {
+          provider: 'openai',
+          model_name: 'text-embedding-3-small',
+        },
+      },
+    });
+    expect(alter.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const describe = await milvusClient.describeCollection({
+      collection_name: COLLECTION,
+      cache: false,
+    });
+    const func = describe.schema.functions.find(f => f.name === 'openai');
+    expect(func).toBeDefined();
+    expect(func!.description).toEqual(
+      'openai text embedding function altered via API'
+    );
   });
 
   it(`Insert text data should success`, async () => {

--- a/test/http/test.ts
+++ b/test/http/test.ts
@@ -6,6 +6,7 @@ import {
   HttpClientConfig,
   MilvusClient,
   DEFAULT_DB,
+  LoadState,
 } from '../../milvus';
 import {
   genCollectionParams,
@@ -347,11 +348,34 @@ export function generateTests(
     });
 
     it('should refresh load successfully', async () => {
+      const load = await client.loadCollection({
+        dbName: config.database,
+        collectionName: createParams.collectionName,
+      });
+      expect(load.code).toEqual(0);
+
+      let loadState = '';
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const state = await client.getCollectionLoadState({
+          dbName: config.database,
+          collectionName: createParams.collectionName,
+        });
+        expect(state.code).toEqual(0);
+
+        loadState = state.data.loadState;
+        if (loadState === LoadState.LoadStateLoaded) {
+          break;
+        }
+        await new Promise(resolve => setTimeout(resolve, 500));
+      }
+      expect(loadState).toEqual(LoadState.LoadStateLoaded);
+
       const refresh = await client.refreshLoad({
+        dbName: config.database,
         collectionName: createParams.collectionName,
       });
 
-      expect([0, 65535]).toContain(refresh.code);
+      expect(refresh.code).toEqual(0);
     });
 
     it('should describe default collection successfully', async () => {

--- a/test/utils/Collection.spec.ts
+++ b/test/utils/Collection.spec.ts
@@ -1,0 +1,707 @@
+import { status as grpcStatus } from '@grpc/grpc-js';
+import {
+  DataType,
+  DEFAULT_DB,
+  ErrorCode,
+  ERROR_REASONS,
+  FunctionType,
+  getGRPCService,
+  IndexType,
+  LOADER_OPTIONS,
+  MilvusClient,
+  ResStatus,
+} from '../../milvus';
+
+type RpcCallback = (error: any, response?: any) => void;
+
+const COLLECTION_NAME = 'schema_alter_collection';
+
+const successStatus: ResStatus = {
+  error_code: ErrorCode.SUCCESS,
+  reason: '',
+  code: 0,
+  extra_info: {},
+  retriable: false,
+  detail: '',
+};
+
+const failedStatus: ResStatus = {
+  error_code: ErrorCode.UnexpectedError,
+  reason: 'schema alteration failed',
+  code: 1,
+  extra_info: {},
+  retriable: false,
+  detail: '',
+};
+
+const respondWith =
+  (response: any) => (_request: any, _options: any, callback: RpcCallback) =>
+    callback(null, response);
+
+const failWith =
+  (error: any) => (_request: any, _options: any, callback: RpcCallback) =>
+    callback(error);
+
+const createTestClient = () => {
+  const rpcClient = {
+    AlterCollectionSchema: jest.fn(),
+    AddCollectionField: jest.fn(),
+    AddCollectionFunction: jest.fn(),
+    DropCollectionFunction: jest.fn(),
+    DropCollection: jest.fn(),
+    DescribeCollection: jest.fn(),
+  };
+  const channelPool = {
+    acquire: jest.fn().mockResolvedValue(rpcClient),
+    release: jest.fn(),
+  };
+  const client = new MilvusClient({
+    address: 'localhost:19530',
+    __SKIP_CONNECT__: true,
+  });
+  (client as any).channelPool = channelPool;
+
+  return { client, rpcClient, channelPool };
+};
+
+const cacheKey = (dbName = DEFAULT_DB) => `${dbName}:${COLLECTION_NAME}`;
+
+const seedCollectionCache = (client: MilvusClient, dbName = DEFAULT_DB) => {
+  const cache = (client as any).collectionInfoCache;
+  cache.set(cacheKey(dbName), { cached: true });
+  return cache;
+};
+
+const bm25Function = {
+  name: 'bm25_function',
+  type: FunctionType.BM25,
+  input_field_names: ['text'],
+  output_field_names: ['sparse_vector'],
+  params: { analyzer: 'standard' },
+};
+
+describe('collection schema alteration', () => {
+  describe('addCollectionField', () => {
+    it('uses AlterCollectionSchema and evicts the schema cache on success', async () => {
+      const { client, rpcClient } = createTestClient();
+      rpcClient.AlterCollectionSchema.mockImplementation(
+        respondWith({ alter_status: successStatus })
+      );
+      const cache = seedCollectionCache(client, 'db1');
+
+      const result = await client.addCollectionField({
+        collection_name: COLLECTION_NAME,
+        db_name: 'db1',
+        client_request_id: 'request-1',
+        field: {
+          name: 'age',
+          data_type: DataType.Int64,
+          nullable: true,
+          default_value: 42,
+        },
+      });
+
+      expect(result).toEqual(successStatus);
+      expect(rpcClient.AlterCollectionSchema).toHaveBeenCalledTimes(1);
+      expect(rpcClient.AddCollectionField).not.toHaveBeenCalled();
+      const alterRequest = rpcClient.AlterCollectionSchema.mock.calls[0][0];
+      expect(alterRequest).toEqual(
+        expect.objectContaining({
+          collection_name: COLLECTION_NAME,
+          db_name: 'db1',
+          action: {
+            add_request: {
+              field_infos: [
+                {
+                  field_schema: expect.objectContaining({
+                    name: 'age',
+                    data_type: DataType.Int64,
+                    nullable: true,
+                    default_value: { long_data: 42 },
+                  }),
+                },
+              ],
+            },
+          },
+        })
+      );
+      const service = getGRPCService(
+        { serviceName: 'milvus.proto.milvus.MilvusService' },
+        LOADER_OPTIONS
+      ) as any;
+      const alterMethod = service.service.AlterCollectionSchema;
+      const serializedRequest = alterMethod.requestDeserialize(
+        alterMethod.requestSerialize(alterRequest)
+      );
+      expect(
+        serializedRequest.action.add_request.field_infos[0].field_schema
+          .default_value
+      ).toEqual(expect.objectContaining({ long_data: '42' }));
+      expect(
+        rpcClient.AlterCollectionSchema.mock.calls[0][1].metadata.get(
+          'client-request-id'
+        )
+      ).toEqual(['request-1']);
+      expect(cache.has(cacheKey('db1'))).toBe(false);
+    });
+
+    it('uses the explicit database name consistently for describe and invalidation', async () => {
+      const { client, rpcClient } = createTestClient();
+      rpcClient.DescribeCollection.mockImplementation(
+        respondWith({
+          status: successStatus,
+          collection_name: COLLECTION_NAME,
+          schema: { fields: [], struct_array_fields: [], functions: [] },
+        })
+      );
+      rpcClient.AlterCollectionSchema.mockImplementation(
+        respondWith({ alter_status: successStatus })
+      );
+
+      await client.describeCollection({
+        collection_name: COLLECTION_NAME,
+        db_name: 'db1',
+        cache: false,
+      });
+      const cache = (client as any).collectionInfoCache;
+      expect(cache.has(cacheKey('db1'))).toBe(true);
+      expect(cache.has(cacheKey())).toBe(false);
+
+      await client.addCollectionField({
+        collection_name: COLLECTION_NAME,
+        db_name: 'db1',
+        field: { name: 'age', data_type: DataType.Int64, nullable: true },
+      });
+      expect(cache.has(cacheKey('db1'))).toBe(false);
+    });
+
+    it('falls back to AddCollectionField only for UNIMPLEMENTED', async () => {
+      const { client, rpcClient } = createTestClient();
+      rpcClient.AlterCollectionSchema.mockImplementation(
+        failWith({ code: grpcStatus.UNIMPLEMENTED, details: 'not implemented' })
+      );
+      rpcClient.AddCollectionField.mockImplementation(
+        respondWith(successStatus)
+      );
+      const cache = seedCollectionCache(client);
+      const defaultValue = '2024-01-15T10:30:00Z';
+      const field = {
+        name: 'event_time',
+        data_type: DataType.Timestamptz,
+        nullable: true,
+        default_value: defaultValue,
+      };
+
+      const result = await client.addCollectionField({
+        collection_name: COLLECTION_NAME,
+        field,
+      });
+
+      expect(result).toEqual(successStatus);
+      expect(rpcClient.AlterCollectionSchema).toHaveBeenCalledTimes(1);
+      expect(rpcClient.AddCollectionField).toHaveBeenCalledTimes(1);
+      const legacyRequest = rpcClient.AddCollectionField.mock.calls[0][0];
+      expect(legacyRequest).toEqual(
+        expect.objectContaining({ collection_name: COLLECTION_NAME })
+      );
+      expect(legacyRequest.schema).toBeInstanceOf(Uint8Array);
+      const fieldSchemaType = (client as any).schemaProto.lookupType(
+        (client as any).protoInternalPath.fieldSchema
+      );
+      const decoded = fieldSchemaType.toObject(
+        fieldSchemaType.decode(legacyRequest.schema),
+        { longs: String }
+      );
+      expect(decoded.defaultValue).toEqual({
+        timestamptzData: (new Date(defaultValue).getTime() * 1000).toString(),
+      });
+      expect(field.default_value).toBe(defaultValue);
+      expect(cache.has(cacheKey())).toBe(false);
+    });
+
+    it('does not fall back for non-UNIMPLEMENTED transport errors', async () => {
+      const { client, rpcClient } = createTestClient();
+      const permissionError = {
+        code: grpcStatus.PERMISSION_DENIED,
+        details: 'permission denied',
+      };
+      rpcClient.AlterCollectionSchema.mockImplementation(
+        failWith(permissionError)
+      );
+      const cache = seedCollectionCache(client);
+
+      await expect(
+        client.addCollectionField({
+          collection_name: COLLECTION_NAME,
+          field: { name: 'age', data_type: DataType.Int64, nullable: true },
+        })
+      ).rejects.toBe(permissionError);
+
+      expect(rpcClient.AddCollectionField).not.toHaveBeenCalled();
+      expect(cache.has(cacheKey())).toBe(true);
+    });
+
+    it('returns AlterCollectionSchema business failures without fallback or cache eviction', async () => {
+      const { client, rpcClient } = createTestClient();
+      rpcClient.AlterCollectionSchema.mockImplementation(
+        respondWith({ alter_status: failedStatus })
+      );
+      const cache = seedCollectionCache(client);
+
+      const result = await client.addCollectionField({
+        collection_name: COLLECTION_NAME,
+        field: { name: 'age', data_type: DataType.Int64, nullable: true },
+      });
+
+      expect(result).toEqual(failedStatus);
+      expect(rpcClient.AddCollectionField).not.toHaveBeenCalled();
+      expect(cache.has(cacheKey())).toBe(true);
+    });
+
+    it('propagates legacy RPC errors and preserves the cache', async () => {
+      const { client, rpcClient } = createTestClient();
+      const legacyError = {
+        code: grpcStatus.INTERNAL,
+        details: 'legacy add field failed',
+      };
+      rpcClient.AlterCollectionSchema.mockImplementation(
+        failWith({ code: grpcStatus.UNIMPLEMENTED })
+      );
+      rpcClient.AddCollectionField.mockImplementation(failWith(legacyError));
+      const cache = seedCollectionCache(client);
+
+      await expect(
+        client.addCollectionField({
+          collection_name: COLLECTION_NAME,
+          field: { name: 'age', data_type: DataType.Int64, nullable: true },
+        })
+      ).rejects.toBe(legacyError);
+
+      expect(rpcClient.AddCollectionField).toHaveBeenCalledTimes(1);
+      expect(cache.has(cacheKey())).toBe(true);
+    });
+
+    it.each([DataType.FloatVector, DataType.BinaryVector])(
+      'rejects non-nullable vector field type %s before sending an RPC',
+      async dataType => {
+        const { client, rpcClient } = createTestClient();
+
+        await expect(
+          client.addCollectionField({
+            collection_name: COLLECTION_NAME,
+            field: {
+              name: 'vector',
+              data_type: dataType,
+              dim: 8,
+            },
+          })
+        ).rejects.toThrow(
+          ERROR_REASONS.ADD_COLLECTION_FIELD_VECTOR_NULLABLE_REQUIRED
+        );
+
+        expect(rpcClient.AlterCollectionSchema).not.toHaveBeenCalled();
+        expect(rpcClient.AddCollectionField).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  describe('dropCollectionField', () => {
+    it.each([
+      [
+        'name',
+        { field_name: 'obsolete_field' },
+        { field_name: 'obsolete_field' },
+      ],
+      ['ID', { field_id: '101' }, { field_id: '101' }],
+      [
+        'ID with an undefined name',
+        { field_name: undefined, field_id: '101' },
+        { field_id: '101' },
+      ],
+    ])('drops a field by %s', async (_mode, identifier, dropRequest) => {
+      const { client, rpcClient } = createTestClient();
+      rpcClient.AlterCollectionSchema.mockImplementation(
+        respondWith({ alter_status: successStatus })
+      );
+      const cache = seedCollectionCache(client);
+
+      const result = await client.dropCollectionField({
+        collection_name: COLLECTION_NAME,
+        ...identifier,
+      } as any);
+
+      expect(result).toEqual(successStatus);
+      expect(rpcClient.AlterCollectionSchema.mock.calls[0][0]).toEqual({
+        collection_name: COLLECTION_NAME,
+        action: { drop_request: dropRequest },
+      });
+      expect(cache.has(cacheKey())).toBe(false);
+    });
+
+    it.each([
+      {},
+      { field_name: 'field', field_id: 101 },
+      { field_name: '' },
+      { field_id: 0 },
+      { field_id: -1 },
+      { field_id: 1.5 },
+      { field_id: Number.MAX_SAFE_INTEGER + 1 },
+      { field_id: 'not-an-id' },
+      { field_id: '9223372036854775808' },
+    ])('rejects invalid field identifier %#', async identifier => {
+      const { client, rpcClient } = createTestClient();
+
+      await expect(
+        client.dropCollectionField({
+          collection_name: COLLECTION_NAME,
+          ...identifier,
+        } as any)
+      ).rejects.toThrow(
+        ERROR_REASONS.DROP_COLLECTION_FIELD_IDENTIFIER_IS_REQUIRED
+      );
+
+      expect(rpcClient.AlterCollectionSchema).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('function fields', () => {
+    it('serializes a BM25 function field and its bound index parameters', async () => {
+      const { client, rpcClient } = createTestClient();
+      rpcClient.AlterCollectionSchema.mockImplementation(
+        respondWith({ alter_status: successStatus })
+      );
+
+      const result = await client.addFunctionField({
+        collection_name: COLLECTION_NAME,
+        field: {
+          name: 'sparse_vector',
+          data_type: DataType.SparseFloatVector,
+          is_function_output: true,
+        },
+        function: bm25Function,
+        index_name: 'sparse_index',
+        extra_params: {
+          index_type: IndexType.SPARSE_INVERTED_INDEX,
+          metric_type: 'BM25',
+          params: { inverted_index_algo: 'DAAT_MAXSCORE', bm25_k1: 1.2 },
+        },
+      });
+
+      expect(result).toEqual(successStatus);
+      const addRequest =
+        rpcClient.AlterCollectionSchema.mock.calls[0][0].action.add_request;
+      expect(addRequest.field_infos[0]).toEqual(
+        expect.objectContaining({
+          index_name: 'sparse_index',
+          field_schema: expect.objectContaining({
+            name: 'sparse_vector',
+            data_type: DataType.SparseFloatVector,
+            is_function_output: true,
+          }),
+          extra_params: [
+            {
+              key: 'index_type',
+              value: IndexType.SPARSE_INVERTED_INDEX,
+            },
+            { key: 'metric_type', value: 'BM25' },
+            {
+              key: 'params',
+              value: '{"inverted_index_algo":"DAAT_MAXSCORE","bm25_k1":1.2}',
+            },
+          ],
+        })
+      );
+      expect(addRequest.func_schema).toEqual([
+        expect.objectContaining({
+          name: 'bm25_function',
+          type: FunctionType.BM25,
+          input_field_names: ['text'],
+          output_field_names: ['sparse_vector'],
+          params: [{ key: 'analyzer', value: 'standard' }],
+        }),
+      ]);
+    });
+
+    it('serializes a MinHash function field and its bound index parameters', async () => {
+      const { client, rpcClient } = createTestClient();
+      rpcClient.AlterCollectionSchema.mockImplementation(
+        respondWith({ alter_status: successStatus })
+      );
+
+      await client.addFunctionField({
+        collection_name: COLLECTION_NAME,
+        field: {
+          name: 'minhash_vector',
+          data_type: DataType.BinaryVector,
+          dim: 512,
+          is_function_output: true,
+        },
+        function: {
+          name: 'minhash_function',
+          type: 'MinHash',
+          input_field_names: ['text'],
+          output_field_names: ['minhash_vector'],
+          params: { num_hashes: 16 },
+        },
+        index_name: 'minhash_index',
+        extra_params: {
+          index_type: IndexType.MINHASH_LSH,
+          metric_type: 'MHJACCARD',
+          params: { mh_lsh_band: 4 },
+        },
+      });
+
+      const addRequest =
+        rpcClient.AlterCollectionSchema.mock.calls[0][0].action.add_request;
+      expect(addRequest.field_infos[0]).toEqual(
+        expect.objectContaining({
+          index_name: 'minhash_index',
+          field_schema: expect.objectContaining({
+            name: 'minhash_vector',
+            data_type: DataType.BinaryVector,
+          }),
+          extra_params: expect.arrayContaining([
+            { key: 'index_type', value: IndexType.MINHASH_LSH },
+            { key: 'metric_type', value: 'MHJACCARD' },
+            { key: 'params', value: '{"mh_lsh_band":4}' },
+          ]),
+        })
+      );
+      expect(addRequest.func_schema[0]).toEqual(
+        expect.objectContaining({
+          name: 'minhash_function',
+          type: FunctionType.MINHASH,
+          params: [{ key: 'num_hashes', value: '16' }],
+        })
+      );
+    });
+
+    it.each([
+      { index_type: IndexType.SPARSE_INVERTED_INDEX, metric_type: 'BM25' },
+      JSON.stringify({
+        index_type: IndexType.SPARSE_INVERTED_INDEX,
+        metric_type: 'BM25',
+      }),
+    ])('accepts index_type from legacy nested params %#', async params => {
+      const { client, rpcClient } = createTestClient();
+      rpcClient.AlterCollectionSchema.mockImplementation(
+        respondWith({ alter_status: successStatus })
+      );
+
+      await client.addFunctionField({
+        collection_name: COLLECTION_NAME,
+        field: {
+          name: 'sparse_vector',
+          data_type: DataType.SparseFloatVector,
+        },
+        function: bm25Function,
+        extra_params: { params },
+      });
+
+      expect(
+        rpcClient.AlterCollectionSchema.mock.calls[0][0].action.add_request
+          .field_infos[0].extra_params
+      ).toEqual([
+        {
+          key: 'params',
+          value: typeof params === 'string' ? params : JSON.stringify(params),
+        },
+      ]);
+    });
+
+    it('treats an undefined top-level index_type as absent', async () => {
+      const { client, rpcClient } = createTestClient();
+      rpcClient.AlterCollectionSchema.mockImplementation(
+        respondWith({ alter_status: successStatus })
+      );
+
+      await client.addFunctionField({
+        collection_name: COLLECTION_NAME,
+        field: {
+          name: 'sparse_vector',
+          data_type: DataType.SparseFloatVector,
+        },
+        function: bm25Function,
+        extra_params: {
+          index_type: undefined,
+          params: {
+            index_type: IndexType.SPARSE_INVERTED_INDEX,
+            metric_type: 'BM25',
+          },
+        },
+      });
+
+      expect(
+        rpcClient.AlterCollectionSchema.mock.calls[0][0].action.add_request
+          .field_infos[0].extra_params
+      ).toEqual([
+        {
+          key: 'params',
+          value: JSON.stringify({
+            index_type: IndexType.SPARSE_INVERTED_INDEX,
+            metric_type: 'BM25',
+          }),
+        },
+      ]);
+    });
+
+    it.each([
+      { index_type: undefined },
+      { index_type: '' },
+      { params: { metric_type: 'BM25' } },
+    ])('rejects missing index_type %#', async extraParams => {
+      const { client, rpcClient } = createTestClient();
+
+      await expect(
+        client.addFunctionField({
+          collection_name: COLLECTION_NAME,
+          field: {
+            name: 'sparse_vector',
+            data_type: DataType.SparseFloatVector,
+          },
+          function: bm25Function,
+          extra_params: extraParams,
+        } as any)
+      ).rejects.toThrow(
+        ERROR_REASONS.ADD_FUNCTION_FIELD_INDEX_TYPE_IS_REQUIRED
+      );
+
+      expect(rpcClient.AlterCollectionSchema).not.toHaveBeenCalled();
+    });
+
+    it('rejects AUTOINDEX for a bound function-field index', async () => {
+      const { client, rpcClient } = createTestClient();
+
+      await expect(
+        client.addFunctionField({
+          collection_name: COLLECTION_NAME,
+          field: {
+            name: 'sparse_vector',
+            data_type: DataType.SparseFloatVector,
+          },
+          function: bm25Function,
+          extra_params: { index_type: IndexType.AUTOINDEX },
+        })
+      ).rejects.toThrow(
+        ERROR_REASONS.ADD_FUNCTION_FIELD_AUTOINDEX_NOT_SUPPORTED
+      );
+
+      expect(rpcClient.AlterCollectionSchema).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { index_type: IndexType.SPARSE_WAND },
+      JSON.stringify({ metric_type: 'IP' }),
+    ])('rejects duplicated nested bound-index params %#', async params => {
+      const { client, rpcClient } = createTestClient();
+
+      await expect(
+        client.addFunctionField({
+          collection_name: COLLECTION_NAME,
+          field: {
+            name: 'sparse_vector',
+            data_type: DataType.SparseFloatVector,
+          },
+          function: bm25Function,
+          extra_params: {
+            index_type: IndexType.SPARSE_INVERTED_INDEX,
+            metric_type: 'BM25',
+            params,
+          },
+        })
+      ).rejects.toThrow(
+        ERROR_REASONS.ADD_FUNCTION_FIELD_DUPLICATED_INDEX_PARAM
+      );
+
+      expect(rpcClient.AlterCollectionSchema).not.toHaveBeenCalled();
+    });
+
+    it('drops a function field with its output fields and indexes', async () => {
+      const { client, rpcClient } = createTestClient();
+      rpcClient.AlterCollectionSchema.mockImplementation(
+        respondWith({ alter_status: successStatus })
+      );
+      const cache = seedCollectionCache(client);
+
+      const result = await client.dropFunctionField({
+        collection_name: COLLECTION_NAME,
+        function_name: 'bm25_function',
+      });
+
+      expect(result).toEqual(successStatus);
+      expect(rpcClient.AlterCollectionSchema.mock.calls[0][0]).toEqual({
+        collection_name: COLLECTION_NAME,
+        action: {
+          drop_request: {
+            function_name: 'bm25_function',
+            drop_function_output_fields: true,
+          },
+        },
+      });
+      expect(cache.has(cacheKey())).toBe(false);
+    });
+  });
+
+  describe('legacy function APIs', () => {
+    it('keeps addCollectionFunction on the legacy RPC', async () => {
+      const { client, rpcClient } = createTestClient();
+      rpcClient.AddCollectionFunction.mockImplementation(
+        respondWith(successStatus)
+      );
+
+      const result = await client.addCollectionFunction({
+        collection_name: COLLECTION_NAME,
+        function: bm25Function,
+      });
+
+      expect(result).toEqual(successStatus);
+      expect(rpcClient.AddCollectionFunction).toHaveBeenCalledTimes(1);
+      expect(rpcClient.AlterCollectionSchema).not.toHaveBeenCalled();
+      expect(rpcClient.AddCollectionFunction.mock.calls[0][0]).toEqual({
+        collection_name: COLLECTION_NAME,
+        functionSchema: expect.objectContaining({
+          name: 'bm25_function',
+          type: FunctionType.BM25,
+        }),
+      });
+    });
+
+    it('keeps dropCollectionFunction on the legacy RPC', async () => {
+      const { client, rpcClient } = createTestClient();
+      rpcClient.DropCollectionFunction.mockImplementation(
+        respondWith(successStatus)
+      );
+
+      const result = await client.dropCollectionFunction({
+        collection_name: COLLECTION_NAME,
+        function_name: 'bm25_function',
+      });
+
+      expect(result).toEqual(successStatus);
+      expect(rpcClient.DropCollectionFunction).toHaveBeenCalledTimes(1);
+      expect(rpcClient.AlterCollectionSchema).not.toHaveBeenCalled();
+      expect(rpcClient.DropCollectionFunction.mock.calls[0][0]).toEqual({
+        collection_name: COLLECTION_NAME,
+        function_name: 'bm25_function',
+      });
+    });
+  });
+
+  describe('collection cache', () => {
+    it('evicts the requested database entry after dropping a collection', async () => {
+      const { client, rpcClient } = createTestClient();
+      rpcClient.DropCollection.mockImplementation(respondWith(successStatus));
+      const cache = seedCollectionCache(client, 'db1');
+      cache.set(cacheKey(), { activeDatabaseEntry: true });
+
+      const result = await client.dropCollection({
+        collection_name: COLLECTION_NAME,
+        db_name: 'db1',
+      });
+
+      expect(result).toEqual(successStatus);
+      expect(cache.has(cacheKey('db1'))).toBe(false);
+      expect(cache.has(cacheKey())).toBe(true);
+    });
+  });
+});

--- a/test/utils/Grpc.spec.ts
+++ b/test/utils/Grpc.spec.ts
@@ -1,9 +1,14 @@
 import path from 'path';
-import { InterceptingCall, Metadata } from '@grpc/grpc-js';
+import {
+  InterceptingCall,
+  Metadata,
+  status as grpcStatus,
+} from '@grpc/grpc-js';
 import {
   getGRPCService,
   getMetaInterceptor,
   getRequestMetadataInterceptor,
+  getRetryInterceptor,
   LOADER_OPTIONS,
 } from '../../milvus';
 // mock
@@ -16,6 +21,7 @@ jest.mock('@grpc/grpc-js', () => {
     loadPackageDefinition: actual.loadPackageDefinition,
     ServiceClientConstructor: actual.ServiceClientConstructor,
     GrpcObject: actual.GrpcObject,
+    status: actual.status,
   };
 });
 
@@ -23,6 +29,45 @@ describe(`utils/grpc`, () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+
+  const createRetryCall = (methodName: string) => {
+    let retryListener: any;
+    const nextCall = jest.fn(() => ({
+      start: jest.fn(),
+      sendMessage: jest.fn(),
+    }));
+    const startNext = jest.fn((_metadata: Metadata, listener: any) => {
+      retryListener = listener;
+    });
+
+    (InterceptingCall as any).mockImplementationOnce(
+      (call: any, requester: any) => ({
+        call,
+        start: requester.start,
+        sendMessage: requester.sendMessage,
+      })
+    );
+
+    const interceptor = getRetryInterceptor({
+      maxRetries: 3,
+      retryDelay: 0,
+      clientId: 'test-client',
+    });
+    const interceptedCall = interceptor(
+      {
+        method_definition: {
+          path: `/milvus.proto.milvus.MilvusService/${methodName}`,
+        },
+        deadline: new Date(Date.now() + 1000),
+      },
+      nextCall
+    ) as any;
+
+    interceptedCall.start(new Metadata(), jest.fn(), startNext);
+    interceptedCall.sendMessage({}, jest.fn());
+
+    return { nextCall, retryListener };
+  };
 
   it(`should return a service client constructor`, () => {
     const protoPath = path.resolve(__dirname, '../../proto/proto/milvus.proto');
@@ -145,5 +190,56 @@ describe(`utils/grpc`, () => {
     // Should also have added client-request-unixmsec
     const unixmsecValues = metadata.get('client-request-unixmsec');
     expect(unixmsecValues.length).toBeGreaterThan(0);
+  });
+
+  it.each(['Connect', 'CreateSnapshot'])(
+    'should retain the existing UNIMPLEMENTED compatibility for %s',
+    methodName => {
+      const { nextCall, retryListener } = createRetryCall(methodName);
+      const messageNext = jest.fn();
+      const statusNext = jest.fn();
+
+      retryListener.onReceiveMessage(
+        { reason: `${methodName} is not implemented` },
+        messageNext
+      );
+      retryListener.onReceiveStatus(
+        {
+          code: grpcStatus.UNIMPLEMENTED,
+          details: `${methodName} is not implemented`,
+          metadata: new Metadata(),
+        },
+        statusNext
+      );
+
+      expect(messageNext).toHaveBeenCalledWith({});
+      expect(statusNext).toHaveBeenCalledWith(
+        expect.objectContaining({ code: grpcStatus.OK })
+      );
+      expect(nextCall).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it('should propagate UNIMPLEMENTED from AlterCollectionSchema without retrying', () => {
+    const { nextCall, retryListener } = createRetryCall(
+      'AlterCollectionSchema'
+    );
+    const messageNext = jest.fn();
+    const statusNext = jest.fn();
+
+    retryListener.onReceiveStatus(
+      {
+        code: grpcStatus.UNIMPLEMENTED,
+        details: 'AlterCollectionSchema is not implemented',
+        metadata: new Metadata(),
+      },
+      statusNext
+    );
+
+    expect(statusNext).toHaveBeenCalledWith(
+      expect.objectContaining({ code: grpcStatus.UNIMPLEMENTED })
+    );
+    expect(nextCall).toHaveBeenCalledTimes(1);
+    expect(messageNext).not.toHaveBeenCalled();
   });
 });

--- a/test/utils/Schema.spec.ts
+++ b/test/utils/Schema.spec.ts
@@ -464,7 +464,7 @@ describe('utils/Schema', () => {
   it('formats function schema when function type is a string enum key', () => {
     const payload = formatFunctionSchema({
       name: 'bm25_func',
-      type: 'BM25' as unknown as FunctionType,
+      type: 'BM25',
       input_field_names: ['text'],
       output_field_names: ['sparse'],
       params: { enable_match: true },
@@ -478,6 +478,68 @@ describe('utils/Schema', () => {
       params: [{ key: 'enable_match', value: 'true' }],
     });
   });
+
+  it.each([
+    ['Unknown', FunctionType.Unknown],
+    ['BM25', FunctionType.BM25],
+    ['TextEmbedding', FunctionType.TEXTEMBEDDING],
+    ['Rerank', FunctionType.RERANK],
+    ['MinHash', FunctionType.MINHASH],
+    ['MolFingerprint', FunctionType.MOLFINGERPRINT],
+  ] as const)(
+    'encodes string function type %s correctly in collection schemas',
+    (functionType, expectedType) => {
+      const schemaProtoPath = path.resolve(
+        __dirname,
+        '../../proto/proto/schema.proto'
+      );
+      const schemaProto = protobuf.loadSync(schemaProtoPath);
+      const collectionSchemaType = schemaProto.lookupType(
+        'milvus.proto.schema.CollectionSchema'
+      );
+      const fieldSchemaType = schemaProto.lookupType(
+        'milvus.proto.schema.FieldSchema'
+      );
+      const functionSchemaType = schemaProto.lookupType(
+        'milvus.proto.schema.FunctionSchema'
+      );
+
+      const payload = formatCollectionSchema(
+        {
+          collection_name: 'function_type_collection',
+          fields: [
+            {
+              name: 'id',
+              data_type: DataType.Int64,
+              is_primary_key: true,
+            },
+          ],
+          functions: [
+            {
+              name: 'function',
+              type: functionType,
+              input_field_names: ['id'],
+              output_field_names: [],
+              params: {},
+            },
+          ],
+        },
+        { fieldSchemaType, functionSchemaType }
+      );
+
+      expect(payload.functions[0].type).toBe(expectedType);
+
+      const decoded = collectionSchemaType.toObject(
+        collectionSchemaType.decode(
+          collectionSchemaType
+            .encode(collectionSchemaType.create(payload))
+            .finish()
+        ),
+        { enums: String, defaults: true }
+      );
+      expect(decoded.functions[0].type).toBe(functionType);
+    }
+  );
 
   it('formats struct array fields in create collection schema', () => {
     const schemaProtoPath = path.resolve(


### PR DESCRIPTION
## Summary

- Add Node.js SDK support for dropping collection fields and adding or dropping function-backed fields through `AlterCollectionSchema`.
- Route `addCollectionField` through `AlterCollectionSchema`, with fallback to the legacy `AddCollectionField` RPC only when the server returns gRPC `UNIMPLEMENTED`.
- Mark the legacy `addCollectionFunction` and `dropCollectionFunction` methods as deprecated in favor of function-field APIs.
- Keep collection schema caches consistent after successful mutations and explicit-database collection drops.
- Normalize string function types before protobuf encoding so collection creation preserves BM25, MinHash, and other supported function enums.
- Update the proto submodule and generated proto descriptors for the schema-alter request and response contracts.
- Pin CI integration tests to a current Milvus 3.0 image that supports the schema-alter add and drop actions covered by this PR.

issue: https://github.com/milvus-io/milvus/issues/48983

Related work:

- https://github.com/milvus-io/milvus/issues/48808
- https://github.com/milvus-io/milvus/issues/51348
- https://github.com/milvus-io/milvus/pull/51411

## Compatibility

- New SDKs remain compatible with older Milvus servers for `addCollectionField`: fallback occurs only for the raw gRPC `UNIMPLEMENTED` status. Permission, validation, transport, and application errors are returned without retrying the legacy RPC.
- Drop-field and function-field methods require a server that implements the corresponding `AlterCollectionSchema` actions.
- The legacy collection-function methods remain callable; only their TypeScript/JSDoc declarations are marked deprecated.

## Test Plan

- [x] `npm run build`
- [x] Prettier checks for all changed handwritten TypeScript files
- [x] Focused utility tests for schema serialization, gRPC response handling, mutation requests, fallback behavior, and cache invalidation (65 tests)
- [x] Protobuf create/encode/decode coverage for all supported string function types
- [x] `git diff --check`

The existing gRPC integration suites require a Milvus instance at `127.0.0.1:19530`; they were not included in the final local run because that instance was stopped.
