### PR TITLE
feat: support function field backfill

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,10 +70,12 @@ jobs:
           docker compose -f docker-compose.yml -f docker-compose.override.yml up -d
           docker compose -f docker-compose.yml -f docker-compose.override.yml ps
 
-      - name: Verify StorageV3 is enabled for Text fields
+      - name: Verify function-field Backfill configuration
         run: |
-          docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' milvus-standalone \
-            | grep -qx 'COMMON_STORAGE_USELOONFFI=true'
+          envs="$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' milvus-standalone)"
+          grep -qx 'COMMON_STORAGE_USELOONFFI=true' <<< "$envs"
+          grep -qx 'DATACOORD_COMPACTION_BUMPSCHEMAVERSION_ENABLED=true' <<< "$envs"
+          grep -qx 'DATACOORD_COMPACTION_STORAGEVERSION_ENABLED=true' <<< "$envs"
 
       - name: Wait for MinIO to be ready
         run: |
@@ -129,6 +131,7 @@ jobs:
       - name: Run Test coverage
         run: |
           yarn build-test
+          NODE_ENV=dev npx jest test/grpc/FunctionFieldBackfill.e2e.spec.ts --runInBand
           yarn coverage
 
       - name: send to codecov

--- a/milvus/grpc/Collection.ts
+++ b/milvus/grpc/Collection.ts
@@ -100,6 +100,7 @@ import {
   UnpinSnapshotDataReq,
   FunctionType,
   IndexType,
+  KeyValuePair,
   collectionNameReq,
 } from '../';
 
