### PR TITLE
feat: add the six index types missing from the IndexType enum

### DIFF
--- a/milvus/const/milvus.ts
+++ b/milvus/const/milvus.ts
@@ -167,6 +167,16 @@ export enum IndexType {
   IVF_RABITQ = 'IVF_RABITQ',
   MINHASH_LSH = 'MINHASH_LSH',
   RTREE = 'RTREE',
+  // quantized HNSW variants
+  HNSW_SQ = 'HNSW_SQ',
+  HNSW_PQ = 'HNSW_PQ',
+  HNSW_PRQ = 'HNSW_PRQ',
+  // DiskANN variant keeping PQ codes inline with the graph
+  AISAQ = 'AISAQ',
+  // scalar: n-gram index for VARCHAR / JSON path, accelerates LIKE
+  NGRAM = 'NGRAM',
+  // scalar: FM-index for VARCHAR, exact anchored LIKE with no recheck
+  FMINDEX = 'FMINDEX',
 }
 
 // MsgType


### PR DESCRIPTION
Closes #596.

The `IndexType` enum in `milvus/const/milvus.ts` had drifted behind the server.
Comparing it against the Java, C++ and Rust SDKs turned up six types Milvus accepts
that it never declared:

| | |
|---|---|
| vector | `HNSW_SQ`, `HNSW_PQ`, `HNSW_PRQ`, `AISAQ` |
| scalar | `NGRAM`, `FMINDEX` |

`FMINDEX` is new (scalar index engine version 5, milvus-io/milvus#51375), so no SDK
had it. The other five have been on the server for a while; `NGRAM` in particular
reached Java, C++ and Rust and was missed here.

Nothing was hard-blocked — `index_type` is typed as `string` in `MilvusIndex.ts`, so
a caller could always pass the literal. But these were missing from the enum users
are meant to reach for, and from autocomplete, which is the point of having it.

Two things deliberately left alone:

- The stale entries already in the enum (`ANNOY`, `GPU_FLAT`, `GPU_IVF_SQ8`,
  `RAFT_IVF_FLAT`, `RAFT_IVF_PQ`) are no longer supported server-side, but removing
  them would break anyone still referencing them.
- `SCANN_DVR`, `IVF_FLAT_CC`, `IVF_SQ_CC`, `IVF_RABITQ_FASTSCAN`, `SVS_*`,
  `SPARSE_*_CC`, `GPU_FAISS_*` and `GPU_CUVS_*` exist in knowhere but no SDK exposes
  them — they are internal or experimental.

`tsc --noEmit` is clean on the changed file.
