### PR TITLE
test: use SiliconFlow for text embeddings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,24 +41,24 @@ jobs:
 
       - name: Run target Milvus
         env:
-          MILVUS_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          MILVUS_SILICONFLOW_API_KEY: ${{ secrets.SILICONFLOW_API_KEY }}
         run: |
-          if [ -n "${MILVUS_OPENAI_API_KEY}" ]; then
-            echo "MILVUS_OPENAI_ENABLED=1" >> "$GITHUB_ENV"
+          if [ -n "${MILVUS_SILICONFLOW_API_KEY}" ]; then
+            echo "MILVUS_SILICONFLOW_ENABLED=1" >> "$GITHUB_ENV"
           else
-            echo "MILVUS_OPENAI_ENABLED=0" >> "$GITHUB_ENV"
+            echo "MILVUS_SILICONFLOW_ENABLED=0" >> "$GITHUB_ENV"
           fi
 
           wget https://raw.githubusercontent.com/milvus-io/milvus/master/deployments/docker/standalone/docker-compose.yml -O docker-compose.yml
           sed -i -e "s/milvusdb.*$/milvusdb\/milvus:${{ steps.info.outputs.milvusVersion }}/g" docker-compose.yml
 
-          # Pass the OpenAI key and enable StorageV3, which is required by Text fields.
+          # Pass the SiliconFlow key and enable StorageV3, which is required by Text fields.
           cat > docker-compose.override.yml << EOF
           services:
             standalone:
               environment:
                 MQ_TYPE: rocksmq
-                MILVUS_OPENAI_API_KEY: ${MILVUS_OPENAI_API_KEY}
+                MILVUS_SILICONFLOW_API_KEY: ${MILVUS_SILICONFLOW_API_KEY}
                 COMMON_STORAGE_USELOONFFI: "true"
                 DATACOORD_COMPACTION_BUMPSCHEMAVERSION_ENABLED: "true"
                 DATACOORD_COMPACTION_STORAGEVERSION_ENABLED: "true"

--- a/test/grpc/TextEmbedding.spec.ts
+++ b/test/grpc/TextEmbedding.spec.ts
@@ -13,14 +13,14 @@ const COLLECTION = GENERATE_NAME();
 const dbParam = {
   db_name: 'TextEmbedding',
 };
-const hasOpenAICredentials =
-  process.env.MILVUS_OPENAI_ENABLED === '1' ||
-  Boolean(process.env.MILVUS_OPENAI_API_KEY);
-const describeIfOpenAIConfigured = hasOpenAICredentials
+const hasSiliconFlowCredentials =
+  process.env.MILVUS_SILICONFLOW_ENABLED === '1' ||
+  Boolean(process.env.MILVUS_SILICONFLOW_API_KEY);
+const describeIfSiliconFlowConfigured = hasSiliconFlowCredentials
   ? describe
   : describe.skip;
 
-describeIfOpenAIConfigured(`Text Embedding Function API`, () => {
+describeIfSiliconFlowConfigured(`Text Embedding Function API`, () => {
   beforeAll(async () => {
     milvusClient = new MilvusClient({ address: IP, logLevel: 'info' });
     await milvusClient.createDatabase(dbParam);
@@ -53,20 +53,20 @@ describeIfOpenAIConfigured(`Text Embedding Function API`, () => {
         {
           name: 'dense',
           data_type: DataType.FloatVector,
-          dim: 1536,
+          dim: 1024,
           is_function_output: true,
         },
       ],
       functions: [
         {
-          name: 'openai',
-          description: 'openai text embedding function',
+          name: 'siliconflow',
+          description: 'siliconflow text embedding function',
           type: FunctionType.TEXTEMBEDDING,
           input_field_names: ['text'],
           output_field_names: ['dense'],
           params: {
-            provider: 'openai',
-            model_name: 'text-embedding-3-small',
+            provider: 'siliconflow',
+            model_name: 'BAAI/bge-large-zh-v1.5',
           },
         },
       ],
@@ -79,7 +79,7 @@ describeIfOpenAIConfigured(`Text Embedding Function API`, () => {
     const denseField = describe.schema.fields.find(f => f.name === 'dense');
     expect(denseField!.is_function_output).toEqual(true);
 
-    const func = describe.schema.functions.find(f => f.name === 'openai');
+    const func = describe.schema.functions.find(f => f.name === 'siliconflow');
     expect(func).toBeDefined();
     expect(func!.input_field_names).toEqual(['text']);
     expect(func!.output_field_names).toEqual(['dense']);
@@ -89,16 +89,16 @@ describeIfOpenAIConfigured(`Text Embedding Function API`, () => {
   it(`Alter text embedding function should success`, async () => {
     const alter = await milvusClient.alterCollectionFunction({
       collection_name: COLLECTION,
-      function_name: 'openai',
+      function_name: 'siliconflow',
       function: {
-        name: 'openai',
-        description: 'openai text embedding function altered via API',
+        name: 'siliconflow',
+        description: 'siliconflow text embedding function altered via API',
         type: FunctionType.TEXTEMBEDDING,
         input_field_names: ['text'],
         output_field_names: ['dense'],
         params: {
-          provider: 'openai',
-          model_name: 'text-embedding-3-small',
+          provider: 'siliconflow',
+          model_name: 'BAAI/bge-large-zh-v1.5',
         },
       },
     });
@@ -108,10 +108,10 @@ describeIfOpenAIConfigured(`Text Embedding Function API`, () => {
       collection_name: COLLECTION,
       cache: false,
     });
-    const func = describe.schema.functions.find(f => f.name === 'openai');
+    const func = describe.schema.functions.find(f => f.name === 'siliconflow');
     expect(func).toBeDefined();
     expect(func!.description).toEqual(
-      'openai text embedding function altered via API'
+      'siliconflow text embedding function altered via API'
     );
   });
 


### PR DESCRIPTION
## Summary

- switch the TextEmbedding E2E provider from OpenAI to SiliconFlow
- use BAAI/bge-large-zh-v1.5 and update the vector dimension to 1024
- inject MILVUS_SILICONFLOW_API_KEY from the SILICONFLOW_API_KEY Actions secret

## Repository setup

Add a repository Actions secret named SILICONFLOW_API_KEY before rerunning the workflow with the external-provider tests enabled.

## Validation

- npm run build
- npx prettier --check test/grpc/TextEmbedding.spec.ts .github/workflows/test.yml
- NODE_ENV=dev npx jest test/grpc/TextEmbedding.spec.ts --runInBand (skipped as expected without a local provider credential)
- SiliconFlow embeddings API smoke test returned a 1024-dimensional vector for BAAI/bge-large-zh-v1.5