@@ -920,7 +921,10 @@ export class Collection extends Database {
    * @returns {string} status.error_code - The error code of the operation.
    * @returns {string} status.reason - The reason for the error, if any.
    * @returns {Object[]} stats - An array of objects, each containing a key-value pair representing a statistic.
-   * @returns {Object} data - Transforms **stats** to an object with properties representing statistics (e.g., { row_count: 0 }).
+   * @returns {Object} data - Transforms every **stats** entry to an object,
+   * including schema-version Backfill progress when reported by Milvus (for
+   * example, `schema_version_consistent_segments` and
+   * `schema_version_total_segments`).
    *
    * @example
    * ```
@@ -940,7 +944,10 @@ export class Collection extends Database {
       data.timeout || this.timeout
     );
 
-    promise.data = formatKeyValueData(promise.stats, ['row_count']);
+    promise.data = formatKeyValueData(
+      promise.stats,
+      promise.stats.map(({ key }: KeyValuePair) => key)
+    );
 
     return promise;
   }
@@ -1744,7 +1751,6 @@ export class Collection extends Database {
    * @param {string} data.collection_name - The collection name.
    * @param {FieldType} data.field - The function output field schema.
    * @param {FunctionObject} data.function - The function schema.
-   * @param {boolean} [data.do_physical_backfill] - Whether to backfill existing data.
    * @param {string} [data.db_name] - The database name.
    * @param {number} [data.timeout] - Optional RPC timeout in milliseconds.
    *
@@ -1779,7 +1785,6 @@ export class Collection extends Database {
           },
         ],
         func_schema: [formatFunctionSchema(data.function)],
-        do_physical_backfill: !!data.do_physical_backfill,
       },
     });
   }
@@ -1789,7 +1794,9 @@ export class Collection extends Database {
    *
    * BM25 requires a SparseFloatVector output field. MinHash requires a
    * BinaryVector output field. The bound index must provide an explicit
-   * index_type and cannot use AUTOINDEX.
+   * index_type and cannot use AUTOINDEX. Milvus backfills existing sealed
+   * segments asynchronously through schema-bump compaction; this RPC returns
+   * after the schema change is accepted, not after backfill finishes.
    *
    * @param {AddFunctionFieldReq} data - The request parameters.
    * @returns {Promise<ResStatus>} The AlterCollectionSchema alter status.

--- a/milvus/types/Collection.ts
+++ b/milvus/types/Collection.ts
@@ -132,7 +132,6 @@ export interface BaseCreateCollectionReq extends GrpcTimeOut {
   functions?: FunctionObject[]; // optionals, doc-in/doc-out functions
   external_source?: string; // optional, external collection source path
   external_spec?: string; // optional, external collection spec configuration
-  do_physical_backfill?: boolean; // optional, whether to physically backfill external data
   file_resource_ids?: Array<number | string>; // optional, external file resource ids
 }
 
@@ -249,7 +248,6 @@ export interface CollectionSchema {
   struct_array_fields: FieldSchema[];
   external_source?: string;
   external_spec?: string;
-  do_physical_backfill?: boolean;
   file_resource_ids?: string[];
 }
 
@@ -359,7 +357,6 @@ export interface AlterCollectionSchemaReq extends collectionNameReq {
   db_name?: string; // optional, db name
   field: FieldType; // required, function output field schema to add
   function: FunctionObject; // required, function schema to add
-  do_physical_backfill?: boolean; // optional, whether Milvus should backfill existing data
   index_name?: string; // optional, index name for the new field
   extra_params?: Record<string, any>; // optional, field info extra params
 }

--- a/milvus/utils/Format.ts
+++ b/milvus/utils/Format.ts
@@ -270,6 +270,10 @@ export const formatDescribedCol = (
 ): DescribeCollectionResponse => {
   // clone object
   const newData = cloneObj<DescribeCollectionResponse>(data);
+  // do_physical_backfill is a legacy wire field ignored by current Milvus.
+  // Keep it out of the public SDK response to match schema-extension requests.
+  delete (newData.schema as any).do_physical_backfill;
+  delete (newData.schema as any).doPhysicalBackfill;
   // merge fields and struct_array_fields
   newData.schema.fields = [
     ...newData.schema.fields,

--- a/milvus/utils/Schema.ts
+++ b/milvus/utils/Schema.ts
@@ -361,7 +361,6 @@ export const formatCollectionSchema = (
     clustering_key_field,
     external_source,
     external_spec,
-    do_physical_backfill,
     file_resource_ids,
   } = data;
 
@@ -435,10 +434,6 @@ export const formatCollectionSchema = (
 
   if (external_spec) {
     payload.externalSpec = external_spec;
-  }
-
-  if (typeof do_physical_backfill !== 'undefined') {
-    payload.doPhysicalBackfill = do_physical_backfill;
   }
 
   if (file_resource_ids) {

--- a/test/grpc/FullTextSearch.spec.ts
+++ b/test/grpc/FullTextSearch.spec.ts
@@ -786,6 +786,12 @@ describe(`FulltextSearch API`, () => {
       );
       expect(sparseField).toBeDefined();
       expect(sparseField!.is_function_output).toEqual(true);
+
+      const drop = await milvusClient.dropFunctionField({
+        collection_name: COLLECTION_FOR_ADD_FUNCTION_FIELD,
+        function_name: 'bm25_added_with_string_enum',
+      });
+      expect(drop.error_code).toEqual(ErrorCode.SUCCESS);
     });
 
     it(`Add and drop MinHash function field should success`, async () => {

--- a/test/grpc/FunctionFieldBackfill.e2e.spec.ts
+++ b/test/grpc/FunctionFieldBackfill.e2e.spec.ts
@@ -1,0 +1,180 @@
+import {
+  ConsistencyLevelEnum,
+  DataType,
+  ErrorCode,
+  FunctionType,
+  IndexState,
+  IndexType,
+  MetricType,
+  MilvusClient,
+} from '../../milvus';
+import { GENERATE_NAME, IP } from '../tools';
+
+jest.setTimeout(240_000);
+
+const COLLECTION_NAME = GENERATE_NAME();
+const DENSE_INDEX_NAME = 'dense_index';
+const BM25_INDEX_NAME = 'backfilled_bm25_index';
+const client = new MilvusClient({ address: IP, logLevel: 'info' });
+
+const delay = (milliseconds: number) =>
+  new Promise(resolve => setTimeout(resolve, milliseconds));
+
+const waitForBackfill = async () => {
+  let lastProgress: Record<string, any> = {};
+  for (let attempt = 0; attempt < 120; attempt++) {
+    const stats = await client.getCollectionStatistics({
+      collection_name: COLLECTION_NAME,
+    });
+    expect(stats.status.error_code).toEqual(ErrorCode.SUCCESS);
+    lastProgress = stats.data;
+
+    const consistent = Number(stats.data.schema_version_consistent_segments);
+    const total = Number(stats.data.schema_version_total_segments);
+    if (total > 0 && consistent === total) {
+      return;
+    }
+    await delay(1_000);
+  }
+
+  throw new Error(
+    `Function-field Backfill did not finish: ${JSON.stringify(lastProgress)}`
+  );
+};
+
+const waitForBoundIndex = async () => {
+  let lastState: IndexState | string = IndexState.IndexStateNone;
+  for (let attempt = 0; attempt < 120; attempt++) {
+    const state = await client.getIndexState({
+      collection_name: COLLECTION_NAME,
+      index_name: BM25_INDEX_NAME,
+    });
+    expect(state.status.error_code).toEqual(ErrorCode.SUCCESS);
+    lastState = state.state;
+
+    if (
+      state.state === IndexState.Finished ||
+      String(state.state) === 'Finished'
+    ) {
+      return;
+    }
+    if (state.state === IndexState.Failed || String(state.state) === 'Failed') {
+      throw new Error('Bound BM25 index failed after Backfill');
+    }
+    await delay(1_000);
+  }
+
+  throw new Error(`Bound BM25 index did not finish, state=${lastState}`);
+};
+
+describe('Function field Backfill E2E', () => {
+  beforeAll(async () => {
+    const create = await client.createCollection({
+      collection_name: COLLECTION_NAME,
+      consistency_level: 'Strong',
+      fields: [
+        {
+          name: 'id',
+          data_type: DataType.Int64,
+          is_primary_key: true,
+          autoID: false,
+        },
+        {
+          name: 'text',
+          data_type: DataType.VarChar,
+          max_length: 256,
+          enable_analyzer: true,
+        },
+        {
+          name: 'vector',
+          data_type: DataType.FloatVector,
+          dim: 4,
+        },
+      ],
+    });
+    expect(create.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const denseIndex = await client.createIndex({
+      collection_name: COLLECTION_NAME,
+      field_name: 'vector',
+      index_name: DENSE_INDEX_NAME,
+      index_type: IndexType.FLAT,
+      metric_type: MetricType.L2,
+    });
+    expect(denseIndex.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const insert = await client.insert({
+      collection_name: COLLECTION_NAME,
+      fields_data: [
+        { id: 1, text: 'apple banana', vector: [0.1, 0.2, 0.3, 0.4] },
+        { id: 2, text: 'banana orange', vector: [0.2, 0.3, 0.4, 0.5] },
+        { id: 3, text: 'fresh apple pie', vector: [0.3, 0.4, 0.5, 0.6] },
+      ],
+    });
+    expect(insert.status.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const flush = await client.flushSync({
+      collection_names: [COLLECTION_NAME],
+    });
+    expect(flush.status.error_code).toEqual(ErrorCode.SUCCESS);
+  });
+
+  afterAll(async () => {
+    try {
+      const exists = await client.hasCollection({
+        collection_name: COLLECTION_NAME,
+      });
+      if (exists.value) {
+        await client.dropCollection({ collection_name: COLLECTION_NAME });
+      }
+    } finally {
+      await client.closeConnection();
+    }
+  });
+
+  it('materializes a newly added BM25 field for pre-existing rows', async () => {
+    const add = await client.addFunctionField({
+      collection_name: COLLECTION_NAME,
+      index_name: BM25_INDEX_NAME,
+      extra_params: {
+        index_type: IndexType.SPARSE_INVERTED_INDEX,
+        metric_type: MetricType.BM25,
+      },
+      field: {
+        name: 'sparse',
+        data_type: DataType.SparseFloatVector,
+        is_function_output: true,
+      },
+      function: {
+        name: 'backfilled_bm25',
+        type: FunctionType.BM25,
+        input_field_names: ['text'],
+        output_field_names: ['sparse'],
+        params: {},
+      },
+    });
+    expect(add.error_code).toEqual(ErrorCode.SUCCESS);
+
+    await waitForBackfill();
+    await waitForBoundIndex();
+
+    const load = await client.loadCollection({
+      collection_name: COLLECTION_NAME,
+    });
+    expect(load.error_code).toEqual(ErrorCode.SUCCESS);
+
+    const search = await client.search({
+      collection_name: COLLECTION_NAME,
+      anns_field: 'sparse',
+      data: 'apple',
+      limit: 3,
+      output_fields: ['id', 'text'],
+      params: { drop_ratio_search: 0 },
+      consistency_level: ConsistencyLevelEnum.Strong,
+    });
+    expect(search.status.error_code).toEqual(ErrorCode.SUCCESS);
+    expect(search.results.map(hit => Number(hit.id))).toEqual(
+      expect.arrayContaining([1, 3])
+    );
+  });
+});

--- a/test/utils/Collection.spec.ts
+++ b/test/utils/Collection.spec.ts
@@ -61,6 +61,7 @@ const createTestClient = () => {
     DropCollectionFunction: jest.fn(),
     DropCollection: jest.fn(),
     DescribeCollection: jest.fn(),
+    GetCollectionStatistics: jest.fn(),
   };
   const channelPool = {
     acquire: jest.fn().mockResolvedValue(rpcClient),
@@ -474,6 +475,32 @@ describe('collection schema alteration', () => {
           params: [{ key: 'analyzer', value: 'standard' }],
         }),
       ]);
+      expect(addRequest).not.toHaveProperty('do_physical_backfill');
+    });
+
+    it('ignores the legacy do_physical_backfill runtime property', async () => {
+      const { client, rpcClient } = createTestClient();
+      rpcClient.AlterCollectionSchema.mockImplementation(
+        respondWith({ alter_status: successStatus })
+      );
+
+      await client.addFunctionField({
+        collection_name: COLLECTION_NAME,
+        field: {
+          name: 'sparse_vector',
+          data_type: DataType.SparseFloatVector,
+        },
+        function: bm25Function,
+        extra_params: {
+          index_type: IndexType.SPARSE_INVERTED_INDEX,
+          metric_type: 'BM25',
+        },
+        do_physical_backfill: true,
+      } as any);
+
+      const addRequest =
+        rpcClient.AlterCollectionSchema.mock.calls[0][0].action.add_request;
+      expect(addRequest).not.toHaveProperty('do_physical_backfill');
     });
 
     it('serializes a MinHash function field and its bound index parameters', async () => {
@@ -737,6 +764,32 @@ describe('collection schema alteration', () => {
       expect(rpcClient.DropCollectionFunction.mock.calls[0][0]).toEqual({
         collection_name: COLLECTION_NAME,
         function_name: 'bm25_function',
+      });
+    });
+  });
+
+  describe('collection statistics', () => {
+    it('exposes schema-version backfill progress in data', async () => {
+      const { client, rpcClient } = createTestClient();
+      rpcClient.GetCollectionStatistics.mockImplementation(
+        respondWith({
+          status: successStatus,
+          stats: [
+            { key: 'row_count', value: '3' },
+            { key: 'schema_version_consistent_segments', value: '1' },
+            { key: 'schema_version_total_segments', value: '2' },
+          ],
+        })
+      );
+
+      const result = await client.getCollectionStatistics({
+        collection_name: COLLECTION_NAME,
+      });
+
+      expect(result.data).toEqual({
+        row_count: '3',
+        schema_version_consistent_segments: '1',
+        schema_version_total_segments: '2',
       });
     });
   });

--- a/test/utils/Schema.spec.ts
+++ b/test/utils/Schema.spec.ts
@@ -256,6 +256,8 @@ describe('utils/Schema', () => {
       ],
       external_source: 's3://bucket/path',
       external_spec: '{"format":"parquet"}',
+      // Legacy callers may still provide this at runtime. Current Milvus
+      // ignores it, so the Node SDK intentionally leaves it off the wire.
       do_physical_backfill: true,
       file_resource_ids: [1, '2'],
       functions: [
@@ -294,9 +296,9 @@ describe('utils/Schema', () => {
       enableDynamicField: false,
       externalSource: 's3://bucket/path',
       externalSpec: '{"format":"parquet"}',
-      doPhysicalBackfill: true,
       fileResourceIds: [1, '2'],
     });
+    expect(payload).not.toHaveProperty('doPhysicalBackfill');
     expect(payload.fields[0]).toMatchObject({
       name: 'testField1',
       description: 'Test PRIMARY KEY field',
@@ -982,7 +984,7 @@ describe('utils/Schema', () => {
       'external_spec',
       '{"format":"parquet"}'
     );
-    expect(formatted.schema).toHaveProperty('do_physical_backfill', true);
+    expect(formatted.schema).not.toHaveProperty('do_physical_backfill');
     expect(formatted.schema).toHaveProperty('file_resource_ids', ['1', '2']);
     expect(formatted.schema).toHaveProperty('properties');
     expect(formatted.schema).toHaveProperty('functions');


### PR DESCRIPTION
## What

- align the Node SDK with current Milvus function-field Backfill semantics
- remove the ignored legacy `do_physical_backfill` option while preserving runtime compatibility
- expose schema-version Backfill progress through collection statistics
- add a real BM25 Backfill E2E test for pre-existing flushed rows
- verify the required StorageV3 and compaction settings in CI
- clean up function fields between integration cases to stay within the vector-field limit

## Testing

- `NODE_ENV=dev npx jest test/utils/Collection.spec.ts test/utils/Schema.spec.ts --runInBand`
- `yarn build`
- `yarn build-test`
- `NODE_ENV=dev npx jest test/grpc/FunctionFieldBackfill.e2e.spec.ts --runInBand`
- `NODE_ENV=dev npx jest test/grpc/FullTextSearch.spec.ts --runInBand --testNamePattern="Add Function Field Operations"`
- Prettier check and `git diff --check`