### PR TITLE
feat: support search aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,37 @@ const results = await client.search({
 });
 ```
 
+Search aggregation supports bucket metrics, top hits, and nested buckets.
+
+```typescript
+const results = await client.search({
+  collection_name: 'products',
+  data: [0.1, 0.2, 0.3, 0.4],
+  output_fields: ['category', 'brand', 'price'],
+  search_aggregation: {
+    fields: ['category'],
+    size: 5,
+    metrics: {
+      item_count: { op: 'count', field_name: '*' },
+      avg_price: { op: 'avg', field_name: 'price' },
+    },
+    order: [{ key: 'avg_price', direction: 'desc' }],
+    top_hits: {
+      size: 2,
+      sort: [{ field_name: 'price', direction: 'asc' }],
+    },
+    sub_aggregation: {
+      fields: ['brand'],
+      size: 3,
+    },
+  },
+});
+
+// A single query vector returns AggregationBucket[].
+// Multiple query vectors return AggregationBucket[][].
+console.log(results.agg_buckets);
+```
+
 #### query
 
 Query rows with scalar filter expression.

--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -25,6 +25,7 @@ import {
   GePersistentSegmentInfoResponse,
   buildSearchRequest,
   formatSearchResult,
+  formatSearchAggregationResult,
   MutationResult,
   QueryResults,
   ResStatus,
@@ -792,13 +793,15 @@ export class Data extends Collection {
       request,
       params.timeout || this.timeout
     );
+    const hasSearchAggregation =
+      'search_aggregation' in params && !!params.search_aggregation;
 
     // if search failed
     // if nothing returned
     // return empty with status
     if (
       originSearchResult.status.error_code !== ErrorCode.SUCCESS ||
-      originSearchResult.results.scores.length === 0
+      (originSearchResult.results.scores.length === 0 && !hasSearchAggregation)
     ) {
       return {
         status: originSearchResult.status,
@@ -816,10 +819,20 @@ export class Data extends Collection {
     }
 
     // build final results array
-    const results = formatSearchResult(originSearchResult, {
-      round_decimal: round_decimal || -1,
-      transformers: params.transformers,
-    });
+    const results = originSearchResult.results.scores.length
+      ? formatSearchResult(originSearchResult, {
+          round_decimal: round_decimal || -1,
+          transformers: params.transformers,
+        })
+      : [];
+    const aggBuckets = hasSearchAggregation
+      ? formatSearchAggregationResult(originSearchResult)
+      : undefined;
+    const formattedAggBuckets = aggBuckets
+      ? ((nq === 1 ? aggBuckets[0] || [] : aggBuckets) as SearchResults<T>[
+          'agg_buckets'
+        ])
+      : undefined;
 
     return {
       status: originSearchResult.status,
@@ -833,6 +846,9 @@ export class Data extends Collection {
         originSearchResult.results.search_iterator_v2_results,
       _search_iterator_v2_results:
         originSearchResult.results._search_iterator_v2_results,
+      ...(formattedAggBuckets
+        ? { agg_buckets: formattedAggBuckets }
+        : {}),
     };
   }
 

--- a/milvus/types.ts
+++ b/milvus/types.ts
@@ -13,5 +13,6 @@ export * from './types/Http';
 export * from './types/Segments';
 export * from './types/Insert';
 export * from './types/Search';
+export * from './types/SearchAggregation';
 export * from './types/DataTypes';
 export * from './types/Volume';

--- a/milvus/types/Search.ts
+++ b/milvus/types/Search.ts
@@ -16,6 +16,11 @@ import {
   OrderByFields,
   GrpcTimeOut,
 } from '../';
+import {
+  AggregationBucket,
+  ProtoAggregationBucket,
+  SearchAggregation,
+} from './SearchAggregation';
 
 // Highlighter types
 export enum HighlightType {
@@ -93,6 +98,7 @@ export interface SearchReq extends collectionNameReq {
   transformers?: OutputTransformers; // provide custom data transformer for specific data type like bf16 or f16 vectors
   ids?: number[] | string[]; // primary keys for search by IDs
   highlighter?: Highlighter; // highlighter for search results
+  search_aggregation?: SearchAggregation; // bucket aggregation configuration
 }
 
 export interface FunctionScore {
@@ -128,6 +134,7 @@ export interface SearchSimpleReq extends collectionNameReq {
   nq?: number; // number of query vectors
   ids?: number[] | string[]; // primary keys for search by IDs
   highlighter?: Highlighter; // highlighter for search results
+  search_aggregation?: SearchAggregation; // bucket aggregation configuration
 }
 
 export type HybridSearchSingleReq = Pick<
@@ -144,7 +151,7 @@ export type HybridSearchSingleReq = Pick<
 
 export interface SearchIteratorReq extends Omit<
   SearchSimpleReq,
-  'vectors' | 'offset' | 'limit' | 'topk'
+  'vectors' | 'offset' | 'limit' | 'topk' | 'search_aggregation'
 > {
   limit?: number; // Optional. Specifies the maximum number of items. Default is no limit (-1 or if not set).
   batchSize: number; // Specifies the number of items to return in each batch. if it exceeds 16384, it will be set to 16384
@@ -167,6 +174,7 @@ export type HybridSearchReq = Omit<
   | 'expr'
   | 'exprValues'
   | 'order_by_fields'
+  | 'search_aggregation'
 > & {
   // search requests
   data: HybridSearchSingleReq[];
@@ -223,6 +231,8 @@ export interface SearchRes extends resStatusResponse {
       field_name: string;
       datas: HighlightData[];
     }[];
+    agg_buckets: ProtoAggregationBucket[];
+    agg_topks: (string | number)[];
   };
   collection_name: string;
   session_ts: number;
@@ -250,6 +260,20 @@ export type DetermineResultsType<T extends Record<string, any>> =
             ? SearchResultData[][]
             : SearchResultData[];
 
+export type DetermineAggregationResultsType<
+  T extends Record<string, any>,
+> = T['vectors'] extends [SearchData]
+  ? AggregationBucket[]
+  : T['vectors'] extends SearchData[]
+    ? AggregationBucket[][]
+    : T['vector'] extends SearchData
+      ? AggregationBucket[]
+      : T['data'] extends SearchData
+        ? AggregationBucket[]
+        : T['data'] extends SearchData[]
+          ? AggregationBucket[][]
+          : AggregationBucket[];
+
 export interface SearchResultData {
   [x: string]: any;
   score: number;
@@ -269,4 +293,5 @@ export interface SearchResults<
   all_search_count?: number;
   search_iterator_v2_results?: Record<string, any>;
   _search_iterator_v2_results?: string;
+  agg_buckets?: DetermineAggregationResultsType<T>;
 }

--- a/milvus/types/SearchAggregation.ts
+++ b/milvus/types/SearchAggregation.ts
@@ -1,0 +1,94 @@
+export type AggregationDirection = 'asc' | 'desc';
+export type AggregationMetricOp = 'avg' | 'sum' | 'count' | 'min' | 'max';
+
+export interface SearchAggregationMetric {
+  op: AggregationMetricOp;
+  field_name: string;
+}
+
+export interface SearchAggregationOrder {
+  key: string;
+  direction: AggregationDirection;
+}
+
+export interface SearchAggregationSort {
+  field_name: string;
+  direction: AggregationDirection;
+}
+
+export interface SearchAggregationTopHits {
+  size: number;
+  sort?: SearchAggregationSort[];
+}
+
+/** Bucket aggregation configuration for a search request. */
+export interface SearchAggregation {
+  fields: string[];
+  size: number;
+  metrics?: Record<string, SearchAggregationMetric>;
+  order?: SearchAggregationOrder[];
+  top_hits?: SearchAggregationTopHits;
+  sub_aggregation?: SearchAggregation;
+}
+
+export interface SearchAggregationSpec extends SearchAggregation {
+  metrics: Record<string, SearchAggregationMetric>;
+  order: SearchAggregationOrder[];
+  top_hits?: SearchAggregationTopHits & { sort: SearchAggregationSort[] };
+  sub_aggregation?: SearchAggregationSpec;
+}
+
+export type AggregationValue = string | number | boolean | Buffer;
+
+export interface AggregationBucketKey {
+  field_id: string | number;
+  field_name: string;
+  value?: AggregationValue;
+}
+
+export interface AggregationHit {
+  [field_name: string]: AggregationValue | undefined;
+  score: number;
+}
+
+export interface AggregationBucket {
+  key: AggregationBucketKey[];
+  count: string | number;
+  metrics: Record<string, AggregationValue | undefined>;
+  hits: AggregationHit[];
+  sub_groups: AggregationBucket[];
+}
+
+export interface ProtoAggregationValue {
+  value?: string;
+  int_val?: string | number;
+  double_val?: number;
+  string_val?: string;
+  bool_val?: boolean;
+}
+
+export interface ProtoAggregationHitField extends ProtoAggregationValue {
+  field_id: string | number;
+  field_name: string;
+  float_val?: number;
+  bytes_val?: Buffer;
+}
+
+export interface ProtoAggregationHit {
+  pk?: string;
+  int_pk?: string | number;
+  str_pk?: string;
+  score: number;
+  fields: ProtoAggregationHitField[];
+}
+
+export interface ProtoAggregationBucket {
+  key: (ProtoAggregationValue & {
+    field_id: string | number;
+    field_name: string;
+  })[];
+  count: string | number;
+  metrics: Record<string, ProtoAggregationValue>;
+  hits: ProtoAggregationHit[];
+  sub_groups: ProtoAggregationBucket[];
+}

--- a/milvus/types/index.ts
+++ b/milvus/types/index.ts
@@ -15,6 +15,7 @@ export * from './Http';
 export * from './Segments';
 export * from './Insert';
 export * from './Search';
+export * from './SearchAggregation';
 export * from './DataTypes';
 export * from './GlobalCluster';
 export * from './Volume';

--- a/milvus/utils/Search.ts
+++ b/milvus/utils/Search.ts
@@ -37,6 +37,8 @@ import {
   HighlightData,
   HighlightResult,
 } from '../';
+import { SearchAggregationSpec } from '../types/SearchAggregation';
+import { buildSearchAggregation } from './SearchAggregation';
 
 /**
  * Type guard to check if an object is a FunctionScore
@@ -171,6 +173,7 @@ type FormatedSearchRequest = {
   function_score?: any;
   requests?: FormatedSearchRequest[];
   highlighter?: { type: number; params: KeyValuePair[] };
+  search_aggregation?: SearchAggregationSpec;
 };
 
 /**
@@ -277,6 +280,59 @@ export const buildSearchRequest = (
     typeof searchHybridReq.data[0] === 'object' &&
     searchHybridReq.data[0].anns_field
   );
+
+  const searchAggregation =
+    searchSimpleReq.search_aggregation || searchReq.search_aggregation;
+  if (searchAggregation && isHybridSearch) {
+    throw new Error('search_aggregation is not supported for hybrid search');
+  }
+  if (searchAggregation && searchSimpleOrHybridReq.highlighter) {
+    throw new Error(
+      'highlighter and search_aggregation cannot be used simultaneously'
+    );
+  }
+
+  const aggregationConflictSources = [
+    searchSimpleReq.params,
+    searchReq.search_params,
+  ];
+  const hasNonEmptyAggregationConflict = (key: string) =>
+    aggregationConflictSources.some(source => {
+      const value = source?.[key];
+      return Array.isArray(value)
+        ? value.length > 0
+        : value !== undefined &&
+            value !== null &&
+            String(value).trim().length > 0;
+    });
+
+  if (
+    searchAggregation &&
+    (searchSimpleReq.group_by_field ||
+      hasNonEmptyAggregationConflict('group_by_field'))
+  ) {
+    throw new Error(
+      'search_aggregation and group_by_field are mutually exclusive'
+    );
+  }
+  if (
+    searchAggregation &&
+    ((Array.isArray((params as any).group_by_fields) &&
+      (params as any).group_by_fields.length > 0) ||
+      hasNonEmptyAggregationConflict('group_by_fields'))
+  ) {
+    throw new Error(
+      'search_aggregation and group_by_fields are mutually exclusive'
+    );
+  }
+
+  const aggregationOffset =
+    searchSimpleReq.offset ??
+    (searchSimpleReq.params?.offset as number | undefined) ??
+    searchReq.search_params?.offset;
+  if (searchAggregation && Number(aggregationOffset || 0) > 0) {
+    throw new Error('offset is not supported with search_aggregation');
+  }
 
   // output fields(reference fields)
   const default_output_fields: string[] = ['*'];
@@ -401,6 +457,9 @@ export const buildSearchRequest = (
       ),
       consistency_level:
         params.consistency_level || (collectionInfo.consistency_level as any),
+      ...(searchAggregation
+        ? { search_aggregation: buildSearchAggregation(searchAggregation) }
+        : {}),
     };
 
     if (ids && ids.length > 0) {

--- a/milvus/utils/SearchAggregation.ts
+++ b/milvus/utils/SearchAggregation.ts
@@ -1,0 +1,296 @@
+import {
+  AggregationBucket,
+  AggregationDirection,
+  AggregationHit,
+  AggregationMetricOp,
+  AggregationValue,
+  SearchAggregation,
+  SearchAggregationSpec,
+} from '../types/SearchAggregation';
+import { SearchRes } from '../types/Search';
+
+const VALID_METRIC_OPS: AggregationMetricOp[] = [
+  'avg',
+  'sum',
+  'count',
+  'min',
+  'max',
+];
+const VALID_DIRECTIONS: AggregationDirection[] = ['asc', 'desc'];
+const SPECIAL_ORDER_KEYS = ['_count', '_key'];
+const MAX_AGGREGATION_DEPTH = 4;
+
+const isObject = (value: unknown): value is Record<string, any> =>
+  !!value && typeof value === 'object' && !Array.isArray(value);
+
+const isPositiveInteger = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isInteger(value) && value > 0;
+
+/** Validate and clone a search aggregation into the protobuf request shape. */
+export const buildSearchAggregation = (
+  aggregation: SearchAggregation,
+  depth = 1
+): SearchAggregationSpec => {
+  if (!isObject(aggregation)) {
+    throw new Error('search_aggregation must be an object');
+  }
+  if (depth > MAX_AGGREGATION_DEPTH) {
+    throw new Error(
+      `search_aggregation supports at most ${MAX_AGGREGATION_DEPTH} levels`
+    );
+  }
+  if (!Array.isArray(aggregation.fields) || aggregation.fields.length === 0) {
+    throw new Error(
+      'search_aggregation.fields must be a non-empty array of strings'
+    );
+  }
+  aggregation.fields.forEach(field => {
+    if (typeof field !== 'string' || field.trim().length === 0) {
+      throw new Error(
+        'search_aggregation.fields must contain non-empty strings'
+      );
+    }
+    if (field.includes('[') || field.includes(']')) {
+      throw new Error(
+        'search_aggregation.fields does not support bracketed JSON paths'
+      );
+    }
+  });
+  if (!isPositiveInteger(aggregation.size)) {
+    throw new Error('search_aggregation.size must be a positive integer');
+  }
+
+  const metrics = aggregation.metrics === undefined ? {} : aggregation.metrics;
+  if (!isObject(metrics)) {
+    throw new Error('search_aggregation.metrics must be an object');
+  }
+  Object.entries(metrics).forEach(([alias, metric]) => {
+    if (!alias.trim()) {
+      throw new Error('search_aggregation metric aliases must be non-empty');
+    }
+    if (!isObject(metric)) {
+      throw new Error(`search_aggregation.metrics.${alias} must be an object`);
+    }
+    if (!VALID_METRIC_OPS.includes(metric.op)) {
+      throw new Error(
+        `search_aggregation.metrics.${alias}.op must be one of ${VALID_METRIC_OPS.join(
+          ', '
+        )}`
+      );
+    }
+    if (typeof metric.field_name !== 'string' || !metric.field_name.trim()) {
+      throw new Error(
+        `search_aggregation.metrics.${alias}.field_name must be non-empty`
+      );
+    }
+    if (metric.field_name === '*' && metric.op !== 'count') {
+      throw new Error("'*' is only valid for the count metric");
+    }
+  });
+
+  const order = aggregation.order === undefined ? [] : aggregation.order;
+  if (!Array.isArray(order)) {
+    throw new Error('search_aggregation.order must be an array');
+  }
+  const allowedOrderKeys = [...Object.keys(metrics), ...SPECIAL_ORDER_KEYS];
+  order.forEach(item => {
+    if (!isObject(item) || typeof item.key !== 'string' || !item.key.trim()) {
+      throw new Error('search_aggregation.order.key must be non-empty');
+    }
+    if (!allowedOrderKeys.includes(item.key)) {
+      throw new Error(
+        'search_aggregation.order.key must be a metric alias, _count, or _key'
+      );
+    }
+    if (!VALID_DIRECTIONS.includes(item.direction)) {
+      throw new Error(
+        "search_aggregation.order.direction must be 'asc' or 'desc'"
+      );
+    }
+  });
+
+  let topHits: SearchAggregationSpec['top_hits'];
+  if (aggregation.top_hits !== undefined) {
+    if (!isObject(aggregation.top_hits)) {
+      throw new Error('search_aggregation.top_hits must be an object');
+    }
+    if (!isPositiveInteger(aggregation.top_hits.size)) {
+      throw new Error(
+        'search_aggregation.top_hits.size must be a positive integer'
+      );
+    }
+    const sort =
+      aggregation.top_hits.sort === undefined ? [] : aggregation.top_hits.sort;
+    if (!Array.isArray(sort)) {
+      throw new Error('search_aggregation.top_hits.sort must be an array');
+    }
+    sort.forEach(item => {
+      if (
+        !isObject(item) ||
+        typeof item.field_name !== 'string' ||
+        !item.field_name.trim()
+      ) {
+        throw new Error(
+          'search_aggregation.top_hits.sort.field_name must be non-empty'
+        );
+      }
+      if (!VALID_DIRECTIONS.includes(item.direction)) {
+        throw new Error(
+          "search_aggregation.top_hits.sort.direction must be 'asc' or 'desc'"
+        );
+      }
+    });
+    topHits = {
+      size: aggregation.top_hits.size,
+      sort: sort.map(item => ({ ...item })),
+    };
+  }
+
+  const metricSpecs = Object.entries(metrics).reduce<
+    SearchAggregationSpec['metrics']
+  >((result, [alias, metric]) => {
+    result[alias] = { op: metric.op, field_name: metric.field_name };
+    return result;
+  }, {});
+
+  return {
+    fields: [...aggregation.fields],
+    size: aggregation.size,
+    metrics: metricSpecs,
+    order: order.map(item => ({ ...item })),
+    ...(topHits ? { top_hits: topHits } : {}),
+    ...(aggregation.sub_aggregation !== undefined
+      ? {
+          sub_aggregation: buildSearchAggregation(
+            aggregation.sub_aggregation,
+            depth + 1
+          ),
+        }
+      : {}),
+  };
+};
+
+const hasOwn = (value: object, key: string) =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+const readOneof = (
+  value: Record<string, any>,
+  discriminator: string,
+  fields: string[]
+): AggregationValue | undefined => {
+  const selected = value[discriminator];
+  if (typeof selected === 'string' && hasOwn(value, selected)) {
+    return value[selected];
+  }
+
+  for (const field of fields) {
+    if (hasOwn(value, field)) {
+      return value[field];
+    }
+  }
+
+  return undefined;
+};
+
+const parseAggregationHit = (
+  hit: SearchRes['results']['agg_buckets'][number]['hits'][number],
+  primaryFieldName: string
+): AggregationHit => {
+  const result: AggregationHit = { score: hit.score };
+  const primaryKey = readOneof(hit, 'pk', ['int_pk', 'str_pk']);
+  if (primaryKey !== undefined) {
+    result[primaryFieldName] = primaryKey;
+  }
+
+  hit.fields.forEach(field => {
+    const value = readOneof(field, 'value', [
+      'int_val',
+      'bool_val',
+      'float_val',
+      'double_val',
+      'string_val',
+      'bytes_val',
+    ]);
+    if (value === undefined) {
+      return;
+    }
+
+    const fieldName = field.field_name || String(field.field_id);
+    result[fieldName] = value;
+  });
+
+  return result;
+};
+
+const parseAggregationBucket = (
+  bucket: SearchRes['results']['agg_buckets'][number],
+  primaryFieldName: string
+): AggregationBucket => {
+  const metrics = Object.entries(bucket.metrics || {}).reduce<
+    AggregationBucket['metrics']
+  >((result, [alias, metric]) => {
+    result[alias] = readOneof(metric, 'value', [
+      'int_val',
+      'double_val',
+      'string_val',
+      'bool_val',
+    ]);
+    return result;
+  }, {});
+
+  return {
+    key: (bucket.key || []).map(entry => ({
+      field_id: entry.field_id,
+      field_name: entry.field_name || String(entry.field_id),
+      value: readOneof(entry, 'value', ['int_val', 'string_val', 'bool_val']),
+    })),
+    count: bucket.count,
+    metrics,
+    hits: (bucket.hits || []).map(hit =>
+      parseAggregationHit(hit, primaryFieldName)
+    ),
+    sub_groups: (bucket.sub_groups || []).map(subGroup =>
+      parseAggregationBucket(subGroup, primaryFieldName)
+    ),
+  };
+};
+
+/** Parse and split search aggregation buckets by query vector. */
+export const formatSearchAggregationResult = (
+  searchRes: SearchRes
+): AggregationBucket[][] => {
+  const protoBuckets = searchRes.results.agg_buckets || [];
+  if (protoBuckets.length === 0) {
+    return [];
+  }
+
+  const primaryFieldName = searchRes.results.primary_field_name || 'id';
+  const buckets = protoBuckets.map(bucket =>
+    parseAggregationBucket(bucket, primaryFieldName)
+  );
+  const aggTopks = searchRes.results.agg_topks || [];
+
+  if (aggTopks.length === 0) {
+    if (Number(searchRes.results.num_queries) > 1) {
+      return Array.from(
+        { length: Number(searchRes.results.num_queries) },
+        () => []
+      );
+    }
+    return [buckets];
+  }
+
+  const result: AggregationBucket[][] = [];
+  let offset = 0;
+  aggTopks.forEach(value => {
+    const bucketCount = Number(value);
+    result.push(buckets.slice(offset, offset + bucketCount));
+    offset += bucketCount;
+  });
+
+  if (offset < buckets.length) {
+    result[result.length - 1].push(...buckets.slice(offset));
+  }
+
+  return result;
+};

--- a/milvus/utils/index.ts
+++ b/milvus/utils/index.ts
@@ -3,6 +3,7 @@ export * from './Connection';
 export * from './Schema';
 export * from './Data';
 export * from './Search';
+export * from './SearchAggregation';
 export * from './Bytes';
 export * from './Format';
 export * from './Validate';

--- a/test/grpc/SearchAggregation.spec.ts
+++ b/test/grpc/SearchAggregation.spec.ts
@@ -1,0 +1,287 @@
+import {
+  AggregationBucket,
+  DataType,
+  ErrorCode,
+  IndexType,
+  MetricType,
+  MilvusClient,
+} from '../../milvus';
+import { GENERATE_NAME, IP } from '../tools';
+
+const milvusClient = new MilvusClient({ address: IP, logLevel: 'info' });
+const COLLECTION_NAME = GENERATE_NAME('search_aggregation');
+
+const rows = [
+  {
+    id: 1,
+    vector: [1, 0],
+    category: 'books',
+    brand: 'acme',
+    price: 10,
+    rating: 4,
+    in_stock: true,
+  },
+  {
+    id: 2,
+    vector: [0.99, 0.01],
+    category: 'books',
+    brand: 'acme',
+    price: 20,
+    rating: 5,
+    in_stock: true,
+  },
+  {
+    id: 3,
+    vector: [0.98, 0.02],
+    category: 'books',
+    brand: 'zen',
+    price: 30,
+    rating: 3,
+    in_stock: true,
+  },
+  {
+    id: 4,
+    vector: [0.97, 0.03],
+    category: 'books',
+    brand: 'zen',
+    price: 40,
+    rating: 4,
+    in_stock: true,
+  },
+  {
+    id: 5,
+    vector: [0.96, 0.04],
+    category: 'music',
+    brand: 'acme',
+    price: 50,
+    rating: 2,
+    in_stock: true,
+  },
+  {
+    id: 6,
+    vector: [0.95, 0.05],
+    category: 'music',
+    brand: 'acme',
+    price: 60,
+    rating: 3,
+    in_stock: true,
+  },
+  {
+    id: 7,
+    vector: [0.94, 0.06],
+    category: 'music',
+    brand: 'zen',
+    price: 70,
+    rating: 4,
+    in_stock: true,
+  },
+  {
+    id: 8,
+    vector: [0.93, 0.07],
+    category: 'music',
+    brand: 'zen',
+    price: 80,
+    rating: 5,
+    in_stock: true,
+  },
+];
+
+const keyValue = (bucket: any, fieldName: string) =>
+  bucket.key.find((entry: any) => entry.field_name === fieldName)?.value;
+
+describe('SearchAggregation API', () => {
+  beforeAll(async () => {
+    await milvusClient.createCollection({
+      collection_name: COLLECTION_NAME,
+      consistency_level: 'Strong',
+      fields: [
+        {
+          name: 'id',
+          data_type: DataType.Int64,
+          is_primary_key: true,
+        },
+        {
+          name: 'vector',
+          data_type: DataType.FloatVector,
+          dim: 2,
+        },
+        {
+          name: 'category',
+          data_type: DataType.VarChar,
+          max_length: 32,
+        },
+        {
+          name: 'brand',
+          data_type: DataType.VarChar,
+          max_length: 32,
+        },
+        {
+          name: 'price',
+          data_type: DataType.Int64,
+        },
+        {
+          name: 'rating',
+          data_type: DataType.Double,
+        },
+        {
+          name: 'in_stock',
+          data_type: DataType.Bool,
+        },
+      ],
+    });
+
+    const insert = await milvusClient.insert({
+      collection_name: COLLECTION_NAME,
+      data: rows,
+    });
+    expect(insert.status.error_code).toBe(ErrorCode.SUCCESS);
+
+    await milvusClient.flush({ collection_names: [COLLECTION_NAME] });
+    await milvusClient.createIndex({
+      collection_name: COLLECTION_NAME,
+      field_name: 'vector',
+      index_type: IndexType.FLAT,
+      metric_type: MetricType.L2,
+    });
+    await milvusClient.loadCollectionSync({
+      collection_name: COLLECTION_NAME,
+    });
+  });
+
+  afterAll(async () => {
+    await milvusClient
+      .releaseCollection({ collection_name: COLLECTION_NAME })
+      .catch(() => undefined);
+    await milvusClient
+      .dropCollection({ collection_name: COLLECTION_NAME })
+      .catch(() => undefined);
+    await milvusClient.closeConnection();
+  });
+
+  it('returns bucket metrics, top hits, and nested aggregation per query', async () => {
+    const result = await milvusClient.search({
+      collection_name: COLLECTION_NAME,
+      anns_field: 'vector',
+      data: [
+        [1, 0],
+        [0.9, 0.1],
+      ],
+      limit: rows.length,
+      filter: 'in_stock == true',
+      output_fields: ['category', 'brand', 'price', 'rating', 'in_stock'],
+      search_aggregation: {
+        fields: ['category'],
+        size: 2,
+        metrics: {
+          doc_count: { op: 'count', field_name: '*' },
+          min_price: { op: 'min', field_name: 'price' },
+          max_price: { op: 'max', field_name: 'price' },
+          total_price: { op: 'sum', field_name: 'price' },
+          avg_price: { op: 'avg', field_name: 'price' },
+        },
+        order: [{ key: 'total_price', direction: 'desc' }],
+        top_hits: {
+          size: 2,
+          sort: [{ field_name: 'price', direction: 'asc' }],
+        },
+        sub_aggregation: {
+          fields: ['brand'],
+          size: 2,
+          metrics: {
+            doc_count: { op: 'count', field_name: '*' },
+            avg_rating: { op: 'avg', field_name: 'rating' },
+          },
+          order: [{ key: 'avg_rating', direction: 'desc' }],
+          top_hits: {
+            size: 2,
+            sort: [{ field_name: 'price', direction: 'asc' }],
+          },
+        },
+      },
+    });
+
+    expect(result.status.error_code).toBe(ErrorCode.SUCCESS);
+    expect(result.results).toEqual([]);
+    const aggBuckets = (result.agg_buckets as unknown) as AggregationBucket[][];
+    expect(aggBuckets).toHaveLength(2);
+
+    aggBuckets.forEach(buckets => {
+      expect(buckets).toHaveLength(2);
+      expect(buckets.map(bucket => keyValue(bucket, 'category'))).toEqual([
+        'music',
+        'books',
+      ]);
+
+      const expectedByCategory = {
+        books: { min: 10, max: 40, sum: 100, avg: 25 },
+        music: { min: 50, max: 80, sum: 260, avg: 65 },
+      };
+
+      buckets.forEach(bucket => {
+        const category = keyValue(bucket, 'category') as 'books' | 'music';
+        const expected = expectedByCategory[category];
+        expect(Number(bucket.count)).toBe(4);
+        expect(Number(bucket.metrics.doc_count)).toBe(4);
+        expect(Number(bucket.metrics.min_price)).toBe(expected.min);
+        expect(Number(bucket.metrics.max_price)).toBe(expected.max);
+        expect(Number(bucket.metrics.total_price)).toBe(expected.sum);
+        expect(Number(bucket.metrics.avg_price)).toBeCloseTo(expected.avg);
+        expect(bucket.hits).toHaveLength(2);
+        expect(bucket.hits.map(hit => Number(hit.price))).toEqual(
+          category === 'books' ? [10, 20] : [50, 60]
+        );
+        bucket.hits.forEach(hit => {
+          expect(hit.category).toBe(category);
+          expect(hit.in_stock).toBe(true);
+        });
+
+        expect(bucket.sub_groups).toHaveLength(2);
+        const brands = bucket.sub_groups.map(subBucket =>
+          keyValue(subBucket, 'brand')
+        );
+        expect(brands.sort()).toEqual(['acme', 'zen']);
+        bucket.sub_groups.forEach(subBucket => {
+          const brand = keyValue(subBucket, 'brand');
+          expect(Number(subBucket.count)).toBe(2);
+          expect(Number(subBucket.metrics.doc_count)).toBe(2);
+          expect(subBucket.hits).toHaveLength(2);
+          const prices = subBucket.hits.map(hit => Number(hit.price));
+          expect(prices).toEqual([...prices].sort((a, b) => a - b));
+          subBucket.hits.forEach(hit => {
+            expect(hit.category).toBe(category);
+            expect(hit.brand).toBe(brand);
+          });
+          const expectedAverage =
+            subBucket.hits.reduce((sum, hit) => sum + Number(hit.rating), 0) /
+            subBucket.hits.length;
+          expect(Number(subBucket.metrics.avg_rating)).toBeCloseTo(
+            expectedAverage
+          );
+        });
+      });
+    });
+  });
+
+  it('returns a flat bucket array for a single query vector', async () => {
+    const result = await milvusClient.search({
+      collection_name: COLLECTION_NAME,
+      anns_field: 'vector',
+      data: [1, 0],
+      search_aggregation: {
+        fields: ['category'],
+        size: 2,
+        metrics: {
+          doc_count: { op: 'count', field_name: '*' },
+        },
+        order: [{ key: '_key', direction: 'asc' }],
+      },
+    });
+
+    expect(result.status.error_code).toBe(ErrorCode.SUCCESS);
+    expect(result.results).toEqual([]);
+    expect(result.agg_buckets).toHaveLength(2);
+    expect(
+      result.agg_buckets!.map(bucket => keyValue(bucket, 'category'))
+    ).toEqual(['books', 'music']);
+  });
+});

--- a/test/utils/SearchAggregation.spec.ts
+++ b/test/utils/SearchAggregation.spec.ts
@@ -1,0 +1,346 @@
+import path from 'path';
+import protobuf from 'protobufjs';
+import {
+  DataType,
+  HighlightType,
+  SearchAggregation,
+  buildSearchAggregation,
+  buildSearchRequest,
+  formatSearchAggregationResult,
+} from '../../milvus';
+
+const collectionInfo = {
+  status: { error_code: 'Success', reason: '' },
+  collection_name: 'products',
+  collectionID: '1',
+  consistency_level: 'Session',
+  schema: {
+    name: 'products',
+    fields: [
+      {
+        name: 'id',
+        fieldID: '1',
+        dataType: DataType.Int64,
+        data_type: 'Int64',
+        is_primary_key: true,
+      },
+      {
+        name: 'vector',
+        fieldID: '2',
+        dataType: DataType.FloatVector,
+        data_type: 'FloatVector',
+        type_params: [{ key: 'dim', value: '2' }],
+        index_params: [],
+      },
+    ],
+  },
+  anns_fields: {
+    vector: {
+      dataType: DataType.FloatVector,
+      data_type: 'FloatVector',
+      type_params: [{ key: 'dim', value: '2' }],
+      index_params: [],
+    },
+  },
+} as any;
+
+const milvusProto = protobuf.loadSync(
+  path.resolve(__dirname, '../../proto/proto/milvus.proto')
+);
+
+const basicAggregation = (): SearchAggregation => ({
+  fields: ['category'],
+  size: 3,
+  metrics: {
+    doc_count: { op: 'count', field_name: '*' },
+  },
+});
+
+describe('SearchAggregation', () => {
+  it('builds metrics, top hits, ordering, and nested aggregation', () => {
+    const aggregation = buildSearchAggregation({
+      fields: ['category'],
+      size: 3,
+      metrics: {
+        doc_count: { op: 'count', field_name: '*' },
+        min_price: { op: 'min', field_name: 'price' },
+        max_price: { op: 'max', field_name: 'price' },
+        total_price: { op: 'sum', field_name: 'price' },
+        avg_rating: { op: 'avg', field_name: 'rating' },
+      },
+      order: [
+        { key: 'avg_rating', direction: 'desc' },
+        { key: '_count', direction: 'desc' },
+        { key: '_key', direction: 'asc' },
+      ],
+      top_hits: {
+        size: 2,
+        sort: [
+          { field_name: 'price', direction: 'asc' },
+          { field_name: '_score', direction: 'desc' },
+        ],
+      },
+      sub_aggregation: {
+        fields: ['brand'],
+        size: 2,
+        metrics: {
+          brand_count: { op: 'count', field_name: '*' },
+        },
+      },
+    });
+
+    expect(aggregation).toEqual({
+      fields: ['category'],
+      size: 3,
+      metrics: {
+        doc_count: { op: 'count', field_name: '*' },
+        min_price: { op: 'min', field_name: 'price' },
+        max_price: { op: 'max', field_name: 'price' },
+        total_price: { op: 'sum', field_name: 'price' },
+        avg_rating: { op: 'avg', field_name: 'rating' },
+      },
+      order: [
+        { key: 'avg_rating', direction: 'desc' },
+        { key: '_count', direction: 'desc' },
+        { key: '_key', direction: 'asc' },
+      ],
+      top_hits: {
+        size: 2,
+        sort: [
+          { field_name: 'price', direction: 'asc' },
+          { field_name: '_score', direction: 'desc' },
+        ],
+      },
+      sub_aggregation: {
+        fields: ['brand'],
+        size: 2,
+        metrics: {
+          brand_count: { op: 'count', field_name: '*' },
+        },
+        order: [],
+      },
+    });
+  });
+
+  it.each([
+    {},
+    { fields: [], size: 1 },
+    { fields: [''], size: 1 },
+    { fields: ['meta["region"]'], size: 1 },
+    { fields: ['brand'], size: 0 },
+    {
+      fields: ['brand'],
+      size: 1,
+      metrics: { bad: { op: 'median', field_name: 'price' } },
+    },
+    {
+      fields: ['brand'],
+      size: 1,
+      metrics: { bad: { op: 'avg', field_name: '*' } },
+    },
+    {
+      fields: ['brand'],
+      size: 1,
+      order: [{ key: 'unknown', direction: 'asc' }],
+    },
+    {
+      fields: ['brand'],
+      size: 1,
+      top_hits: { size: 0 },
+    },
+    {
+      fields: ['brand'],
+      size: 1,
+      top_hits: {
+        size: 1,
+        sort: [{ field_name: '_score', direction: 'sideways' }],
+      },
+    },
+  ])('rejects invalid configurations', aggregation => {
+    expect(() => buildSearchAggregation(aggregation as any)).toThrow();
+  });
+
+  it('adds a plain aggregation object to a regular search request', () => {
+    const searchAggregation = basicAggregation();
+    const result = buildSearchRequest(
+      {
+        collection_name: 'products',
+        data: [0.1, 0.2],
+        search_aggregation: searchAggregation,
+      },
+      collectionInfo,
+      milvusProto
+    );
+
+    expect(result.isHybridSearch).toBe(false);
+    expect((result.request as any).search_aggregation).toEqual({
+      ...searchAggregation,
+      order: [],
+    });
+  });
+
+  it.each([
+    { group_by_field: 'brand', error: 'group_by_field' },
+    { params: { group_by_fields: ['brand'] }, error: 'group_by_fields' },
+    { offset: 1, error: 'offset' },
+    {
+      highlighter: { type: HighlightType.Lexical },
+      error: 'highlighter',
+    },
+  ])('rejects incompatible search options: $error', option => {
+    expect(() =>
+      buildSearchRequest(
+        {
+          collection_name: 'products',
+          data: [0.1, 0.2],
+          search_aggregation: basicAggregation(),
+          ...option,
+        } as any,
+        collectionInfo,
+        milvusProto
+      )
+    ).toThrow(option.error);
+  });
+
+  it('rejects search aggregation in hybrid search', () => {
+    expect(() =>
+      buildSearchRequest(
+        {
+          collection_name: 'products',
+          data: [{ anns_field: 'vector', data: [0.1, 0.2] }],
+          search_aggregation: basicAggregation(),
+        } as any,
+        collectionInfo,
+        milvusProto
+      )
+    ).toThrow('hybrid search');
+  });
+
+  it('parses typed metrics, top hits, and nested buckets', () => {
+    const result = formatSearchAggregationResult({
+      results: {
+        num_queries: 1,
+        agg_topks: ['1'],
+        agg_buckets: [
+          {
+            key: [
+              {
+                field_id: '10',
+                field_name: 'category',
+                string_val: 'books',
+                value: 'string_val',
+              },
+              {
+                field_id: '11',
+                field_name: 'featured',
+                bool_val: false,
+                value: 'bool_val',
+              },
+            ],
+            count: '9007199254740993',
+            metrics: {
+              total: {
+                int_val: '9007199254740995',
+                value: 'int_val',
+              },
+              average: { double_val: 12.5, value: 'double_val' },
+              label: { string_val: 'popular', value: 'string_val' },
+              active: { bool_val: true, value: 'bool_val' },
+            },
+            hits: [
+              {
+                int_pk: '9007199254740997',
+                pk: 'int_pk',
+                score: 0.25,
+                fields: [
+                  {
+                    field_id: '20',
+                    field_name: 'price',
+                    int_val: '99',
+                    value: 'int_val',
+                  },
+                  {
+                    field_id: '21',
+                    field_name: 'rating',
+                    double_val: 4.5,
+                    value: 'double_val',
+                  },
+                ],
+              },
+            ],
+            sub_groups: [
+              {
+                key: [
+                  {
+                    field_id: '30',
+                    field_name: 'brand',
+                    string_val: 'acme',
+                    value: 'string_val',
+                  },
+                ],
+                count: '1',
+                metrics: {},
+                hits: [],
+                sub_groups: [],
+              },
+            ],
+          },
+        ],
+      },
+    } as any);
+
+    const bucket = result[0][0];
+    expect(bucket.key.map(entry => entry.value)).toEqual(['books', false]);
+    expect(bucket.count).toBe('9007199254740993');
+    expect(bucket.metrics).toEqual({
+      total: '9007199254740995',
+      average: 12.5,
+      label: 'popular',
+      active: true,
+    });
+    expect(bucket.hits[0]).toEqual({
+      id: '9007199254740997',
+      score: 0.25,
+      price: '99',
+      rating: 4.5,
+    });
+    expect(bucket.sub_groups[0].key[0].value).toBe('acme');
+  });
+
+  it('splits top-level buckets by agg_topks', () => {
+    const bucket = (count: number) => ({
+      key: [],
+      count,
+      metrics: {},
+      hits: [],
+      sub_groups: [],
+    });
+    const result = formatSearchAggregationResult({
+      results: {
+        num_queries: 3,
+        agg_topks: ['2', '1', '3'],
+        agg_buckets: [1, 2, 3, 4, 5, 6].map(bucket),
+      },
+    } as any);
+
+    expect(result.map(buckets => buckets.map(item => item.count))).toEqual([
+      [1, 2],
+      [3],
+      [4, 5, 6],
+    ]);
+  });
+
+  it('does not guess bucket ownership without agg_topks for multiple queries', () => {
+    const result = formatSearchAggregationResult({
+      results: {
+        num_queries: 2,
+        agg_topks: [],
+        agg_buckets: [
+          { key: [], count: 1, metrics: {}, hits: [], sub_groups: [] },
+        ],
+      },
+    } as any);
+
+    expect(result).toEqual([[], []]);
+  });
+});

--- a/test/utils/SearchAggregation.spec.ts
+++ b/test/utils/SearchAggregation.spec.ts
@@ -123,11 +123,28 @@ describe('SearchAggregation', () => {
   });
 
   it.each([
+    null,
     {},
     { fields: [], size: 1 },
     { fields: [''], size: 1 },
     { fields: ['meta["region"]'], size: 1 },
     { fields: ['brand'], size: 0 },
+    { fields: ['brand'], size: 1, metrics: null },
+    {
+      fields: ['brand'],
+      size: 1,
+      metrics: { ' ': { op: 'count', field_name: '*' } },
+    },
+    {
+      fields: ['brand'],
+      size: 1,
+      metrics: { bad: null },
+    },
+    {
+      fields: ['brand'],
+      size: 1,
+      metrics: { bad: { op: 'count', field_name: ' ' } },
+    },
     {
       fields: ['brand'],
       size: 1,
@@ -138,6 +155,8 @@ describe('SearchAggregation', () => {
       size: 1,
       metrics: { bad: { op: 'avg', field_name: '*' } },
     },
+    { fields: ['brand'], size: 1, order: null },
+    { fields: ['brand'], size: 1, order: [{}] },
     {
       fields: ['brand'],
       size: 1,
@@ -146,7 +165,23 @@ describe('SearchAggregation', () => {
     {
       fields: ['brand'],
       size: 1,
+      order: [{ key: '_key', direction: 'sideways' }],
+    },
+    { fields: ['brand'], size: 1, top_hits: null },
+    {
+      fields: ['brand'],
+      size: 1,
       top_hits: { size: 0 },
+    },
+    {
+      fields: ['brand'],
+      size: 1,
+      top_hits: { size: 1, sort: null },
+    },
+    {
+      fields: ['brand'],
+      size: 1,
+      top_hits: { size: 1, sort: [{}] },
     },
     {
       fields: ['brand'],
@@ -158,6 +193,21 @@ describe('SearchAggregation', () => {
     },
   ])('rejects invalid configurations', aggregation => {
     expect(() => buildSearchAggregation(aggregation as any)).toThrow();
+  });
+
+  it('rejects aggregation nesting deeper than four levels', () => {
+    let aggregation: any = { fields: ['level_5'], size: 1 };
+    for (let level = 4; level >= 1; level--) {
+      aggregation = {
+        fields: [`level_${level}`],
+        size: 1,
+        sub_aggregation: aggregation,
+      };
+    }
+
+    expect(() => buildSearchAggregation(aggregation)).toThrow(
+      'at most 4 levels'
+    );
   });
 
   it('adds a plain aggregation object to a regular search request', () => {
@@ -181,8 +231,11 @@ describe('SearchAggregation', () => {
 
   it.each([
     { group_by_field: 'brand', error: 'group_by_field' },
+    { params: { group_by_field: 'brand' }, error: 'group_by_field' },
+    { group_by_fields: ['brand'], error: 'group_by_fields' },
     { params: { group_by_fields: ['brand'] }, error: 'group_by_fields' },
     { offset: 1, error: 'offset' },
+    { params: { offset: 1 }, error: 'offset' },
     {
       highlighter: { type: HighlightType.Lexical },
       error: 'highlighter',
@@ -327,6 +380,79 @@ describe('SearchAggregation', () => {
       [1, 2],
       [3],
       [4, 5, 6],
+    ]);
+  });
+
+  it('handles protobuf oneofs without discriminators', () => {
+    const result = formatSearchAggregationResult({
+      results: {
+        primary_field_name: 'product_id',
+        num_queries: 1,
+        agg_topks: [],
+        agg_buckets: [
+          {
+            key: [
+              { field_id: '10', field_name: '', int_val: '7' },
+              { field_id: '11', field_name: 'missing' },
+            ],
+            count: '1',
+            metrics: {
+              count: { int_val: '1' },
+              missing: {},
+            },
+            hits: [
+              {
+                str_pk: 'product-1',
+                score: 0.5,
+                fields: [
+                  {
+                    field_id: '20',
+                    field_name: '',
+                    string_val: 'value',
+                  },
+                  { field_id: '21', field_name: 'missing' },
+                ],
+              },
+            ],
+            sub_groups: [],
+          },
+        ],
+      },
+    } as any);
+
+    expect(result[0][0]).toEqual({
+      key: [
+        { field_id: '10', field_name: '10', value: '7' },
+        { field_id: '11', field_name: 'missing', value: undefined },
+      ],
+      count: '1',
+      metrics: { count: '1', missing: undefined },
+      hits: [{ product_id: 'product-1', score: 0.5, '20': 'value' }],
+      sub_groups: [],
+    });
+  });
+
+  it('returns empty buckets and appends unmatched trailing buckets', () => {
+    expect(
+      formatSearchAggregationResult({
+        results: { num_queries: 1, agg_topks: [], agg_buckets: [] },
+      } as any)
+    ).toEqual([]);
+
+    const result = formatSearchAggregationResult({
+      results: {
+        num_queries: 2,
+        agg_topks: ['1', '0'],
+        agg_buckets: [
+          { key: [], count: 1, metrics: {}, hits: [], sub_groups: [] },
+          { key: [], count: 2, metrics: {}, hits: [], sub_groups: [] },
+        ],
+      },
+    } as any);
+
+    expect(result.map(buckets => buckets.map(bucket => bucket.count))).toEqual([
+      [1],
+      [2],
     ]);
   });
 


### PR DESCRIPTION
## What changed

- add a plain-object `search_aggregation` API for bucket aggregation, count/min/max/sum/avg metrics, bucket ordering, top hits, and nested aggregation
- validate unsupported combinations and serialize the aggregation tree into `SearchRequest.search_aggregation`
- parse typed aggregation buckets and top hits while preserving int64 values as strings
- return flat `agg_buckets` for one query vector and per-query bucket arrays for multiple vectors
- document the API and add unit plus real-Milvus integration coverage

## Validation

- `npm run build`
- `NODE_ENV=dev npx jest test/utils/SearchAggregation.spec.ts test/utils/Search.spec.ts --runInBand`
- `NODE_ENV=dev npx jest test/grpc/SearchAggregation.spec.ts --runInBand` against local Milvus `127.0.0.1:19530`
- `npx tsc --noEmit`

Related: milvus-io/milvus#49046