### PR TITLE
fix: support adding fields to external collections

### DIFF
--- a/milvus/grpc/Collection.ts
+++ b/milvus/grpc/Collection.ts
@@ -161,6 +161,9 @@ const formatGrpcStructArrayFieldSchema = (
   };
 };
 
+const EXTERNAL_COLLECTION_ALTER_SCHEMA_UNSUPPORTED =
+  'alter collection schema operation is not supported for external collection';
+
 /**
  * @see [collection operation examples](https://github.com/milvus-io/milvus-sdk-node/blob/main/example/Collection.ts)
  */
@@ -462,7 +465,13 @@ export class Collection extends Database {
           ],
         },
       });
-      return result.alter_status;
+      if (
+        !result.alter_status.reason?.includes(
+          EXTERNAL_COLLECTION_ALTER_SCHEMA_UNSUPPORTED
+        )
+      ) {
+        return result.alter_status;
+      }
     } catch (error) {
       if ((error as { code?: number })?.code !== grpcStatus.UNIMPLEMENTED) {
         throw error;

--- a/test/grpc/ExternalCollection.spec.ts
+++ b/test/grpc/ExternalCollection.spec.ts
@@ -1,5 +1,21 @@
-import { DataType, ErrorCode, MilvusClient } from '../../milvus';
+import {
+  BulkWriter,
+  DataType,
+  ErrorCode,
+  FunctionType,
+  IndexType,
+  MetricType,
+  MilvusClient,
+  RefreshExternalCollectionState,
+  sleep,
+} from '../../milvus';
 import { GENERATE_NAME, IP } from '../tools';
+import * as Minio from 'minio';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+jest.setTimeout(180000);
 
 const milvusClient = new MilvusClient({
   address: IP,
@@ -18,6 +34,58 @@ const DEFAULT_EXTERNAL_SPEC = JSON.stringify({
     cloud_provider: 'aws',
   },
 });
+
+const MINIO_ADDRESS = process.env.MINIO_ADDRESS || '127.0.0.1';
+const MINIO_BUCKET = process.env.EXTERNAL_COLLECTION_MINIO_BUCKET || 'a-bucket';
+const MINIO_ACCESS_KEY = process.env.MINIO_ACCESS_KEY || 'minioadmin';
+const MINIO_SECRET_KEY = process.env.MINIO_SECRET_KEY || 'minioadmin';
+const MILVUS_MINIO_ADDRESS =
+  process.env.EXTERNAL_COLLECTION_MINIO_ADDRESS || 'minio:9000';
+
+const minioClient = new Minio.Client({
+  endPoint: MINIO_ADDRESS,
+  port: 9000,
+  useSSL: false,
+  accessKey: MINIO_ACCESS_KEY,
+  secretKey: MINIO_SECRET_KEY,
+});
+
+const buildMinioExternalSpec = () =>
+  JSON.stringify({
+    format: 'parquet',
+    extfs: {
+      cloud_provider: 'minio',
+      region: 'us-east-1',
+      access_key_id: MINIO_ACCESS_KEY,
+      access_key_value: MINIO_SECRET_KEY,
+      use_ssl: 'false',
+    },
+  });
+
+const waitForExternalRefresh = async (jobId: string) => {
+  for (let attempt = 0; attempt < 120; attempt++) {
+    const progress = await milvusClient.getRefreshExternalCollectionProgress({
+      job_id: jobId,
+    });
+    expect(progress.status.error_code).toEqual(ErrorCode.SUCCESS);
+
+    if (
+      progress.job_info.state ===
+      RefreshExternalCollectionState.RefreshCompleted
+    ) {
+      return;
+    }
+    if (
+      progress.job_info.state === RefreshExternalCollectionState.RefreshFailed
+    ) {
+      throw new Error(progress.job_info.reason || 'External refresh failed');
+    }
+
+    await sleep(1000);
+  }
+
+  throw new Error('External collection refresh timed out');
+};
 
 describe('External Collection API', () => {
   const collectionName = GENERATE_NAME();
@@ -98,5 +166,250 @@ describe('External Collection API', () => {
     });
     expect(jobs.status.error_code).toEqual(ErrorCode.SUCCESS);
     expect(Array.isArray(jobs.jobs)).toBe(true);
+  });
+
+  it('adds a nullable vector field to an external collection', async () => {
+    const schemaEvolutionCollection = GENERATE_NAME();
+    const nullableVectorField = 'nullable_vec';
+
+    try {
+      const create = await milvusClient.createCollection({
+        collection_name: schemaEvolutionCollection,
+        external_source:
+          process.env.EXTERNAL_COLLECTION_SOURCE || DEFAULT_EXTERNAL_SOURCE,
+        external_spec:
+          process.env.EXTERNAL_COLLECTION_SPEC || DEFAULT_EXTERNAL_SPEC,
+        fields: [
+          {
+            name: 'product_id',
+            data_type: DataType.Int64,
+            external_field: 'id',
+          },
+          {
+            name: 'vec',
+            data_type: DataType.FloatVector,
+            dim: 4,
+            external_field: 'vector',
+          },
+        ],
+      });
+      expect(create.error_code).toEqual(ErrorCode.SUCCESS);
+
+      const add = await milvusClient.addCollectionField({
+        collection_name: schemaEvolutionCollection,
+        field: {
+          name: nullableVectorField,
+          data_type: DataType.FloatVector,
+          dim: 4,
+          nullable: true,
+          external_field: 'nullable_vector',
+        },
+      });
+      expect(add).toEqual(
+        expect.objectContaining({ error_code: ErrorCode.SUCCESS })
+      );
+
+      const describeAfterAdd = await milvusClient.describeCollection({
+        collection_name: schemaEvolutionCollection,
+        cache: false,
+      });
+      const addedField = describeAfterAdd.schema.fields.find(
+        field => field.name === nullableVectorField
+      );
+      expect(addedField).toBeDefined();
+      expect(addedField?.data_type).toEqual('FloatVector');
+      expect(Number(addedField?.dim)).toEqual(4);
+      expect(addedField?.nullable).toEqual(true);
+      expect(addedField?.external_field).toEqual('nullable_vector');
+    } finally {
+      await milvusClient.dropCollection({
+        collection_name: schemaEvolutionCollection,
+      });
+    }
+  });
+
+  describe('Function and text search', () => {
+    const functionCollection = GENERATE_NAME('external_function');
+    const objectPrefix = `node-sdk-external/${functionCollection}`;
+    const uploadedObjects: string[] = [];
+    const sourceFields = [
+      { name: 'id', data_type: DataType.Int64 },
+      {
+        name: 'text',
+        data_type: DataType.VarChar,
+        max_length: 512,
+      },
+      {
+        name: 'sparse',
+        data_type: DataType.SparseFloatVector,
+        is_function_output: true,
+      },
+    ];
+    const rows = [
+      { id: 0, text: 'apple banana' },
+      { id: 1, text: 'banana pear' },
+      { id: 2, text: 'fresh apple pie' },
+      { id: 3, text: 'orange fruit' },
+      { id: 4, text: 'apple orchard' },
+      { id: 5, text: 'distributed vector database' },
+    ];
+
+    beforeAll(async () => {
+      if (!(await minioClient.bucketExists(MINIO_BUCKET))) {
+        await minioClient.makeBucket(MINIO_BUCKET, 'us-east-1');
+      }
+
+      const localDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'external-function-')
+      );
+      try {
+        const writer = new BulkWriter({
+          schema: { fields: sourceFields },
+          localPath: localDir,
+          format: 'parquet',
+        });
+        for (const row of rows) {
+          await writer.append(row);
+        }
+
+        const files = (await writer.close()).flat();
+        for (const localFile of files) {
+          const objectName = `${objectPrefix}/${path.basename(localFile)}`;
+          await minioClient.fPutObject(
+            MINIO_BUCKET,
+            objectName,
+            localFile
+          );
+          uploadedObjects.push(objectName);
+        }
+      } finally {
+        fs.rmSync(localDir, { recursive: true, force: true });
+      }
+
+      const create = await milvusClient.createCollection({
+        collection_name: functionCollection,
+        external_source: `s3://${MILVUS_MINIO_ADDRESS}/${MINIO_BUCKET}/${objectPrefix}/`,
+        external_spec: buildMinioExternalSpec(),
+        fields: [
+          {
+            name: 'id',
+            data_type: DataType.Int64,
+            external_field: 'id',
+          },
+          {
+            name: 'text',
+            data_type: DataType.VarChar,
+            max_length: 512,
+            enable_analyzer: true,
+            enable_match: true,
+            analyzer_params: {
+              tokenizer: 'standard',
+              filter: ['lowercase'],
+            },
+            external_field: 'text',
+          },
+          {
+            name: 'sparse',
+            data_type: DataType.SparseFloatVector,
+            is_function_output: true,
+          },
+        ],
+        functions: [
+          {
+            name: 'bm25',
+            type: FunctionType.BM25,
+            input_field_names: ['text'],
+            output_field_names: ['sparse'],
+            params: {},
+          },
+        ],
+      });
+      expect(create.error_code).toEqual(ErrorCode.SUCCESS);
+
+      const refresh = await milvusClient.refreshExternalCollection({
+        collection_name: functionCollection,
+      });
+      expect(refresh.status.error_code).toEqual(ErrorCode.SUCCESS);
+      await waitForExternalRefresh(refresh.job_id);
+
+      const index = await milvusClient.createIndex({
+        collection_name: functionCollection,
+        field_name: 'sparse',
+        index_type: IndexType.SPARSE_INVERTED_INDEX,
+        metric_type: MetricType.BM25,
+      });
+      expect(index.error_code).toEqual(ErrorCode.SUCCESS);
+
+      const load = await milvusClient.loadCollectionSync({
+        collection_name: functionCollection,
+      });
+      expect(load.error_code).toEqual(ErrorCode.SUCCESS);
+    });
+
+    afterAll(async () => {
+      await milvusClient.dropCollection({
+        collection_name: functionCollection,
+      });
+      for (const objectName of uploadedObjects) {
+        try {
+          await minioClient.removeObject(MINIO_BUCKET, objectName);
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    });
+
+    it('exposes the BM25 function in the external collection schema', async () => {
+      const describe = await milvusClient.describeCollection({
+        collection_name: functionCollection,
+        cache: false,
+      });
+      const bm25 = describe.schema.functions.find(
+        functionSchema => functionSchema.name === 'bm25'
+      );
+      const sparse = describe.schema.fields.find(
+        field => field.name === 'sparse'
+      );
+
+      expect(bm25).toEqual(
+        expect.objectContaining({
+          type: 'BM25',
+          input_field_names: ['text'],
+          output_field_names: ['sparse'],
+        })
+      );
+      expect(sparse?.is_function_output).toEqual(true);
+    });
+
+    it('runs full-text search on the external BM25 function output', async () => {
+      const search = await milvusClient.search({
+        collection_name: functionCollection,
+        data: 'apple',
+        anns_field: 'sparse',
+        limit: 3,
+        output_fields: ['id', 'text'],
+      });
+
+      expect(search.status.error_code).toEqual(ErrorCode.SUCCESS);
+      expect(search.results).toHaveLength(3);
+      expect(
+        search.results.every(result => result.text.includes('apple'))
+      ).toEqual(true);
+    });
+
+    it('filters external text fields with TEXT_MATCH', async () => {
+      const query = await milvusClient.query({
+        collection_name: functionCollection,
+        filter: "TEXT_MATCH(text, 'apple')",
+        output_fields: ['id', 'text'],
+        limit: 10,
+      });
+
+      expect(query.status.error_code).toEqual(ErrorCode.SUCCESS);
+      expect(
+        query.data.map(row => Number(row.id)).sort((a, b) => a - b)
+      ).toEqual([0, 2, 4]);
+      expect(query.data.every(row => row.text.includes('apple'))).toEqual(true);
+    });
   });
 });

--- a/test/utils/Collection.spec.ts
+++ b/test/utils/Collection.spec.ts
@@ -34,6 +34,17 @@ const failedStatus: ResStatus = {
   detail: '',
 };
 
+const externalCollectionAlterUnsupportedStatus: ResStatus = {
+  error_code: ErrorCode.IllegalArgument,
+  reason:
+    'alter collection schema operation is not supported for external collection schema_alter_collection',
+  code: 1100,
+  extra_info: { is_input_error: 'true' },
+  retriable: false,
+  detail:
+    'alter collection schema operation is not supported for external collection schema_alter_collection',
+};
+
 const respondWith =
   (response: any) => (_request: any, _options: any, callback: RpcCallback) =>
     callback(null, response);
@@ -216,6 +227,49 @@ describe('collection schema alteration', () => {
         timestamptzData: (new Date(defaultValue).getTime() * 1000).toString(),
       });
       expect(field.default_value).toBe(defaultValue);
+      expect(cache.has(cacheKey())).toBe(false);
+    });
+
+    it('falls back to AddCollectionField when alter schema rejects an external collection', async () => {
+      const { client, rpcClient } = createTestClient();
+      rpcClient.AlterCollectionSchema.mockImplementation(
+        respondWith({ alter_status: externalCollectionAlterUnsupportedStatus })
+      );
+      rpcClient.AddCollectionField.mockImplementation(
+        respondWith(successStatus)
+      );
+      const cache = seedCollectionCache(client);
+
+      const result = await client.addCollectionField({
+        collection_name: COLLECTION_NAME,
+        field: {
+          name: 'nullable_vector',
+          data_type: DataType.FloatVector,
+          dim: 8,
+          nullable: true,
+          external_field: 'external_vector',
+        },
+      });
+
+      expect(result).toEqual(successStatus);
+      expect(rpcClient.AlterCollectionSchema).toHaveBeenCalledTimes(1);
+      expect(rpcClient.AddCollectionField).toHaveBeenCalledTimes(1);
+      const legacyRequest = rpcClient.AddCollectionField.mock.calls[0][0];
+      const fieldSchemaType = (client as any).schemaProto.lookupType(
+        (client as any).protoInternalPath.fieldSchema
+      );
+      const decoded = fieldSchemaType.toObject(
+        fieldSchemaType.decode(legacyRequest.schema),
+        { longs: String }
+      );
+      expect(decoded).toEqual(
+        expect.objectContaining({
+          name: 'nullable_vector',
+          dataType: DataType.FloatVector,
+          nullable: true,
+          externalField: 'external_vector',
+        })
+      );
       expect(cache.has(cacheKey())).toBe(false);
     });
 


### PR DESCRIPTION
## Summary

- fall back to the legacy AddCollectionField RPC when AlterCollectionSchema rejects an external collection
- preserve nullable vector and external field metadata in the fallback request
- add real MinIO/Parquet integration coverage for external nullable vector field addition
- verify External Collection BM25 Function schema and generated sparse output
- verify External Collection full-text search and TEXT_MATCH queries against refreshed data

## Testing

- NODE_ENV=dev npx jest test/utils/Collection.spec.ts --runInBand (36 passed)
- NODE_ENV=dev npx jest test/grpc/ExternalCollection.spec.ts --runInBand (5 passed against local Milvus and MinIO)
- npm run build
- npx prettier --write milvus/grpc/Collection.ts test/utils/Collection.spec.ts test/grpc/ExternalCollection.spec.ts
- git diff --check