### PR TITLE
feat: support query aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,10 +271,30 @@ const results = await client.query({
   output_fields?: string[];     // Fields to return (default: all)
   limit?: number;
   offset?: number;
+  group_by_fields?: string[];   // Scalar fields used to group aggregation results
   consistency_level?: ConsistencyLevelEnum;
   partition_names?: string[];
 });
 // Returns: { data: Record<string, any>[] }
+```
+
+Aggregation functions are specified in `output_fields`. The supported functions
+are `count`, `min`, `max`, `sum`, and `avg`.
+
+```typescript
+const results = await client.query({
+  collection_name: 'sales',
+  filter: 'price > 0',
+  group_by_fields: ['category'],
+  output_fields: [
+    'category',
+    'count(price)',
+    'min(price)',
+    'max(price)',
+    'sum(price)',
+    'avg(price)',
+  ],
+});
 ```
 
 #### get

--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -1127,6 +1127,7 @@ export class Data extends Collection {
    * @param {string[]} [data.partitions_names] - Array of partition names (optional).
    * @param {string[]} data.output_fields - Vector or scalar field to be returned.
    * @param {number} [data.timeout] - An optional duration of time in millisecond to allow for the RPC. If it is set to undefined, the client keeps waiting until the server responds or error occurs. Default is undefined.
+   * @param {string[]} [data.group_by_fields] - Scalar fields used to group aggregation results. Aggregation expressions such as `count(*)`, `min(price)`, `max(price)`, `sum(price)`, and `avg(price)` are specified in `output_fields`.
    * @param {OrderByFields} [data.order_by_fields] - Fields to sort query results by, for example `price:asc` or `[{ field: 'price', order: 'asc' }]` (optional).
    * @param {OrderByFields} [data.order_by] - Alias for data.order_by_fields (optional).
    * @param {{key: value}[]} [data.params] - An optional key pair json array of search parameters.
@@ -1162,6 +1163,15 @@ export class Data extends Collection {
     }
 
     const queryParams: { [key: string]: any } = { ...limits, ...offset };
+    if (data.group_by_fields !== undefined) {
+      if (!Array.isArray(data.group_by_fields)) {
+        throw new Error('Invalid group_by_fields format');
+      }
+
+      if (data.group_by_fields.length > 0) {
+        queryParams.group_by_fields = data.group_by_fields.join(',');
+      }
+    }
     const orderByFields = normalizeOrderByFields(
       data.order_by_fields ?? data.order_by
     );

--- a/milvus/types/Data.ts
+++ b/milvus/types/Data.ts
@@ -90,6 +90,7 @@ type BaseQueryReq = collectionNameReq & {
   filter?: string; // alias for expr
   offset?: number; // skip how many results
   limit?: number; // how many results you want
+  group_by_fields?: string[]; // scalar fields used to group aggregation results
   order_by_fields?: OrderByFields; // order by fields
   order_by?: OrderByFields; // alias for order_by_fields
   consistency_level?: ConsistencyLevelEnum; // consistency level

--- a/test/grpc/Data.spec.ts
+++ b/test/grpc/Data.spec.ts
@@ -667,6 +667,39 @@ describe(`Data.API`, () => {
     expect(Number(res.data[0][DEFAULT_COUNT_QUERY_STRING])).toEqual(count.data);
   });
 
+  it(`Query with grouped count, min, max, sum, and avg aggregations`, async () => {
+    const res = await milvusClient.query({
+      collection_name: COLLECTION_NAME,
+      group_by_fields: ['varChar2'],
+      output_fields: [
+        'varChar2',
+        'count(float)',
+        'min(float)',
+        'max(float)',
+        'sum(float)',
+        'avg(float)',
+      ],
+      limit: 10,
+    });
+
+    expect(res.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(res.data.length).toBeGreaterThan(0);
+    expect(res.data.length).toBeLessThanOrEqual(10);
+    res.data.forEach(row => {
+      const count = Number(row['count(float)']);
+      const min = Number(row['min(float)']);
+      const max = Number(row['max(float)']);
+      const sum = Number(row['sum(float)']);
+      const avg = Number(row['avg(float)']);
+
+      expect(row.varChar2).toBeDefined();
+      expect(count).toBeGreaterThan(0);
+      expect(min).toBeLessThanOrEqual(avg);
+      expect(avg).toBeLessThanOrEqual(max);
+      expect(sum).toBeCloseTo(avg * count, 5);
+    });
+  });
+
   it(`Query with count(*) and expr`, async () => {
     const count = await milvusClient.count({
       collection_name: COLLECTION_NAME,

--- a/test/utils/Data.spec.ts
+++ b/test/utils/Data.spec.ts
@@ -19,7 +19,7 @@ import {
 } from '../../milvus';
 
 describe('utils/Data', () => {
-  it('should pass query order by fields through query params', async () => {
+  it('should pass query grouping and order by fields through query params', async () => {
     const client = new MilvusClient({
       address: 'localhost:19530',
       __SKIP_CONNECT__: true,
@@ -43,16 +43,129 @@ describe('utils/Data', () => {
       filter: 'id > 0',
       limit: 10,
       offset: 2,
+      group_by_fields: ['category', 'brand'],
       order_by: ['price:asc', { field: 'rating', order: 'desc' }],
       cluster_id: 'in07-xxx',
     });
 
     expect(findKeyValue(queryParams.query_params, 'limit')).toBe(10);
     expect(findKeyValue(queryParams.query_params, 'offset')).toBe(2);
+    expect(findKeyValue(queryParams.query_params, 'group_by_fields')).toBe(
+      'category,brand'
+    );
     expect(findKeyValue(queryParams.query_params, 'order_by_fields')).toBe(
       'price:asc,rating:desc'
     );
     expect(findKeyValue(queryParams.query_params, CLUSTER_ID)).toBe('in07-xxx');
+  });
+
+  it('should reject an invalid query group_by_fields value', async () => {
+    const client = new MilvusClient({
+      address: 'localhost:19530',
+      __SKIP_CONNECT__: true,
+    });
+
+    await expect(
+      client.query({
+        collection_name: 'test_collection',
+        group_by_fields: 'category',
+        output_fields: ['category', 'count(*)'],
+      } as any)
+    ).rejects.toThrow('Invalid group_by_fields format');
+  });
+
+  it('should decode grouped count, min, max, sum, and avg query results', async () => {
+    const client = new MilvusClient({
+      address: 'localhost:19530',
+      __SKIP_CONNECT__: true,
+    });
+    const response: any = {
+      status: { error_code: ErrorCode.SUCCESS, reason: '' },
+      fields_data: [
+        {
+          type: 'VarChar',
+          field_name: 'category',
+          field_id: '101',
+          is_dynamic: false,
+          scalars: {
+            string_data: { data: ['books', 'music'] },
+            data: 'string_data',
+          },
+          field: 'scalars',
+        },
+        ...['count(price)', 'min(price)', 'max(price)', 'sum(price)'].map(
+          (field_name, index) => ({
+            type: 'Int64',
+            field_name,
+            field_id: `${102 + index}`,
+            is_dynamic: false,
+            scalars: {
+              long_data: {
+                data:
+                  field_name === 'count(price)'
+                    ? ['2', '1']
+                    : field_name === 'min(price)'
+                    ? ['10', '30']
+                    : field_name === 'max(price)'
+                    ? ['20', '30']
+                    : ['30', '30'],
+              },
+              data: 'long_data',
+            },
+            field: 'scalars',
+          })
+        ),
+        {
+          type: 'Double',
+          field_name: 'avg(price)',
+          field_id: '106',
+          is_dynamic: false,
+          scalars: {
+            double_data: { data: [15, 30] },
+            data: 'double_data',
+          },
+          field: 'scalars',
+        },
+      ],
+    };
+    (client as any).channelPool = {
+      acquire: jest.fn().mockResolvedValue({
+        Query: (_params: any, _options: any, cb: any) => cb(null, response),
+      }),
+      release: jest.fn(),
+    };
+
+    const result = await client.query({
+      collection_name: 'test_collection',
+      group_by_fields: ['category'],
+      output_fields: [
+        'category',
+        'count(price)',
+        'min(price)',
+        'max(price)',
+        'sum(price)',
+        'avg(price)',
+      ],
+    });
+
+    expect(result.data).toEqual([
+      {
+        category: 'books',
+        'count(price)': '2',
+        'min(price)': '10',
+        'max(price)': '20',
+        'sum(price)': '30',
+        'avg(price)': 15,
+      },
+      {
+        category: 'music',
+        'count(price)': '1',
+        'min(price)': '30',
+        'max(price)': '30',
+        'sum(price)': '30',
+        'avg(price)': 30,
+      },
+    ]);
   });
 
   it('should forward cluster_id through count query requests', async () => {


### PR DESCRIPTION
## What

- add group_by_fields to QueryReq and serialize it through Query query_params
- support grouped query results using count, min, max, sum, and avg expressions in output_fields
- validate invalid group_by_fields values and document the new query API
- add unit coverage for request serialization and aggregate result decoding
- add a real gRPC integration test covering all five aggregation functions

Related Milvus implementation: https://github.com/milvus-io/milvus/pull/44394

## Validation

- npm run build
- NODE_ENV=dev npx jest test/utils/Data.spec.ts --runInBand
- NODE_ENV=dev npx jest test/grpc/Data.spec.ts --runInBand against local Milvus 3.0-20260729-a4088530