### PR TITLE
fix: expose TypeScript declaration entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "milvusVersion": "v3.0.0",
   "version": "3.0.3",
   "main": "dist/milvus",
+  "types": "dist/milvus/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary

- add the package types entry for dist/milvus/index.d.ts
- allow TypeScript and editors to resolve declarations from @zilliz/milvus2-sdk-node
- keep runtime behavior unchanged

## Verification

- npm run build
- npx prettier --check package.json
- confirmed the declaration entry exists after build
- confirmed npm pack includes dist/milvus/index.d.ts

Supersedes #581. Thanks @zxxj for identifying the issue and proposing the fix.