### PR TITLE
fix: upgrade js-yaml to 3.15.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2509,9 +2509,9 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.15.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
-  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
+  version "3.15.1"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz#24bc95028f361cdaaa84745b06a109c4486773c0"
+  integrity sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
## Summary

- upgrade the transitive `js-yaml` dependency from 3.15.0 to 3.15.1
- resolve Dependabot alert #446 (GHSA-5p4m-2wfm-xmqj)
- keep `js-yaml` as a transitive development dependency

## Testing

- `yarn install --frozen-lockfile --ignore-scripts`
- `npm run build`
- `NODE_ENV=dev npx jest test/build/Collection.spec.ts --runInBand` (13 tests passed)
- verified the `!!omap` proof of concept no longer shows quadratic scaling
