### PR TITLE
feat: support Text data type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
           wget https://raw.githubusercontent.com/milvus-io/milvus/master/deployments/docker/standalone/docker-compose.yml -O docker-compose.yml
           sed -i -e "s/milvusdb.*$/milvusdb\/milvus:${{ steps.info.outputs.milvusVersion }}/g" docker-compose.yml
 
-          # Use docker-compose override to pass OpenAI key
+          # Pass the OpenAI key and enable StorageV3, which is required by Text fields.
           cat > docker-compose.override.yml << EOF
           services:
             standalone:
@@ -69,6 +69,11 @@ jobs:
 
           docker compose -f docker-compose.yml -f docker-compose.override.yml up -d
           docker compose -f docker-compose.yml -f docker-compose.override.yml ps
+
+      - name: Verify StorageV3 is enabled for Text fields
+        run: |
+          docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' milvus-standalone \
+            | grep -qx 'COMMON_STORAGE_USELOONFFI=true'
 
       - name: Wait for MinIO to be ready
         run: |

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 100%
+        threshold: 0%

--- a/milvus/bulkwriter/BulkWriter.ts
+++ b/milvus/bulkwriter/BulkWriter.ts
@@ -264,6 +264,12 @@ export class BulkWriter extends EventEmitter {
         }
         break;
       }
