### PR TITLE
feat: support advanced struct array operations

### DIFF
--- a/milvus/const/error.ts
+++ b/milvus/const/error.ts
@@ -83,6 +83,8 @@ export const ERROR_REASONS = {
     'Duplicated bound index parameters are not allowed.',
   ADD_COLLECTION_FIELD_VECTOR_NULLABLE_REQUIRED:
     'Adding a vector field to an existing collection requires nullable=true.',
+  ADD_COLLECTION_STRUCT_FIELD_NULLABLE_REQUIRED:
+    'Adding a struct array field to an existing collection requires nullable=true.',
   DROP_COLLECTION_FIELD_IDENTIFIER_IS_REQUIRED:
     'Specify exactly one valid `field_name` or `field_id`.',
   ALTER_COLLECTION_SCHEMA_STATUS_IS_REQUIRED:

--- a/milvus/grpc/Collection.ts
+++ b/milvus/grpc/Collection.ts
@@ -103,11 +103,9 @@ import {
   collectionNameReq,
 } from '../';
 
-const formatGrpcFieldSchema = (
-  field: FieldType,
-  schemaTypes: { fieldSchemaType: any }
+const formatFormattedGrpcFieldSchema = (
+  schema: Record<string, any>
 ): Record<string, any> => {
-  const schema = formatFieldSchema(field, schemaTypes);
   let defaultValue = schema.defaultValue;
   if (defaultValue) {
     defaultValue = {
@@ -137,6 +135,13 @@ const formatGrpcFieldSchema = (
   };
 };
 
+const formatGrpcFieldSchema = (
+  field: FieldType,
+  schemaTypes: { fieldSchemaType: any }
+): Record<string, any> => {
+  return formatFormattedGrpcFieldSchema(formatFieldSchema(field, schemaTypes));
+};
+
 const formatGrpcStructArrayFieldSchema = (
   field: FieldType,
   schemaTypes: {
@@ -152,25 +157,7 @@ const formatGrpcStructArrayFieldSchema = (
     description: schema.description,
     type_params: schema.typeParams,
     nullable: schema.nullable,
-    fields: schema.fields.map((child: any) => ({
-      fieldID: child.fieldID,
-      name: child.name,
-      is_primary_key: child.isPrimaryKey,
-      description: child.description,
-      data_type: child.dataType,
-      type_params: child.typeParams,
-      index_params: child.indexParams,
-      autoID: child.autoID,
-      state: child.state,
-      element_type: child.elementType,
-      default_value: child.defaultValue,
-      is_dynamic: child.isDynamic,
-      is_partition_key: child.isPartitionKey,
-      is_clustering_key: child.isClusteringKey,
-      nullable: child.nullable,
-      is_function_output: child.isFunctionOutput,
-      external_field: child.externalField,
-    })),
+    fields: schema.fields.map(formatFormattedGrpcFieldSchema),
   };
 };
 

--- a/milvus/grpc/Collection.ts
+++ b/milvus/grpc/Collection.ts
@@ -47,6 +47,7 @@ import {
   checkCollectionName,
   sleep,
   formatCollectionSchema,
+  formatStructArrayFieldSchema,
   formatDescribedCol,
   getDataKey,
   validatePartitionNumbers,
@@ -133,6 +134,43 @@ const formatGrpcFieldSchema = (
     nullable: schema.nullable,
     is_function_output: schema.isFunctionOutput,
     external_field: schema.externalField,
+  };
+};
+
+const formatGrpcStructArrayFieldSchema = (
+  field: FieldType,
+  schemaTypes: {
+    fieldSchemaType: any;
+    structArrayFieldSchemaType: any;
+  }
+): Record<string, any> => {
+  const schema = formatStructArrayFieldSchema(field, schemaTypes) as any;
+
+  return {
+    fieldID: schema.fieldID,
+    name: schema.name,
+    description: schema.description,
+    type_params: schema.typeParams,
+    nullable: schema.nullable,
+    fields: schema.fields.map((child: any) => ({
+      fieldID: child.fieldID,
+      name: child.name,
+      is_primary_key: child.isPrimaryKey,
+      description: child.description,
+      data_type: child.dataType,
+      type_params: child.typeParams,
+      index_params: child.indexParams,
+      autoID: child.autoID,
+      state: child.state,
+      element_type: child.elementType,
+      default_value: child.defaultValue,
+      is_dynamic: child.isDynamic,
+      is_partition_key: child.isPartitionKey,
+      is_clustering_key: child.isClusteringKey,
+      nullable: child.nullable,
+      is_function_output: child.isFunctionOutput,
+      external_field: child.externalField,
+    })),
   };
 };
 
@@ -370,10 +408,51 @@ export class Collection extends Database {
   async addCollectionField(data: AddCollectionFieldReq): Promise<ResStatus> {
     checkCollectionName(data);
 
-    if (
-      isVectorType(convertToDataType(data.field.data_type)) &&
-      data.field.nullable !== true
-    ) {
+    const dataType = convertToDataType(data.field.data_type);
+    const elementType =
+      typeof data.field.element_type === 'undefined'
+        ? DataType.None
+        : convertToDataType(data.field.element_type);
+    const isStructArray =
+      dataType === DataType.Array && elementType === DataType.Struct;
+
+    if (isStructArray) {
+      if (data.field.nullable !== true) {
+        throw new Error(
+          ERROR_REASONS.ADD_COLLECTION_STRUCT_FIELD_NULLABLE_REQUIRED
+        );
+      }
+
+      const schemaTypes = {
+        fieldSchemaType: this.schemaProto.lookupType(
+          this.protoInternalPath.fieldSchema
+        ),
+        structArrayFieldSchemaType: this.schemaProto.lookupType(
+          this.protoInternalPath.structArrayFieldSchema
+        ),
+      };
+      const result = await promisify(
+        this.channelPool,
+        'AddCollectionStructField',
+        {
+          collection_name: data.collection_name,
+          ...(data.db_name ? { db_name: data.db_name } : {}),
+          struct_array_field_schema: formatGrpcStructArrayFieldSchema(
+            data.field,
+            schemaTypes
+          ),
+        },
+        data.timeout || this.timeout,
+        data
+      );
+
+      if (result.error_code === ErrorCode.SUCCESS) {
+        this.invalidateCollectionInfo(data);
+      }
+      return result;
+    }
+
+    if (isVectorType(dataType) && data.field.nullable !== true) {
       throw new Error(
         ERROR_REASONS.ADD_COLLECTION_FIELD_VECTOR_NULLABLE_REQUIRED
       );

--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -86,6 +86,43 @@ import {
 } from '../';
 import { Collection } from './Collection';
 
+// Detect function calls without treating quoted text as executable syntax.
+const hasElementFilterExpression = (expr: string): boolean => {
+  let quote: "'" | '"' | undefined;
+  let escaped = false;
+
+  for (let index = 0; index < expr.length; index++) {
+    const char = expr[index];
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+
+    const previousChar = index > 0 ? expr[index - 1] : '';
+    if (/[A-Za-z0-9_]/.test(previousChar)) {
+      continue;
+    }
+
+    if (/^element_filter\b\s*\(/i.test(expr.slice(index))) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 export class Data extends Collection {
   /**
    * Upsert data into Milvus, view _insert for detail
@@ -556,8 +593,7 @@ export class Data extends Collection {
 
       if (typeof op === 'number') {
         const opName = FieldPartialUpdateOpType[op] as
-          | keyof typeof FieldPartialUpdateOpType
-          | undefined;
+          keyof typeof FieldPartialUpdateOpType | undefined;
         if (typeof opName === 'undefined') {
           throw new Error(`unsupported field partial update op: ${op}`);
         }
@@ -833,9 +869,9 @@ export class Data extends Collection {
       ? formatSearchAggregationResult(originSearchResult)
       : undefined;
     const formattedAggBuckets = aggBuckets
-      ? ((nq === 1 ? aggBuckets[0] || [] : aggBuckets) as SearchResults<T>[
-          'agg_buckets'
-        ])
+      ? ((nq === 1
+          ? aggBuckets[0] || []
+          : aggBuckets) as SearchResults<T>['agg_buckets'])
       : undefined;
 
     return {
@@ -850,9 +886,7 @@ export class Data extends Collection {
         originSearchResult.results.search_iterator_v2_results,
       _search_iterator_v2_results:
         originSearchResult.results._search_iterator_v2_results,
-      ...(formattedAggBuckets
-        ? { agg_buckets: formattedAggBuckets }
-        : {}),
+      ...(formattedAggBuckets ? { agg_buckets: formattedAggBuckets } : {}),
     };
   }
 
@@ -975,7 +1009,7 @@ export class Data extends Collection {
     const client = this;
     // expr
     const userExpr = data.expr || data.filter || '';
-    const isElementFilter = /element_filter\s*\(/i.test(userExpr);
+    const isElementFilter = hasElementFilterExpression(userExpr);
     const collectionInfo = isElementFilter
       ? await this.describeCollection({
           collection_name: data.collection_name,
@@ -1007,9 +1041,9 @@ export class Data extends Collection {
         : queryData.batchSize;
 
     // local variables
-    let expr = userExpr;
-    let lastBatchRes: Record<string, any> = [];
-    let lastPKId: string | number = '';
+    const expr = userExpr;
+    let lastBatchRes: RowData[] = [];
+    let lastPKId: string | number | undefined;
     let lastElementOffset: string | number | undefined;
     let currentBatchSize = batchSize; // Store the current batch size
     const iteratorParams: Record<string, any> | undefined = isElementFilter
@@ -1044,7 +1078,7 @@ export class Data extends Collection {
             if (iteratorParams) {
               queryData.params = { ...iteratorParams };
               if (
-                lastPKId !== '' &&
+                typeof lastPKId !== 'undefined' &&
                 typeof lastElementOffset !== 'undefined'
               ) {
                 queryData.params.query_iter_last_pk = lastPKId;
@@ -1183,7 +1217,7 @@ export class Data extends Collection {
    * @param {string[]} [data.group_by_fields] - Scalar fields used to group aggregation results. Aggregation expressions such as `count(*)`, `min(price)`, `max(price)`, `sum(price)`, and `avg(price)` are specified in `output_fields`.
    * @param {OrderByFields} [data.order_by_fields] - Fields to sort query results by, for example `price:asc` or `[{ field: 'price', order: 'asc' }]` (optional).
    * @param {OrderByFields} [data.order_by] - Alias for data.order_by_fields (optional).
-   * @param {{key: value}[]} [data.params] - An optional key pair json array of search parameters.
+   * @param {Record<string, unknown>} [data.params] - Additional query parameters as a key-value object.
    * @param {OutputTransformers} data.transformers - The transformers for bf16 or f16 data, it accept bytes or sparse dic vector, it can ouput f32 array or other format(optional)
    *
    * @returns {Promise<QueryResults>} The result of the operation.

--- a/milvus/grpc/Data.ts
+++ b/milvus/grpc/Data.ts
@@ -403,6 +403,10 @@ export class Data extends Collection {
             break;
 
           case DataType.ArrayOfVector: {
+            const vectorRows =
+              field.nullable === true
+                ? field.data.filter(v => v !== undefined && v !== null)
+                : field.data;
             const buildVectorArrayData = (vector: any) => {
               switch (field.elementType) {
                 case DataType.FloatVector:
@@ -449,7 +453,7 @@ export class Data extends Collection {
             keyValue = {
               [dataKey]: {
                 dim: field.dim,
-                data: field.data.map(buildVectorArrayData),
+                data: vectorRows.map(buildVectorArrayData),
                 element_type: field.elementType,
               },
             };
@@ -967,12 +971,20 @@ export class Data extends Collection {
    * }
    */
   async queryIterator(data: QueryIteratorReq): Promise<any> {
-    // get collection info
-    const pkField = await this.getPkField(data);
     // store client;
     const client = this;
     // expr
     const userExpr = data.expr || data.filter || '';
+    const isElementFilter = /element_filter\s*\(/i.test(userExpr);
+    const collectionInfo = isElementFilter
+      ? await this.describeCollection({
+          collection_name: data.collection_name,
+          db_name: data.db_name,
+        })
+      : undefined;
+    const pkField = isElementFilter
+      ? collectionInfo!.schema.fields.find(field => field.is_primary_key)!
+      : await this.getPkField(data);
     // get count
     const count = await client.count({
       collection_name: data.collection_name,
@@ -998,7 +1010,15 @@ export class Data extends Collection {
     let expr = userExpr;
     let lastBatchRes: Record<string, any> = [];
     let lastPKId: string | number = '';
+    let lastElementOffset: string | number | undefined;
     let currentBatchSize = batchSize; // Store the current batch size
+    const iteratorParams: Record<string, any> | undefined = isElementFilter
+      ? {
+          ...data.params,
+          iterator: true,
+          collection_id: collectionInfo!.collectionID,
+        }
+      : undefined;
 
     // return iterator
     return {
@@ -1019,15 +1039,32 @@ export class Data extends Collection {
               expr: expr,
               pkField,
               lastPKId,
+              lastElementOffset,
             });
+            if (iteratorParams) {
+              queryData.params = { ...iteratorParams };
+              if (
+                lastPKId !== '' &&
+                typeof lastElementOffset !== 'undefined'
+              ) {
+                queryData.params.query_iter_last_pk = lastPKId;
+                queryData.params.query_iter_last_element_offset =
+                  lastElementOffset;
+              }
+            }
 
             // search data
             const res = await client.query(queryData as QueryReq);
+
+            if (!res.data.length) {
+              return { done: true, value: null };
+            }
 
             // get last item of the data
             const lastItem = res.data[res.data.length - 1];
             // update last pk id
             lastPKId = lastItem && lastItem[pkField.name];
+            lastElementOffset = isElementFilter ? lastItem?.offset : undefined;
 
             // store last batch result
             lastBatchRes = res.data;
@@ -1178,7 +1215,11 @@ export class Data extends Collection {
       offset = { offset: data.offset };
     }
 
-    const queryParams: { [key: string]: any } = { ...limits, ...offset };
+    const queryParams: { [key: string]: any } = {
+      ...data.params,
+      ...limits,
+      ...offset,
+    };
     if (data.group_by_fields !== undefined) {
       if (!Array.isArray(data.group_by_fields)) {
         throw new Error('Invalid group_by_fields format');

--- a/milvus/types/Data.ts
+++ b/milvus/types/Data.ts
@@ -96,6 +96,7 @@ type BaseQueryReq = collectionNameReq & {
   consistency_level?: ConsistencyLevelEnum; // consistency level
   transformers?: OutputTransformers; // provide custom data transformer for specific data type like bf16 or f16 vectors
   exprValues?: keyValueObj; // template values for filter expression, eg: {key: 'value'}
+  params?: keyValueObj; // additional query parameters
 };
 
 export type QueryReq = BaseQueryReq &

--- a/milvus/utils/Data.ts
+++ b/milvus/utils/Data.ts
@@ -77,12 +77,13 @@ export const processVectorData = (
       return physicalData;
     }
 
+    const isRowDense = physicalData.length === item.valid_data.length;
     let physicalIndex = 0;
-    return item.valid_data.map((valid: boolean) => {
+    return item.valid_data.map((valid: boolean, logicalIndex: number) => {
       if (!valid) {
         return null;
       }
-      return physicalData[physicalIndex++];
+      return physicalData[isRowDense ? logicalIndex : physicalIndex++];
     });
   };
 
@@ -215,13 +216,18 @@ export const processScalarData = (item: any): any => {
       break;
   }
 
-  // set the field data with null if item.valid_data is not empty array, it the item in valid_data is false, set the field data with null
-  if (item.valid_data && item.valid_data.length) {
-    item.valid_data.forEach((v: any, i: number) => {
-      if (!v) {
-        field_data[i] = null;
-      }
-    });
+  // Insert payloads are compact, while query/search payloads may already be
+  // row-dense. Support both representations without shifting valid values.
+  if (
+    item.valid_data &&
+    item.valid_data.length &&
+    !item.valid_data.every(Boolean)
+  ) {
+    const isRowDense = field_data.length === item.valid_data.length;
+    let physicalIndex = 0;
+    field_data = item.valid_data.map((valid: boolean, logicalIndex: number) =>
+      valid ? field_data[isRowDense ? logicalIndex : physicalIndex++] : null
+    );
   }
 
   return field_data;
@@ -247,15 +253,25 @@ export const processStructArraysData = (item: any): any => {
   });
 
   // Get the number of rows from the first processed field
-  const rowCount = processedFields[0].fieldData.length;
+  const rowCount =
+    item.valid_data?.length || processedFields[0].fieldData.length;
 
   // Initialize result array
   const result = [];
 
   // Process each row
   for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+    if (item.valid_data?.length && !item.valid_data[rowIndex]) {
+      result.push(null);
+      continue;
+    }
+
     // Get the length of arrays in this row (assuming all fields have same array length)
     const firstFieldArray = processedFields[0].fieldData[rowIndex];
+    if (firstFieldArray === null || typeof firstFieldArray === 'undefined') {
+      result.push(null);
+      continue;
+    }
     const arrayLength = firstFieldArray.length;
 
     // Create an array of struct objects for this row
@@ -275,15 +291,6 @@ export const processStructArraysData = (item: any): any => {
     }
 
     result.push(rowArray);
-  }
-
-  // Apply valid_data filtering if present
-  if (item.valid_data && item.valid_data.length) {
-    item.valid_data.forEach((v: any, i: number) => {
-      if (!v) {
-        result[i] = null;
-      }
-    });
   }
 
   return result;
@@ -354,9 +361,9 @@ export const buildFieldData = (
         ? f16Transformer(rowData[name] as Float16Vector)
         : rowData[name];
     case DataType.JSON:
-      return rowData[name]
-        ? Buffer.from(JSON.stringify(rowData[name] || {}))
-        : Buffer.alloc(0);
+      return rowData[name] === null || typeof rowData[name] === 'undefined'
+        ? undefined
+        : Buffer.from(JSON.stringify(rowData[name]));
 
     case DataType.ArrayOfVector:
       switch (elementType) {
@@ -381,6 +388,20 @@ export const buildFieldData = (
 
       // Special handling for struct types
       if (elementType == DataType.Struct) {
+        if (rowData[name] === null || typeof rowData[name] === 'undefined') {
+          fieldMap.forEach(structField => {
+            structField.data[rowIndex!] = undefined;
+          });
+          return undefined;
+        }
+
+        if ((rowData[name] as Struct[]).length === 0) {
+          fieldMap.forEach(structField => {
+            structField.data[rowIndex!] = [];
+          });
+          return rowData[name];
+        }
+
         // Process each struct element as if it were fields_data
         (rowData[name] as Struct[]).forEach((structElement, elementIndex) => {
           // get field names

--- a/milvus/utils/Function.ts
+++ b/milvus/utils/Function.ts
@@ -17,9 +17,7 @@ import { Metadata, status as grpcStatus } from '@grpc/grpc-js';
  * after all interceptor retries are exhausted.
  * Should return a new pool to retry with, or null if no failover occurred.
  */
-export type FailoverHandler = (
-  error: any
-) => Promise<Pool<any> | null>;
+export type FailoverHandler = (error: any) => Promise<Pool<any> | null>;
 
 /** Well-known property key for attaching a failover handler to a pool. */
 export const FAILOVER_HANDLER_KEY = '__failoverHandler';
@@ -116,8 +114,9 @@ export async function promisify(
     return await executeCall(pool, target, params, timeout, requestMetadata);
   } catch (error: any) {
     // Check for global cluster failover handler
-    const handler: FailoverHandler | undefined =
-      (pool as any)[FAILOVER_HANDLER_KEY];
+    const handler: FailoverHandler | undefined = (pool as any)[
+      FAILOVER_HANDLER_KEY
+    ];
 
     if (handler && isUnavailableError(error)) {
       logger.debug(
@@ -156,29 +155,29 @@ export const sleep = (time: number) => {
  * @param params - The parameters for generating the query iterator expression.
  * @param params.expr - The expression to be combined with the iterator expression.
  * @param params.pkField - The primary key field schema.
- * @param params.page - The current page number.
- * @param params.pageCache - The cache of previous pages.
+ * @param params.lastPKId - The primary key cursor from the previous batch.
+ * @param params.lastElementOffset - The struct element cursor from the previous batch.
  * @returns The query iterator expression.
  */
 export const getQueryIteratorExpr = (params: {
   expr: string;
   pkField: FieldSchema;
-  lastPKId: string | number;
+  lastPKId?: string | number;
   lastElementOffset?: string | number;
 }) => {
   // get params
   const { expr, lastPKId, lastElementOffset, pkField } = params;
 
   // If cache does not exist, return expression based on primaryKey type
-  let compareValue = '';
-  if (!lastPKId) {
+  let compareValue: string | number = '';
+  if (typeof lastPKId === 'undefined') {
     // get default value
     compareValue =
       pkField?.data_type === DataTypeStringEnum.VarChar
         ? ''
         : `${DEFAULT_MIN_INT64}`;
   } else {
-    compareValue = lastPKId as string;
+    compareValue = lastPKId;
   }
 
   // return expr combined with iteratorExpr

--- a/milvus/utils/Function.ts
+++ b/milvus/utils/Function.ts
@@ -164,9 +164,10 @@ export const getQueryIteratorExpr = (params: {
   expr: string;
   pkField: FieldSchema;
   lastPKId: string | number;
+  lastElementOffset?: string | number;
 }) => {
   // get params
-  const { expr, lastPKId, pkField } = params;
+  const { expr, lastPKId, lastElementOffset, pkField } = params;
 
   // If cache does not exist, return expression based on primaryKey type
   let compareValue = '';
@@ -185,7 +186,7 @@ export const getQueryIteratorExpr = (params: {
     pkField,
     value: compareValue,
     expr,
-    condition: '>',
+    condition: typeof lastElementOffset === 'undefined' ? '>' : '>=',
   });
 };
 
@@ -201,7 +202,9 @@ export const getPKFieldExpr = (data: {
     pkField?.data_type === DataTypeStringEnum.VarChar
       ? `'${value}'`
       : `${value}`;
-  return `${pkField?.name} ${condition} ${pkValue}${expr ? ` && ${expr}` : ''}`;
+  return `${pkField?.name} ${condition} ${pkValue}${
+    expr ? ` && (${expr})` : ''
+  }`;
 };
 // get biggest size of sparse vector array
 export const getSparseDim = (data: SparseFloatVector[]) => {

--- a/milvus/utils/Schema.ts
+++ b/milvus/utils/Schema.ts
@@ -311,19 +311,30 @@ export const formatStructArrayFieldSchema = (
   field: FieldType,
   schemaTypes: Record<string, Type>
 ) => {
+  const formattedField = assignTypeParams(field);
+  const structTypeParams = { ...formattedField.type_params };
+  delete structTypeParams.max_capacity;
+  const maxCapacity = field.max_capacity ?? field.type_params?.max_capacity;
+
   return schemaTypes.structArrayFieldSchemaType.create({
     name: field.name,
     description: field.description,
+    nullable: field.nullable === true,
+    typeParams: parseToKeyValue(structTypeParams),
     fields: field.fields!.map((f: FieldType) => {
-      // convert the field to array field, and set the max capacity
-      f.element_type = f.data_type;
-      f.data_type = isVectorType(convertToDataType(f.data_type as DataType)!)
-        ? DataType.ArrayOfVector
-        : DataType.Array;
-      f.max_capacity = field.max_capacity;
+      const childDataType = convertToDataType(f.data_type as DataType)!;
+      const childField: FieldType = {
+        ...f,
+        element_type: childDataType,
+        data_type: isVectorType(childDataType)
+          ? DataType.ArrayOfVector
+          : DataType.Array,
+        max_capacity: maxCapacity,
+        nullable: field.nullable === true,
+      };
 
       // format schema
-      return formatFieldSchema(f, schemaTypes);
+      return formatFieldSchema(childField, schemaTypes);
     }),
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zilliz/milvus2-sdk-node",
   "author": "Zilliz",
-  "milvusVersion": "3.0-20260729-a4088530",
+  "milvusVersion": "v3.0.0",
   "version": "3.0.3",
   "main": "dist/milvus",
   "files": [

--- a/test/grpc/StructArrayAdvanced.spec.ts
+++ b/test/grpc/StructArrayAdvanced.spec.ts
@@ -142,7 +142,7 @@ describe('StructArray advanced integration', () => {
         `Initial insert failed: ${JSON.stringify(oldInsert.status)}`
       );
     }
-    await client.flush({ collection_names: [COLLECTION_NAME] });
+    await client.flushSync({ collection_names: [COLLECTION_NAME] });
 
     const addField = await client.addCollectionField({
       collection_name: COLLECTION_NAME,
@@ -276,7 +276,7 @@ describe('StructArray advanced integration', () => {
       throw new Error(`Bulk insert failed: ${JSON.stringify(insert.status)}`);
     }
     expect(insert.succ_index).toHaveLength(rows.length);
-    await client.flush({ collection_names: [COLLECTION_NAME] });
+    await client.flushSync({ collection_names: [COLLECTION_NAME] });
 
     const indexes = await client.createIndex([
       {
@@ -577,6 +577,16 @@ describe('StructArray advanced integration', () => {
   });
 
   it('supports element-level search and query iterators without losing offsets', async () => {
+    const zeroPrimaryKeyIterator = await client.queryIterator({
+      collection_name: COLLECTION_NAME,
+      filter: 'id >= 0',
+      output_fields: ['id'],
+      batchSize: 1,
+      limit: 2,
+    });
+    const zeroPrimaryKeyRows = await drain(zeroPrimaryKeyIterator);
+    expect(zeroPrimaryKeyRows.map(row => Number(row.id))).toEqual([0, 1]);
+
     const searchIterator = await client.searchIterator({
       collection_name: COLLECTION_NAME,
       anns_field: 'profile[embedding]',

--- a/test/grpc/StructArrayAdvanced.spec.ts
+++ b/test/grpc/StructArrayAdvanced.spec.ts
@@ -1,0 +1,606 @@
+import {
+  DataType,
+  ErrorCode,
+  findKeyValue,
+  IndexType,
+  MetricType,
+  MilvusClient,
+} from '../../milvus';
+import { GENERATE_NAME, IP } from '../tools';
+
+jest.setTimeout(180000);
+
+const client = new MilvusClient({ address: IP, logLevel: 'info' });
+const COLLECTION_NAME = GENERATE_NAME('struct_array_advanced');
+const NESTED_ARRAY_COLLECTION = GENERATE_NAME('struct_array_nested');
+const DB_NAME = GENERATE_NAME('struct_array_advanced_db');
+const DIM = 8;
+const BACKGROUND_ROWS = 1200;
+
+const unitVector = (axis: number) =>
+  Array.from({ length: DIM }, (_, index) => (index === axis ? 1 : 0));
+
+const vectorFor = (seed: number) => {
+  const angle = ((seed % 100) / 100) * (Math.PI / 2);
+  return [
+    Math.cos(angle),
+    Math.sin(angle),
+    ...Array.from({ length: DIM - 2 }, () => 0),
+  ];
+};
+
+const sharedStructFields = [
+  { name: 'embedding', data_type: DataType.FloatVector, dim: DIM },
+  { name: 'label', data_type: DataType.VarChar, max_length: 64 },
+  { name: 'score', data_type: DataType.Int32 },
+];
+
+const waitForField = async (fieldName: string) => {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const describe = await client.describeCollection({
+      collection_name: COLLECTION_NAME,
+      cache: false,
+    });
+    const field = describe.schema.fields.find(item => item.name === fieldName);
+    if (field) {
+      return field;
+    }
+    await new Promise(resolve => setTimeout(resolve, 200));
+  }
+  throw new Error(`Timed out waiting for field ${fieldName}`);
+};
+
+const drain = async (iterator: any) => {
+  const rows: any[] = [];
+  for await (const batch of iterator) {
+    rows.push(...batch);
+  }
+  return rows;
+};
+
+describe('StructArray advanced integration', () => {
+  beforeAll(async () => {
+    const createDatabase = await client.createDatabase({ db_name: DB_NAME });
+    expect(createDatabase.error_code).toEqual(ErrorCode.SUCCESS);
+    await client.use({ db_name: DB_NAME });
+
+    const create = await client.createCollection({
+      collection_name: COLLECTION_NAME,
+      consistency_level: 'Strong',
+      fields: [
+        {
+          name: 'id',
+          data_type: DataType.Int64,
+          is_primary_key: true,
+          autoID: false,
+        },
+        {
+          name: 'normal_vector',
+          data_type: DataType.FloatVector,
+          dim: DIM,
+        },
+        {
+          name: 'nullable_text',
+          data_type: DataType.VarChar,
+          max_length: 64,
+          nullable: true,
+        },
+        {
+          name: 'nullable_numbers',
+          data_type: DataType.Array,
+          element_type: DataType.Int32,
+          max_capacity: 4,
+          nullable: true,
+        },
+        {
+          name: 'nullable_json',
+          data_type: DataType.JSON,
+          nullable: true,
+        },
+        {
+          name: 'image_features',
+          data_type: DataType.Array,
+          element_type: DataType.Struct,
+          max_capacity: 4,
+          nullable: true,
+          fields: sharedStructFields,
+        },
+        {
+          name: 'text_features',
+          data_type: DataType.Array,
+          element_type: DataType.Struct,
+          max_capacity: 4,
+          nullable: true,
+          fields: sharedStructFields,
+        },
+      ],
+    });
+    expect(create.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const oldInsert = await client.insert({
+      collection_name: COLLECTION_NAME,
+      data: [
+        {
+          id: 0,
+          normal_vector: unitVector(0),
+          nullable_text: null,
+          nullable_numbers: null,
+          nullable_json: null,
+          image_features: null,
+          text_features: [
+            {
+              embedding: unitVector(1),
+              label: 'old-text',
+              score: 1,
+            },
+          ],
+        },
+      ],
+    });
+    if (oldInsert.status.error_code !== ErrorCode.SUCCESS) {
+      throw new Error(
+        `Initial insert failed: ${JSON.stringify(oldInsert.status)}`
+      );
+    }
+    await client.flush({ collection_names: [COLLECTION_NAME] });
+
+    const addField = await client.addCollectionField({
+      collection_name: COLLECTION_NAME,
+      field: {
+        name: 'profile',
+        description: 'dynamically added nullable struct array',
+        data_type: DataType.Array,
+        element_type: DataType.Struct,
+        max_capacity: 4,
+        nullable: true,
+        fields: [
+          { name: 'score', data_type: DataType.Int64 },
+          { name: 'tag', data_type: DataType.VarChar, max_length: 32 },
+          { name: 'rank', data_type: DataType.Int32 },
+          { name: 'active', data_type: DataType.Bool },
+          { name: 'embedding', data_type: DataType.FloatVector, dim: DIM },
+        ],
+      },
+    });
+    expect(addField.error_code).toEqual(ErrorCode.SUCCESS);
+    await waitForField('profile');
+
+    const rows: any[] = [
+      {
+        id: 1,
+        normal_vector: unitVector(0),
+        nullable_text: 'present',
+        nullable_numbers: [1, 2],
+        nullable_json: { kind: 'object' },
+        image_features: [
+          {
+            embedding: unitVector(0),
+            label: 'image-one',
+            score: 11,
+          },
+        ],
+        text_features: [
+          {
+            embedding: unitVector(1),
+            label: 'text-one',
+            score: 101,
+          },
+        ],
+        profile: [
+          {
+            score: 900000,
+            tag: 'hot',
+            rank: 1,
+            active: true,
+            embedding: unitVector(0),
+          },
+          {
+            score: 900001,
+            tag: 'hot',
+            rank: 2,
+            active: false,
+            embedding: vectorFor(5),
+          },
+          {
+            score: 900002,
+            tag: 'hot',
+            rank: 3,
+            active: true,
+            embedding: vectorFor(10),
+          },
+        ],
+      },
+    ];
+
+    for (let id = 2; id < BACKGROUND_ROWS + 2; id++) {
+      rows.push({
+        id,
+        normal_vector: vectorFor(id + 31),
+        nullable_text: `text-${id}`,
+        nullable_numbers: [id],
+        nullable_json: { id },
+        image_features: [
+          {
+            embedding: vectorFor(id),
+            label: `image-${id}`,
+            score: id,
+          },
+        ],
+        text_features: [
+          {
+            embedding: vectorFor(id + 17),
+            label: `text-${id}`,
+            score: id + 10000,
+          },
+        ],
+        profile: [
+          {
+            score: id,
+            tag: id % 2 === 0 ? 'even' : 'odd',
+            rank: id % 10,
+            active: id % 2 === 0,
+            embedding: vectorFor(id + 7),
+          },
+        ],
+      });
+    }
+
+    rows.push(
+      {
+        id: BACKGROUND_ROWS + 2,
+        normal_vector: unitVector(2),
+        nullable_text: null,
+        nullable_numbers: null,
+        nullable_json: null,
+        image_features: null,
+        text_features: null,
+        profile: null,
+      },
+      {
+        id: BACKGROUND_ROWS + 3,
+        normal_vector: unitVector(3),
+        nullable_text: '',
+        nullable_numbers: [],
+        nullable_json: {},
+        image_features: [],
+        text_features: [],
+        profile: [],
+      }
+    );
+
+    const insert = await client.insert({
+      collection_name: COLLECTION_NAME,
+      data: rows,
+    });
+    if (insert.status.error_code !== ErrorCode.SUCCESS) {
+      throw new Error(`Bulk insert failed: ${JSON.stringify(insert.status)}`);
+    }
+    expect(insert.succ_index).toHaveLength(rows.length);
+    await client.flush({ collection_names: [COLLECTION_NAME] });
+
+    const indexes = await client.createIndex([
+      {
+        collection_name: COLLECTION_NAME,
+        index_name: 'normal_vector_flat',
+        field_name: 'normal_vector',
+        index_type: IndexType.FLAT,
+        metric_type: MetricType.COSINE,
+      },
+      {
+        collection_name: COLLECTION_NAME,
+        index_name: 'profile_embedding_diskann',
+        field_name: 'profile[embedding]',
+        index_type: IndexType.DISKANN,
+        metric_type: MetricType.COSINE,
+      },
+      {
+        collection_name: COLLECTION_NAME,
+        index_name: 'profile_score_stl_sort',
+        field_name: 'profile[score]',
+        index_type: IndexType.STL_SORT,
+      },
+      {
+        collection_name: COLLECTION_NAME,
+        index_name: 'profile_tag_bitmap',
+        field_name: 'profile[tag]',
+        index_type: IndexType.BITMAP,
+      },
+      {
+        collection_name: COLLECTION_NAME,
+        index_name: 'profile_rank_inverted',
+        field_name: 'profile[rank]',
+        index_type: IndexType.INVERTED,
+      },
+      {
+        collection_name: COLLECTION_NAME,
+        index_name: 'image_embedding_flat',
+        field_name: 'image_features[embedding]',
+        index_type: IndexType.FLAT,
+        metric_type: MetricType.COSINE,
+      },
+      {
+        collection_name: COLLECTION_NAME,
+        index_name: 'text_embedding_flat',
+        field_name: 'text_features[embedding]',
+        index_type: IndexType.FLAT,
+        metric_type: MetricType.COSINE,
+      },
+    ]);
+    expect(indexes.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const load = await client.loadCollection({
+      collection_name: COLLECTION_NAME,
+      timeout: 120000,
+    });
+    expect(load.error_code).toEqual(ErrorCode.SUCCESS);
+  });
+
+  afterAll(async () => {
+    await client
+      .dropCollection({ collection_name: COLLECTION_NAME })
+      .catch(() => undefined);
+    await client
+      .dropCollection({ collection_name: NESTED_ARRAY_COLLECTION })
+      .catch(() => undefined);
+    await client.dropDatabase({ db_name: DB_NAME }).catch(() => undefined);
+  });
+
+  it('supports duplicate child names, nullable rows, and dynamic StructArray fields', async () => {
+    const describe = await client.describeCollection({
+      collection_name: COLLECTION_NAME,
+      cache: false,
+    });
+    const profile = describe.schema.fields.find(
+      field => field.name === 'profile'
+    );
+    expect(profile).toMatchObject({
+      data_type: 'Array',
+      element_type: 'Struct',
+      nullable: true,
+      max_capacity: '4',
+    });
+    expect(profile!.fields!.map(field => field.name)).toEqual([
+      'score',
+      'tag',
+      'rank',
+      'active',
+      'embedding',
+    ]);
+
+    const result = await client.query({
+      collection_name: COLLECTION_NAME,
+      filter: `id in [0, 1, ${BACKGROUND_ROWS + 2}, ${BACKGROUND_ROWS + 3}]`,
+      output_fields: [
+        'id',
+        'image_features[label]',
+        'image_features[score]',
+        'text_features[label]',
+        'text_features[score]',
+        'profile',
+        'nullable_text',
+        'nullable_numbers',
+        'nullable_json',
+      ],
+      limit: 10,
+    });
+    expect(result.status.error_code).toEqual(ErrorCode.SUCCESS);
+    const byId = new Map(result.data.map(row => [Number(row.id), row]));
+
+    expect(byId.get(0)!.profile).toBeNull();
+    expect(byId.get(0)!.image_features).toBeNull();
+    expect(byId.get(0)!.nullable_text).toBeNull();
+    expect(byId.get(0)!.nullable_numbers).toBeNull();
+    expect(byId.get(0)!.nullable_json).toBeNull();
+    expect(byId.get(1)!.image_features[0]).toMatchObject({
+      label: 'image-one',
+      score: 11,
+    });
+    expect(byId.get(1)!.text_features[0]).toMatchObject({
+      label: 'text-one',
+      score: 101,
+    });
+    expect(byId.get(1)!.nullable_text).toEqual('present');
+    expect(byId.get(1)!.nullable_numbers).toEqual([1, 2]);
+    expect(byId.get(1)!.nullable_json).toEqual({ kind: 'object' });
+    expect(byId.get(BACKGROUND_ROWS + 2)!.profile).toBeNull();
+    expect(byId.get(BACKGROUND_ROWS + 2)!.nullable_text).toBeNull();
+    expect(byId.get(BACKGROUND_ROWS + 2)!.nullable_numbers).toBeNull();
+    expect(byId.get(BACKGROUND_ROWS + 2)!.nullable_json).toBeNull();
+    expect(byId.get(BACKGROUND_ROWS + 3)!.profile).toEqual([]);
+    expect(byId.get(BACKGROUND_ROWS + 3)!.nullable_text).toEqual('');
+    expect(byId.get(BACKGROUND_ROWS + 3)!.nullable_numbers).toEqual([]);
+    expect(byId.get(BACKGROUND_ROWS + 3)!.nullable_json).toEqual({});
+  });
+
+  it('reports DISKANN, STL_SORT, Bitmap, and scalar indexes on struct children', async () => {
+    const expectedIndexes = [
+      ['profile_embedding_diskann', IndexType.DISKANN],
+      ['profile_score_stl_sort', IndexType.STL_SORT],
+      ['profile_tag_bitmap', IndexType.BITMAP],
+      ['profile_rank_inverted', IndexType.INVERTED],
+    ];
+
+    for (const [indexName, indexType] of expectedIndexes) {
+      const describe = await client.describeIndex({
+        collection_name: COLLECTION_NAME,
+        index_name: indexName,
+      });
+      expect(describe.status.error_code).toEqual(ErrorCode.SUCCESS);
+      expect(
+        findKeyValue(describe.index_descriptions[0].params, 'index_type')
+      ).toEqual(indexType);
+    }
+  });
+
+  it('rejects nested Array children with the server limitation', async () => {
+    await expect(
+      client.createCollection({
+        collection_name: NESTED_ARRAY_COLLECTION,
+        fields: [
+          {
+            name: 'id',
+            data_type: DataType.Int64,
+            is_primary_key: true,
+          },
+          {
+            name: 'vector',
+            data_type: DataType.FloatVector,
+            dim: DIM,
+          },
+          {
+            name: 'items',
+            data_type: DataType.Array,
+            element_type: DataType.Struct,
+            max_capacity: 4,
+            fields: [
+              {
+                name: 'nested',
+                data_type: DataType.Array,
+                element_type: DataType.Int64,
+                max_capacity: 2,
+              },
+            ],
+          },
+        ],
+      })
+    ).rejects.toMatchObject({
+      error_code: ErrorCode.IllegalArgument,
+      reason: expect.stringMatching(/nested array is not supported/i),
+    });
+  });
+
+  it('supports element-level filter, query, and same-named struct paths', async () => {
+    const query = await client.query({
+      collection_name: COLLECTION_NAME,
+      filter: 'element_filter(profile, $[score] >= 900000)',
+      output_fields: ['id', 'profile[score]', 'profile[tag]'],
+      limit: 10,
+    });
+    expect(query.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(query.data).toHaveLength(3);
+    expect(query.data.map(row => Number(row.id))).toEqual([1, 1, 1]);
+    expect(query.data.map(row => Number(row.offset))).toEqual([0, 1, 2]);
+
+    const imageSearch = await client.search({
+      collection_name: COLLECTION_NAME,
+      anns_field: 'image_features[embedding]',
+      data: unitVector(0),
+      filter: 'id == 1',
+      output_fields: ['id', 'image_features[label]', 'text_features[label]'],
+      limit: 1,
+    });
+    expect(imageSearch.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(imageSearch.results[0]).toMatchObject({ id: '1', offset: '0' });
+    expect(imageSearch.results[0].image_features[0].label).toEqual('image-one');
+    expect(imageSearch.results[0].text_features[0].label).toEqual('text-one');
+
+    const textSearch = await client.search({
+      collection_name: COLLECTION_NAME,
+      anns_field: 'text_features[embedding]',
+      data: unitVector(1),
+      filter: 'id == 1',
+      output_fields: ['id', 'text_features[label]'],
+      limit: 1,
+    });
+    expect(textSearch.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(textSearch.results[0]).toMatchObject({ id: '1', offset: '0' });
+    expect(textSearch.results[0].text_features[0].label).toEqual('text-one');
+  });
+
+  it('supports element-level search, group_by, and range search', async () => {
+    const search = await client.search({
+      collection_name: COLLECTION_NAME,
+      anns_field: 'profile[embedding]',
+      data: vectorFor(5),
+      filter: 'element_filter(profile, $[score] == 900001)',
+      output_fields: ['id', 'profile[score]', 'profile[tag]'],
+      limit: 1,
+    });
+    expect(search.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(search.results[0]).toMatchObject({ id: '1', offset: '1' });
+
+    const grouped = await client.search({
+      collection_name: COLLECTION_NAME,
+      anns_field: 'profile[embedding]',
+      data: unitVector(0),
+      filter: 'element_filter(profile, $[score] >= 0)',
+      group_by_field: 'id',
+      output_fields: ['id'],
+      limit: 10,
+    });
+    expect(grouped.status.error_code).toEqual(ErrorCode.SUCCESS);
+    const groupedIds = grouped.results.map((hit: any) => hit.id);
+    expect(new Set(groupedIds).size).toEqual(groupedIds.length);
+
+    const range = await client.search({
+      collection_name: COLLECTION_NAME,
+      anns_field: 'profile[embedding]',
+      data: unitVector(0),
+      filter: 'element_filter(profile, $[score] >= 900000)',
+      params: { radius: 0.98, range_filter: 1.01 },
+      output_fields: ['id', 'profile[score]'],
+      limit: 10,
+    });
+    expect(range.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(range.results.length).toBeGreaterThan(0);
+    range.results.forEach((hit: any) => {
+      expect(hit.id).toEqual('1');
+      expect(hit.score).toBeGreaterThanOrEqual(0.98);
+      expect(hit.score).toBeLessThan(1.01);
+    });
+  });
+
+  it('supports element-level hybrid search with a normal vector request', async () => {
+    const result = await client.hybridSearch({
+      collection_name: COLLECTION_NAME,
+      data: [
+        {
+          anns_field: 'profile[embedding]',
+          data: unitVector(0),
+          expr: 'element_filter(profile, $[score] >= 900000)',
+          limit: 3,
+        },
+        {
+          anns_field: 'normal_vector',
+          data: unitVector(0),
+          expr: 'id == 1',
+          limit: 3,
+        },
+      ],
+      output_fields: ['id'],
+      limit: 3,
+    });
+
+    expect(result.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(result.results[0].id).toEqual('1');
+    expect(result.results[0].offset).toBeUndefined();
+  });
+
+  it('supports element-level search and query iterators without losing offsets', async () => {
+    const searchIterator = await client.searchIterator({
+      collection_name: COLLECTION_NAME,
+      anns_field: 'profile[embedding]',
+      data: unitVector(0),
+      filter: 'element_filter(profile, $[score] >= 900000)',
+      output_fields: ['id', 'profile[score]'],
+      batchSize: 1,
+      limit: 3,
+    });
+    const searchRows = await drain(searchIterator);
+    expect(searchRows).toHaveLength(3);
+    expect(
+      new Set(searchRows.map(row => `${row.id}:${row.offset}`)).size
+    ).toEqual(3);
+
+    const queryIterator = await client.queryIterator({
+      collection_name: COLLECTION_NAME,
+      filter: 'element_filter(profile, $[score] >= 900000)',
+      output_fields: ['id', 'profile[score]'],
+      batchSize: 1,
+      limit: 3,
+    });
+    const queryRows = await drain(queryIterator);
+    expect(queryRows.map(row => Number(row.id))).toEqual([1, 1, 1]);
+    expect(queryRows.map(row => Number(row.offset))).toEqual([0, 1, 2]);
+  });
+});

--- a/test/grpc/StructArrayAdvanced.spec.ts
+++ b/test/grpc/StructArrayAdvanced.spec.ts
@@ -169,7 +169,7 @@ describe('StructArray advanced integration', () => {
       {
         id: 1,
         normal_vector: unitVector(0),
-        nullable_text: 'present',
+        nullable_text: 'quoted "element_filter(profile, value)',
         nullable_numbers: [1, 2],
         nullable_json: { kind: 'object' },
         image_features: [
@@ -399,7 +399,9 @@ describe('StructArray advanced integration', () => {
       label: 'text-one',
       score: 101,
     });
-    expect(byId.get(1)!.nullable_text).toEqual('present');
+    expect(byId.get(1)!.nullable_text).toEqual(
+      'quoted "element_filter(profile, value)'
+    );
     expect(byId.get(1)!.nullable_numbers).toEqual([1, 2]);
     expect(byId.get(1)!.nullable_json).toEqual({ kind: 'object' });
     expect(byId.get(BACKGROUND_ROWS + 2)!.profile).toBeNull();
@@ -410,6 +412,40 @@ describe('StructArray advanced integration', () => {
     expect(byId.get(BACKGROUND_ROWS + 3)!.nullable_text).toEqual('');
     expect(byId.get(BACKGROUND_ROWS + 3)!.nullable_numbers).toEqual([]);
     expect(byId.get(BACKGROUND_ROWS + 3)!.nullable_json).toEqual({});
+  });
+
+  it('requires nullable struct arrays for dynamic fields', async () => {
+    await expect(
+      client.addCollectionField({
+        collection_name: COLLECTION_NAME,
+        field: {
+          name: 'invalid_profile',
+          data_type: DataType.Array,
+          element_type: DataType.Struct,
+          max_capacity: 2,
+          fields: [{ name: 'score', data_type: DataType.Int64 }],
+        },
+      })
+    ).rejects.toThrow(
+      'Adding a struct array field to an existing collection requires nullable=true.'
+    );
+  });
+
+  it('treats element_filter text inside quoted values as plain text', async () => {
+    const iterator = await client.queryIterator({
+      collection_name: COLLECTION_NAME,
+      filter: 'nullable_text == "quoted \\"element_filter(profile, value)"',
+      output_fields: ['id', 'nullable_text'],
+      batchSize: 1,
+      limit: 1,
+    });
+    const rows = await drain(iterator);
+
+    expect(rows).toHaveLength(1);
+    expect(Number(rows[0].id)).toBe(1);
+    expect(rows[0].nullable_text).toBe(
+      'quoted "element_filter(profile, value)'
+    );
   });
 
   it('reports DISKANN, STL_SORT, Bitmap, and scalar indexes on struct children', async () => {
@@ -612,5 +648,34 @@ describe('StructArray advanced integration', () => {
     const queryRows = await drain(queryIterator);
     expect(queryRows.map(row => Number(row.id))).toEqual([1, 1, 1]);
     expect(queryRows.map(row => Number(row.offset))).toEqual([0, 1, 2]);
+
+    const growingID = BACKGROUND_ROWS + 4;
+    const growingInsert = await client.insert({
+      collection_name: COLLECTION_NAME,
+      data: [
+        {
+          id: growingID,
+          normal_vector: unitVector(4),
+          nullable_text: null,
+          nullable_numbers: null,
+          nullable_json: null,
+          image_features: null,
+          text_features: null,
+          profile: null,
+        },
+      ],
+    });
+    expect(growingInsert.status.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const ignoreGrowingIterator = await client.queryIterator({
+      collection_name: COLLECTION_NAME,
+      filter: `id == ${growingID}`,
+      output_fields: ['id'],
+      params: { ignore_growing: true },
+      batchSize: 1,
+    });
+    const emptyPage =
+      await ignoreGrowingIterator[Symbol.asyncIterator]().next();
+    expect(emptyPage).toEqual({ done: true, value: null });
   });
 });

--- a/test/utils/Data.spec.ts
+++ b/test/utils/Data.spec.ts
@@ -13,6 +13,8 @@ import {
   f32ArrayToBinaryBytes,
   f32ArrayToInt8Bytes,
   processVectorData,
+  processScalarData,
+  processStructArraysData,
   findKeyValue,
   FieldPartialUpdateOpType,
   CLUSTER_ID,
@@ -779,6 +781,92 @@ describe('utils/Data', () => {
     expect(vectorField.vectors.float_vector.data).toEqual([]);
   });
 
+  it('should expand compact nullable scalar payloads', () => {
+    expect(
+      processScalarData({
+        valid_data: [true, false, true],
+        scalars: {
+          data: 'int_data',
+          int_data: { data: [10, 30] },
+        },
+      })
+    ).toEqual([10, null, 30]);
+  });
+
+  it('should preserve row-dense nullable scalar payload alignment', () => {
+    expect(
+      processScalarData({
+        valid_data: [false, true, false],
+        scalars: {
+          data: 'array_data',
+          array_data: {
+            data: [
+              { data: 'int_data', int_data: { data: [] } },
+              { data: 'int_data', int_data: { data: [10] } },
+              {},
+            ],
+          },
+        },
+      })
+    ).toEqual([null, [10], null]);
+  });
+
+  it('should decode nullable struct arrays with scalar and vector children', () => {
+    const result = processStructArraysData({
+      valid_data: [true, false, true],
+      struct_arrays: {
+        fields: [
+          {
+            field_name: 'score',
+            valid_data: [true, false, true],
+            scalars: {
+              data: 'array_data',
+              array_data: {
+                data: [
+                  {
+                    data: 'int_data',
+                    int_data: { data: [1, 2] },
+                  },
+                  { data: 'int_data', int_data: { data: [3] } },
+                ],
+              },
+            },
+          },
+          {
+            field_name: 'embedding',
+            valid_data: [true, false, true],
+            vectors: {
+              data: 'vector_array',
+              vector_array: {
+                data: [
+                  {
+                    data: 'float_vector',
+                    dim: 2,
+                    float_vector: { data: [1, 0, 0, 1] },
+                  },
+                  {
+                    data: 'float_vector',
+                    dim: 2,
+                    float_vector: { data: [0.5, 0.5] },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(result).toEqual([
+      [
+        { score: 1, embedding: [1, 0] },
+        { score: 2, embedding: [0, 1] },
+      ],
+      null,
+      [{ score: 3, embedding: [0.5, 0.5] }],
+    ]);
+  });
+
   it('should decode nullable float vectors from valid_data and dense payload', () => {
     const result = processVectorData({
       valid_data: [true, false, true],
@@ -1404,8 +1492,7 @@ describe('utils/Data', () => {
         } as _Field;
 
         const result = buildFieldData(row, field);
-        expect(Buffer.isBuffer(result)).toBe(true);
-        expect((result as Buffer).length).toBe(0);
+        expect(result).toBeUndefined();
       });
 
       it('should handle JSON type with undefined value', () => {
@@ -1417,8 +1504,7 @@ describe('utils/Data', () => {
         } as _Field;
 
         const result = buildFieldData(row, field);
-        expect(Buffer.isBuffer(result)).toBe(true);
-        expect((result as Buffer).length).toBe(0); // undefined returns empty buffer
+        expect(result).toBeUndefined();
       });
     });
 

--- a/test/utils/Function.spec.ts
+++ b/test/utils/Function.spec.ts
@@ -68,7 +68,7 @@ describe('Function API testing', () => {
         name: 'id',
         data_type: DataTypeStringEnum.VarChar,
       },
-      lastPkId: '',
+      lastPKId: undefined,
     } as any;
 
     const result = getQueryIteratorExpr(params);
@@ -98,8 +98,7 @@ describe('Function API testing', () => {
         name: 'id',
         data_type: DataTypeStringEnum.VarChar,
       },
-      page: 1,
-      lastPkId: '',
+      lastPKId: undefined,
     } as any;
 
     const result = getQueryIteratorExpr(params);
@@ -114,7 +113,7 @@ describe('Function API testing', () => {
         name: 'id',
         data_type: DataTypeStringEnum.Int64,
       },
-      lastPkId: '',
+      lastPKId: undefined,
     } as any;
 
     const result = getQueryIteratorExpr(params);
@@ -164,6 +163,20 @@ describe('Function API testing', () => {
     });
 
     expect(result).toBe('id >= 7 && (element_filter(items, $[score] >= 10))');
+  });
+
+  it('preserves an Int64 primary key cursor with value zero', () => {
+    const result = getQueryIteratorExpr({
+      expr: 'element_filter(items, $[score] >= 10)',
+      pkField: {
+        name: 'id',
+        data_type: DataTypeStringEnum.Int64,
+      } as any,
+      lastPKId: 0,
+      lastElementOffset: 1,
+    });
+
+    expect(result).toBe('id >= 0 && (element_filter(items, $[score] >= 10))');
   });
 
   it('should return the correct dimension of the sparse vector', () => {

--- a/test/utils/Function.spec.ts
+++ b/test/utils/Function.spec.ts
@@ -104,7 +104,7 @@ describe('Function API testing', () => {
 
     const result = getQueryIteratorExpr(params);
 
-    expect(result).toBe("id > '' && field > 10");
+    expect(result).toBe("id > '' && (field > 10)");
   });
 
   it('should return int64 expression when cache does not exist', () => {
@@ -149,7 +149,21 @@ describe('Function API testing', () => {
 
     const result = getQueryIteratorExpr(params);
 
-    expect(result).toBe('id > 10 && field > 10');
+    expect(result).toBe('id > 10 && (field > 10)');
+  });
+
+  it('keeps element_filter right-most and resumes the last element offset', () => {
+    const result = getQueryIteratorExpr({
+      expr: 'element_filter(items, $[score] >= 10)',
+      pkField: {
+        name: 'id',
+        data_type: DataTypeStringEnum.Int64,
+      } as any,
+      lastPKId: 7,
+      lastElementOffset: 1,
+    });
+
+    expect(result).toBe('id >= 7 && (element_filter(items, $[score] >= 10))');
   });
 
   it('should return the correct dimension of the sparse vector', () => {

--- a/test/utils/Schema.spec.ts
+++ b/test/utils/Schema.spec.ts
@@ -574,7 +574,7 @@ describe('utils/Schema', () => {
           element_type: DataType.Struct,
           max_capacity: 2,
           nullable: true,
-          type_params: { 'mmap.enabled': true },
+          'mmap.enabled': true,
           fields: [
             {
               name: 'score',
@@ -601,7 +601,7 @@ describe('utils/Schema', () => {
     expect(payload.structArrayFields[0].name).toBe('metadata');
     expect(payload.structArrayFields[0].nullable).toBe(true);
     expect(payload.structArrayFields[0].typeParams).toEqual([
-      { key: 'mmap.enabled', value: true },
+      { key: 'mmap.enabled', value: 'true' },
     ]);
     expect(payload.structArrayFields[0].fields[0]).toMatchObject({
       name: 'score',

--- a/test/utils/Schema.spec.ts
+++ b/test/utils/Schema.spec.ts
@@ -555,45 +555,54 @@ describe('utils/Schema', () => {
       'milvus.proto.schema.StructArrayFieldSchema'
     );
 
-    const payload = formatCollectionSchema(
-      {
-        collection_name: 'structCollection',
-        fields: [
-          {
-            name: 'id',
-            data_type: DataType.Int64,
-            is_primary_key: true,
-          },
-          {
-            name: 'vector',
-            data_type: DataType.FloatVector,
-            dim: 4,
-          },
-          {
-            name: 'metadata',
-            data_type: DataType.Array,
-            element_type: DataType.Struct,
-            max_capacity: 2,
-            fields: [
-              {
-                name: 'score',
-                data_type: DataType.Float,
-              },
-              {
-                name: 'embedding',
-                data_type: DataType.FloatVector,
-                dim: 4,
-              },
-            ],
-          },
-        ],
-      } as CreateCollectionReq,
-      { fieldSchemaType, structArrayFieldSchemaType }
-    );
+    const request = {
+      collection_name: 'structCollection',
+      fields: [
+        {
+          name: 'id',
+          data_type: DataType.Int64,
+          is_primary_key: true,
+        },
+        {
+          name: 'vector',
+          data_type: DataType.FloatVector,
+          dim: 4,
+        },
+        {
+          name: 'metadata',
+          data_type: DataType.Array,
+          element_type: DataType.Struct,
+          max_capacity: 2,
+          nullable: true,
+          type_params: { 'mmap.enabled': true },
+          fields: [
+            {
+              name: 'score',
+              data_type: DataType.Float,
+            },
+            {
+              name: 'embedding',
+              data_type: DataType.FloatVector,
+              dim: 4,
+            },
+          ],
+        },
+      ],
+    } as CreateCollectionReq;
+    const originalRequest = JSON.parse(JSON.stringify(request));
+
+    const payload = formatCollectionSchema(request, {
+      fieldSchemaType,
+      structArrayFieldSchemaType,
+    });
 
     expect(payload.fields).toHaveLength(2);
     expect(payload.structArrayFields).toHaveLength(1);
     expect(payload.structArrayFields[0].name).toBe('metadata');
+    expect(payload.structArrayFields[0].nullable).toBe(true);
+    expect(payload.structArrayFields[0].typeParams).toEqual([
+      { key: 'mmap.enabled', value: true },
+    ]);
     expect(payload.structArrayFields[0].fields[0]).toMatchObject({
       name: 'score',
       dataType: DataType.Array,
@@ -608,6 +617,7 @@ describe('utils/Schema', () => {
         { key: 'max_capacity', value: '2' },
       ],
     });
+    expect(request).toEqual(originalRequest);
   });
 
   it('adds a dataType property to each field object in the schema', () => {


### PR DESCRIPTION
## What this PR does

- routes plain-object Array<Struct> fields through AddCollectionStructField for schema evolution
- preserves struct schema inputs and nullable/type parameters
- supports nullable StructArray insertion and decoding, including null versus empty arrays
- supports element-level query iterators by resuming with primary key plus element offset
- keeps generic query parameters available for iterator requests
- fixes nullable JSON insertion so null values use valid_data instead of empty JSON bytes

## Real Milvus coverage

The new integration suite connects directly to the local Milvus instance; it does not use __SKIP_CONNECT__ or mocked RPCs. It covers:

- duplicate child names across StructArray fields
- dynamically adding a nullable StructArray field
- nullable scalar, Array, JSON, and StructArray values
- DISKANN, STL_SORT, BITMAP, and INVERTED indexes on struct children
- nested Array server limitation
- element-level filter, query, search, group_by, range search, hybrid search, and iterators

Existing real Struct coverage also verifies BinaryVector, Float16Vector, BFloat16Vector, and Int8Vector child fields.

## Verification

- npm run build
- NODE_ENV=dev npx jest test/utils/Data.spec.ts test/utils/Function.spec.ts test/utils/Schema.spec.ts --runInBand
- NODE_ENV=dev npx jest test/grpc/StructArrayAdvanced.spec.ts test/grpc/Struct.spec.ts test/grpc/ElementLevel.spec.ts test/grpc/NullableVector.spec.ts --runInBand

Results: 116 unit tests and 27 real Milvus integration tests passed locally.