+      case DataType.Text: {
+        if (typeof val !== 'string') {
+          throw new Error(`Field "${field.name}": Text must be a string.`);
+        }
+        break;
+      }
       case DataType.Array: {
         if (!Array.isArray(val)) {
           throw new Error(

--- a/milvus/bulkwriter/ColumnBuffer.ts
+++ b/milvus/bulkwriter/ColumnBuffer.ts
@@ -101,6 +101,7 @@ export class ColumnBuffer {
     if (fixed) return fixed;
     if (
       dt === DataType.VarChar ||
+      dt === DataType.Text ||
       dt === DataType.Geometry ||
       dt === DataType.Timestamptz
     ) {

--- a/milvus/bulkwriter/ParquetFormatter.ts
+++ b/milvus/bulkwriter/ParquetFormatter.ts
@@ -26,8 +26,9 @@ function parquetFieldDef(dt: DataType): Record<string, any> {
       return { type: 'FLOAT' };
     case DataType.Double:
       return { type: 'DOUBLE' };
-    // VarChar, JSON, Geometry, Timestamptz, SparseFloatVector → UTF8 string
+    // VarChar, Text, JSON, Geometry, Timestamptz, SparseFloatVector → UTF8 string
     case DataType.VarChar:
+    case DataType.Text:
     case DataType.JSON:
     case DataType.Geometry:
     case DataType.Timestamptz:

--- a/milvus/const/milvus.ts
+++ b/milvus/const/milvus.ts
@@ -291,6 +291,7 @@ export enum DataType {
   Array = 22,
   JSON = 23,
   Geometry = 24,
+  Text = 25, // variable-length strings without a max_length limit; requires StorageV3
   Timestamptz = 26,
 
   BinaryVector = 100,
@@ -362,6 +363,7 @@ export const DataTypeMap: { [key in keyof typeof DataType]: number } = {
   Array: 22,
   JSON: 23,
   Geometry: 24,
+  Text: 25,
   Timestamptz: 26,
   BinaryVector: 100,
   FloatVector: 101,
@@ -387,6 +389,7 @@ export enum DataTypeStringEnum {
   Array = 'Array',
   JSON = 'JSON',
   Geometry = 'Geometry',
+  Text = 'Text',
   Timestamptz = 'Timestamptz',
   BinaryVector = 'BinaryVector',
   FloatVector = 'FloatVector',

--- a/milvus/utils/Schema.ts
+++ b/milvus/utils/Schema.ts
@@ -84,6 +84,7 @@ export const getDataKey = (type: DataType, camelCase: boolean = false) => {
       dataKey = 'bool_data';
       break;
     case DataType.VarChar:
+    case DataType.Text:
       dataKey = 'string_data';
       break;
     case DataType.Array:

--- a/test/bulkwriter/BulkWriter.spec.ts
+++ b/test/bulkwriter/BulkWriter.spec.ts
@@ -1852,6 +1852,37 @@ describe('BulkWriter validation', () => {
     ).rejects.toThrow(/max_length/);
   });
 
+  it('should write Text values beyond the VarChar length limit', async () => {
+    const longText = 'milvus-text-'.repeat(6000);
+    const { allRows } = await writeAndParse(
+      {
+        fields: [
+          { name: 'id', data_type: DataType.Int64, is_primary_key: true },
+          { name: 'content', data_type: DataType.Text },
+        ],
+      },
+      [{ id: 1, content: longText }]
+    );
+
+    expect(allRows[0].content).toBe(longText);
+  });
+
+  it('should reject non-string Text values', async () => {
+    const writer = new BulkWriter({
+      schema: {
+        fields: [
+          { name: 'id', data_type: DataType.Int64, is_primary_key: true },
+          { name: 'content', data_type: DataType.Text },
+        ],
+      },
+      localPath: tmpDir,
+    });
+
+    await expect(writer.append({ id: 1, content: 12345 })).rejects.toThrow(
+      /Text/
+    );
+  });
+
   it('should reject non-array for Array field', async () => {
     const writer = new BulkWriter({
       schema: {

--- a/test/bulkwriter/ParquetFormatter.spec.ts
+++ b/test/bulkwriter/ParquetFormatter.spec.ts
@@ -105,6 +105,21 @@ describe('ParquetFormatter basic', () => {
     expect(allRows[1].text).toBe('world');
   });
 
+  it('should write and read Text without max_length', async () => {
+    const longText = 'milvus-text-'.repeat(6000);
+    const { allRows } = await writeAndReadParquet(
+      {
+        fields: [
+          { name: 'id', data_type: DataType.Int64, is_primary_key: true },
+          { name: 'content', data_type: DataType.Text },
+        ],
+      },
+      [{ id: 1, content: longText }]
+    );
+
+    expect(allRows[0].content).toBe(longText);
+  });
+
   it('should auto-chunk with parquet format', async () => {
     const { files, allRows } = await writeAndReadParquet(
       {

--- a/test/grpc/Text.spec.ts
+++ b/test/grpc/Text.spec.ts
@@ -1,0 +1,176 @@
+import {
+  ConsistencyLevelEnum,
+  DataType,
+  ErrorCode,
+  IndexType,
+  MetricType,
+  MilvusClient,
+} from '../../milvus';
+import { GENERATE_NAME, IP } from '../tools';
+
+jest.setTimeout(180000);
+
+const milvusClient = new MilvusClient({ address: IP, logLevel: 'info' });
+const COLLECTION_NAME = GENERATE_NAME('text_type');
+const LONG_TEXT = 'milvus storage v3 text payload '.repeat(3000);
+
+describe('Text data type', () => {
+  afterAll(async () => {
+    await milvusClient.dropCollection({
+      collection_name: COLLECTION_NAME,
+    });
+    await milvusClient.closeConnection();
+  });
+
+  it('supports schema, long values, filtering, search, and upsert', async () => {
+    const create = await milvusClient.createCollection({
+      collection_name: COLLECTION_NAME,
+      fields: [
+        {
+          name: 'id',
+          data_type: DataType.Int64,
+          is_primary_key: true,
+        },
+        {
+          name: 'vector',
+          data_type: DataType.FloatVector,
+          dim: 4,
+        },
+        {
+          name: 'content',
+          data_type: DataType.Text,
+          nullable: true,
+          enable_analyzer: true,
+          enable_match: true,
+          analyzer_params: { tokenizer: 'standard' },
+        },
+      ],
+    });
+    expect(create.error_code).toBe(ErrorCode.SUCCESS);
+
+    const describe = await milvusClient.describeCollection({
+      collection_name: COLLECTION_NAME,
+    });
+    const contentField = describe.schema.fields.find(
+      field => field.name === 'content'
+    );
+    expect(contentField?.dataType).toBe(DataType.Text);
+    expect(contentField?.data_type).toBe('Text');
+    expect(contentField?.max_length).toBeUndefined();
+
+    const insert = await milvusClient.insert({
+      collection_name: COLLECTION_NAME,
+      data: [
+        {
+          id: 1,
+          vector: [1, 0, 0, 0],
+          content: LONG_TEXT,
+        },
+        {
+          id: 2,
+          vector: [0, 1, 0, 0],
+          content: 'Milvus 支持超长文本、向量检索和 emoji 🚀',
+        },
+        {
+          id: 3,
+          vector: [0, 0, 1, 0],
+          content: null,
+        },
+      ],
+    });
+    expect(insert.status.error_code).toBe(ErrorCode.SUCCESS);
+
+    const flush = await milvusClient.flushSync({
+      collection_names: [COLLECTION_NAME],
+    });
+    expect(flush.status.error_code).toBe(ErrorCode.SUCCESS);
+
+    const createIndex = await milvusClient.createIndex({
+      collection_name: COLLECTION_NAME,
+      field_name: 'vector',
+      index_type: IndexType.AUTOINDEX,
+      metric_type: MetricType.COSINE,
+    });
+    expect(createIndex.error_code).toBe(ErrorCode.SUCCESS);
+
+    const load = await milvusClient.loadCollectionSync({
+      collection_name: COLLECTION_NAME,
+    });
+    expect(load.error_code).toBe(ErrorCode.SUCCESS);
+
+    const query = await milvusClient.query({
+      collection_name: COLLECTION_NAME,
+      filter: 'id in [1, 2, 3]',
+      output_fields: ['id', 'content'],
+      consistency_level: ConsistencyLevelEnum.Strong,
+    });
+    expect(query.status.error_code).toBe(ErrorCode.SUCCESS);
+
+    const rows = new Map(query.data.map(row => [Number(row.id), row]));
+    expect(rows.get(1)?.content).toBe(LONG_TEXT);
+    expect(rows.get(2)?.content).toBe(
+      'Milvus 支持超长文本、向量检索和 emoji 🚀'
+    );
+    expect(rows.get(3)?.content).toBeNull();
+
+    const matched = await milvusClient.query({
+      collection_name: COLLECTION_NAME,
+      filter: "text_match(content, 'storage')",
+      output_fields: ['id'],
+      consistency_level: ConsistencyLevelEnum.Strong,
+    });
+    expect(matched.status.error_code).toBe(ErrorCode.SUCCESS);
+    expect(matched.data.map(row => Number(row.id))).toEqual([1]);
+
+    const search = await milvusClient.search({
+      collection_name: COLLECTION_NAME,
+      data: [1, 0, 0, 0],
+      filter: "text_match(content, 'storage')",
+      output_fields: ['id', 'content'],
+      limit: 3,
+      consistency_level: ConsistencyLevelEnum.Strong,
+    });
+    expect(search.status.error_code).toBe(ErrorCode.SUCCESS);
+    expect(search.results).toHaveLength(1);
+    expect(Number(search.results[0].id)).toBe(1);
+    expect(search.results[0].content).toBe(LONG_TEXT);
+
+    const updatedText = `${LONG_TEXT} updated`;
+    const upsert = await milvusClient.upsert({
+      collection_name: COLLECTION_NAME,
+      data: [
+        {
+          id: 2,
+          vector: [0, 1, 0, 0],
+          content: updatedText,
+        },
+      ],
+    });
+    expect(upsert.status.error_code).toBe(ErrorCode.SUCCESS);
+
+    const flushUpsert = await milvusClient.flushSync({
+      collection_names: [COLLECTION_NAME],
+    });
+    expect(flushUpsert.status.error_code).toBe(ErrorCode.SUCCESS);
+
+    const release = await milvusClient.releaseCollection({
+      collection_name: COLLECTION_NAME,
+    });
+    expect(release.error_code).toBe(ErrorCode.SUCCESS);
+
+    const reload = await milvusClient.loadCollectionSync({
+      collection_name: COLLECTION_NAME,
+    });
+    expect(reload.error_code).toBe(ErrorCode.SUCCESS);
+
+    const updated = await milvusClient.query({
+      collection_name: COLLECTION_NAME,
+      filter: 'id == 2',
+      output_fields: ['id', 'content'],
+      consistency_level: ConsistencyLevelEnum.Strong,
+    });
+    expect(updated.status.error_code).toBe(ErrorCode.SUCCESS);
+    expect(updated.data).toHaveLength(1);
+    expect(updated.data[0].content).toBe(updatedText);
+  });
+});

--- a/test/tools/data.ts
+++ b/test/tools/data.ts
@@ -353,6 +353,7 @@ const createDataGenMap = () => {
     [DataType.Float]: genFloat,
     [DataType.Double]: genFloat,
     [DataType.VarChar]: genVarChar,
+    [DataType.Text]: genVarChar,
     [DataType.Array]: genArray,
     [DataType.JSON]: genJSON,
     [DataType.Geometry]: genGeometry,

--- a/test/utils/Function.spec.ts
+++ b/test/utils/Function.spec.ts
@@ -221,6 +221,7 @@ describe('Function API testing', () => {
     expect(getDataKey(DataType.Int8)).toEqual('int_data');
     expect(getDataKey(DataType.Bool)).toEqual('bool_data');
     expect(getDataKey(DataType.VarChar)).toEqual('string_data');
+    expect(getDataKey(DataType.Text)).toEqual('string_data');
     expect(getDataKey(DataType.Array)).toEqual('array_data');
     expect(getDataKey(DataType.JSON)).toEqual('json_data');
     expect(getDataKey(DataType.None)).toEqual('none');
@@ -242,6 +243,7 @@ describe('Function API testing', () => {
     expect(getDataKey(DataType.Int8, true)).toEqual('intData');
     expect(getDataKey(DataType.Bool, true)).toEqual('boolData');
     expect(getDataKey(DataType.VarChar, true)).toEqual('stringData');
+    expect(getDataKey(DataType.Text, true)).toEqual('stringData');
     expect(getDataKey(DataType.Array, true)).toEqual('arrayData');
     expect(getDataKey(DataType.JSON, true)).toEqual('jsonData');
     expect(getDataKey(DataType.None, true)).toEqual('none');

--- a/test/utils/Schema.spec.ts
+++ b/test/utils/Schema.spec.ts
@@ -17,6 +17,41 @@ import {
 } from '../../milvus';
 
 describe('utils/Schema', () => {
+  it('formats Text fields without requiring max_length', () => {
+    const schemaProtoPath = path.resolve(
+      __dirname,
+      '../../proto/proto/schema.proto'
+    );
+    const schemaProto = protobuf.loadSync(schemaProtoPath);
+    const fieldSchemaType = schemaProto.lookupType(
+      'milvus.proto.schema.FieldSchema'
+    );
+
+    const payload = formatFieldSchema(
+      {
+        name: 'content',
+        data_type: DataType.Text,
+        enable_analyzer: true,
+        analyzer_params: { tokenizer: 'standard' },
+      },
+      { fieldSchemaType }
+    );
+
+    expect(payload.dataType).toBe(25);
+    expect(payload.typeParams).toEqual(
+      expect.arrayContaining([
+        { key: 'enable_analyzer', value: 'true' },
+        {
+          key: 'analyzer_params',
+          value: JSON.stringify({ tokenizer: 'standard' }),
+        },
+      ])
+    );
+    expect(payload.typeParams).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: 'max_length' })])
+    );
+  });
+
   it('builds the default schema from shorthand create collection params', () => {
     expect(
       buildDefaultSchema({

--- a/test/utils/Validate.spec.ts
+++ b/test/utils/Validate.spec.ts
@@ -206,6 +206,27 @@ describe('utils/validate', () => {
     );
   });
 
+  it('should accept a Text field without max_length', () => {
+    const fields: FieldType[] = [
+      {
+        name: 'content',
+        data_type: DataType.Text,
+      },
+      {
+        name: 'vector',
+        data_type: DataType.FloatVector,
+        dim: 4,
+      },
+      {
+        name: 'id',
+        data_type: DataType.Int64,
+        is_primary_key: true,
+      },
+    ];
+
+    expect(checkCollectionFields(fields)).toBe(true);
+  });
+
   it('should return true if all fields are valid', () => {
     const fields: FieldType[] = [
       {


### PR DESCRIPTION
## Summary

- add `DataType.Text` with the Milvus protocol value `25`
- encode Text through the scalar string field without requiring `max_length`
- support Text validation and JSON/Parquet output in BulkWriter
- enable and verify StorageV3 for Text end-to-end tests in GitHub Actions
- enforce 100% Codecov patch coverage

## Testing

- `npm run build`
- 291 focused unit tests passed
- `NODE_ENV=dev npx jest test/grpc/Text.spec.ts --runInBand`
- added-code coverage: 17/17 statements and functions, 6/6 branches

The end-to-end test covers schema creation, long and nullable Text values, query readback, `text_match`, vector search, upsert, flush, release, and reload.