### PR TITLE
docs: update guides for SDK 3.0.5 and fix documentation navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Official Node.js SDK for [Milvus](https://github.com/milvus-io/milvus) vector da
 [![downloads](https://img.shields.io/npm/dw/@zilliz/milvus2-sdk-node)](https://www.npmjs.com/package/@zilliz/milvus2-sdk-node)
 [![codecov](https://codecov.io/gh/milvus-io/milvus-sdk-node/branch/main/graph/badge.svg?token=Zu5FwWstwI)](https://codecov.io/gh/milvus-io/milvus-sdk-node)
 
+Documentation: [Guides & API reference](https://milvus-io.github.io/milvus-sdk-node/) · [3.0.5 release notes](https://milvus-io.github.io/milvus-sdk-node/reference/release-notes)
+
+The latest documented release is **3.0.5**. New features include Bloom/Roaring membership helpers, client telemetry (enabled by default), and six additional index enum values. SDK 3.0.4 also added Text fields and asynchronous function-field backfill.
+
 ## Installation
 
 ```bash
@@ -18,11 +22,12 @@ yarn add @zilliz/milvus2-sdk-node
 
 ## Compatibility
 
-| Milvus version | SDK version | Install command                             |
-| :------------: | :---------: | :------------------------------------------ |
-|    v2.6.0+     |  **latest** | `yarn add @zilliz/milvus2-sdk-node@latest`  |
-|    v2.5.0+     |   v2.5.0    | `yarn add @zilliz/milvus2-sdk-node@2.5.12`  |
-|    v2.4.0+     |   v2.4.9    | `yarn add @zilliz/milvus2-sdk-node@2.4.9`   |
+| Milvus version | SDK version | Install command                            |
+| :------------: | :---------: | :----------------------------------------- |
+|    v3.0.0+     |  **3.0.x**  | `yarn add @zilliz/milvus2-sdk-node@3`      |
+|    v2.6.0+     |  **2.6.x**  | `yarn add @zilliz/milvus2-sdk-node@2.6`    |
+|    v2.5.0+     |   v2.5.0    | `yarn add @zilliz/milvus2-sdk-node@2.5.12` |
+|    v2.4.0+     |   v2.4.9    | `yarn add @zilliz/milvus2-sdk-node@2.4.9`  |
 
 ## Quick Start
 
@@ -43,7 +48,7 @@ const client = new MilvusClient({
 
 // Zilliz Cloud
 const client = new MilvusClient({
-  address: 'your-endpoint.zillizcloud.com',
+  address: 'https://your-endpoint.zillizcloud.com',
   token: 'your-api-key',
 });
 
@@ -54,11 +59,7 @@ await client.connectPromise;
 ### Create Collection, Insert, and Search
 
 ```typescript
-import {
-  MilvusClient,
-  DataType,
-  MetricType,
-} from '@zilliz/milvus2-sdk-node';
+import { MilvusClient, DataType, MetricType } from '@zilliz/milvus2-sdk-node';
 
 const client = new MilvusClient({ address: 'localhost:19530' });
 
@@ -66,7 +67,12 @@ const client = new MilvusClient({ address: 'localhost:19530' });
 await client.createCollection({
   collection_name: 'my_collection',
   fields: [
-    { name: 'id', data_type: DataType.Int64, is_primary_key: true, autoID: true },
+    {
+      name: 'id',
+      data_type: DataType.Int64,
+      is_primary_key: true,
+      autoID: true,
+    },
     { name: 'text', data_type: DataType.VarChar, max_length: 512 },
     { name: 'vector', data_type: DataType.FloatVector, dim: 128 },
   ],
@@ -82,7 +88,7 @@ await client.createCollection({
 });
 
 // 2. Load into memory (required before search/query)
-await client.loadCollection({ collection_name: 'my_collection' });
+await client.loadCollectionSync({ collection_name: 'my_collection' });
 
 // 3. Insert data
 await client.insert({
@@ -98,6 +104,7 @@ const results = await client.search({
   collection_name: 'my_collection',
   data: [Array(128).fill(0.1)],
   limit: 10,
+  consistency_level: 'Strong', // Include the rows just inserted
   output_fields: ['text'],
 });
 console.log(results.results);
@@ -139,10 +146,11 @@ new MilvusClient({
   password?: string;            // Password for auth
   ssl?: boolean;                // Enable SSL/TLS
   database?: string;            // Default database name
-  timeout?: number | string;    // Request timeout in ms (or string like '30s')
+  timeout?: number | string;    // Request timeout in milliseconds
   maxRetries?: number;          // Max retry attempts (default: 3)
   retryDelay?: number;          // Retry delay in ms (default: 10)
   logLevel?: string;            // 'debug' | 'info' | 'warn' | 'error'
+  telemetry?: TelemetryConfig;  // Heartbeat metrics; enabled by default
   trace?: boolean;              // Enable OpenTelemetry tracing
   tls?: {                       // TLS certificate configuration
     rootCertPath?: string;
@@ -552,7 +560,12 @@ await client.createResourceGroup({ resource_group, config });
 await client.listResourceGroups();
 await client.describeResourceGroup({ resource_group });
 await client.dropResourceGroup({ resource_group });
-await client.transferReplica({ source_resource_group, target_resource_group, collection_name, num_replica });
+await client.transferReplica({
+  source_resource_group,
+  target_resource_group,
+  collection_name,
+  num_replica,
+});
 ```
 
 ---
@@ -572,9 +585,9 @@ const writer = new BulkWriter({
       { name: 'title', data_type: DataType.VarChar, max_length: 256 },
     ],
   },
-  format: 'parquet',  // 'json' or 'parquet'
+  format: 'parquet', // 'json' or 'parquet'
   localPath: './bulk_data',
-  chunkSize: 128 * 1024 * 1024,  // 128 MB per file
+  chunkSize: 128 * 1024 * 1024, // 128 MB per file
 });
 
 // Append rows
@@ -616,10 +629,10 @@ await client.getCompactionState({ compactionID });
 ### System Operations
 
 ```typescript
-await client.getVersion();                        // Milvus server version
-await client.checkHealth();                       // Server health status
-await client.reconnectToPrimary();                // Force reconnect to primary node
-await client.runAnalyzer({ text, analyzer });     // Test text analyzer tokenization
+await client.getVersion(); // Milvus server version
+await client.checkHealth(); // Server health status
+await client.reconnectToPrimary(); // Force reconnect to primary node
+await client.runAnalyzer({ text, analyzer }); // Test text analyzer tokenization
 ```
 
 ---
@@ -628,29 +641,29 @@ await client.runAnalyzer({ text, analyzer });     // Test text analyzer tokeniza
 
 ### Scalar Types
 
-| DataType enum        | TypeScript value  | Notes                                 |
-| -------------------- | ----------------- | ------------------------------------- |
-| `DataType.Bool`      | `boolean`         |                                       |
-| `DataType.Int8`      | `number`          |                                       |
-| `DataType.Int16`     | `number`          |                                       |
-| `DataType.Int32`     | `number`          |                                       |
-| `DataType.Int64`     | `number \| string` | Use string for values > 2^53         |
-| `DataType.Float`     | `number`          |                                       |
-| `DataType.Double`    | `number`          |                                       |
-| `DataType.VarChar`   | `string`          | Requires `max_length`                 |
-| `DataType.JSON`      | `object`          |                                       |
-| `DataType.Array`     | `any[]`           | Requires `element_type`, `max_capacity` |
+| DataType enum      | TypeScript value   | Notes                                   |
+| ------------------ | ------------------ | --------------------------------------- |
+| `DataType.Bool`    | `boolean`          |                                         |
+| `DataType.Int8`    | `number`           |                                         |
+| `DataType.Int16`   | `number`           |                                         |
+| `DataType.Int32`   | `number`           |                                         |
+| `DataType.Int64`   | `number \| string` | Use string for values > 2^53            |
+| `DataType.Float`   | `number`           |                                         |
+| `DataType.Double`  | `number`           |                                         |
+| `DataType.VarChar` | `string`           | Requires `max_length`                   |
+| `DataType.JSON`    | `object`           |                                         |
+| `DataType.Array`   | `any[]`            | Requires `element_type`, `max_capacity` |
 
 ### Vector Types
 
-| DataType enum                | Data format                        | Field param   |
-| ---------------------------- | ---------------------------------- | ------------- |
-| `DataType.FloatVector`       | `number[]`                         | `dim: number` |
-| `DataType.BinaryVector`      | `number[]` (uint8 bytes)           | `dim: number` |
-| `DataType.Float16Vector`     | `number[]`                         | `dim: number` |
-| `DataType.BFloat16Vector`    | `number[]`                         | `dim: number` |
-| `DataType.Int8Vector`        | `number[]`                         | `dim: number` |
-| `DataType.SparseFloatVector` | `Record<number, number>` or array  | no dim needed |
+| DataType enum                | Data format                       | Field param   |
+| ---------------------------- | --------------------------------- | ------------- |
+| `DataType.FloatVector`       | `number[]`                        | `dim: number` |
+| `DataType.BinaryVector`      | `number[]` (uint8 bytes)          | `dim: number` |
+| `DataType.Float16Vector`     | `number[]`                        | `dim: number` |
+| `DataType.BFloat16Vector`    | `number[]`                        | `dim: number` |
+| `DataType.Int8Vector`        | `number[]`                        | `dim: number` |
+| `DataType.SparseFloatVector` | `Record<number, number>` or array | no dim needed |
 
 ### Field Definition
 
@@ -660,13 +673,13 @@ interface FieldType {
   data_type: DataType;
   is_primary_key?: boolean;
   autoID?: boolean;
-  dim?: number;                    // Required for vector types
-  max_length?: number;             // Required for VarChar
-  element_type?: DataType;         // Required for Array
-  max_capacity?: number;           // Required for Array
+  dim?: number; // Required for vector types
+  max_length?: number; // Required for VarChar
+  element_type?: DataType; // Required for Array
+  max_capacity?: number; // Required for Array
   default_value?: any;
   is_partition_key?: boolean;
-  enable_analyzer?: boolean;       // For full-text search
+  enable_analyzer?: boolean; // For full-text search
   analyzer_params?: object;
 }
 ```
@@ -678,47 +691,47 @@ interface FieldType {
 ### MetricType
 
 ```typescript
-MetricType.L2          // Euclidean distance (smaller = more similar)
-MetricType.IP          // Inner product (larger = more similar)
-MetricType.COSINE      // Cosine similarity (larger = more similar)
-MetricType.HAMMING     // Hamming distance (binary vectors)
-MetricType.JACCARD     // Jaccard distance (binary vectors)
-MetricType.BM25        // BM25 relevance (sparse/text)
+MetricType.L2; // Euclidean distance (smaller = more similar)
+MetricType.IP; // Inner product (larger = more similar)
+MetricType.COSINE; // Cosine similarity (larger = more similar)
+MetricType.HAMMING; // Hamming distance (binary vectors)
+MetricType.JACCARD; // Jaccard distance (binary vectors)
+MetricType.BM25; // BM25 relevance (sparse/text)
 ```
 
 ### IndexType
 
 ```typescript
-IndexType.AUTOINDEX    // Automatic selection (recommended)
-IndexType.HNSW         // High recall, in-memory
-IndexType.IVF_FLAT     // Balanced speed/recall
-IndexType.IVF_SQ8      // Compressed IVF
-IndexType.IVF_PQ       // High compression IVF
-IndexType.FLAT         // Brute-force (exact)
-IndexType.DISKANN      // On-disk index
-IndexType.BIN_FLAT     // Binary brute-force
-IndexType.BIN_IVF_FLAT // Binary IVF
-IndexType.SPARSE_INVERTED_INDEX  // Sparse vectors
-IndexType.SPARSE_WAND           // Sparse vectors (WAND)
+IndexType.AUTOINDEX; // Automatic selection (recommended)
+IndexType.HNSW; // High recall, in-memory
+IndexType.IVF_FLAT; // Balanced speed/recall
+IndexType.IVF_SQ8; // Compressed IVF
+IndexType.IVF_PQ; // High compression IVF
+IndexType.FLAT; // Brute-force (exact)
+IndexType.DISKANN; // On-disk index
+IndexType.BIN_FLAT; // Binary brute-force
+IndexType.BIN_IVF_FLAT; // Binary IVF
+IndexType.SPARSE_INVERTED_INDEX; // Sparse vectors
+IndexType.SPARSE_WAND; // Sparse vectors (WAND)
 ```
 
 ### ConsistencyLevelEnum
 
 ```typescript
-ConsistencyLevelEnum.Strong      // Read-after-write guarantee
-ConsistencyLevelEnum.Session     // Session-level consistency
-ConsistencyLevelEnum.Bounded     // Bounded staleness
-ConsistencyLevelEnum.Eventually  // Best performance
+ConsistencyLevelEnum.Strong; // Read-after-write guarantee
+ConsistencyLevelEnum.Session; // Session-level consistency
+ConsistencyLevelEnum.Bounded; // Bounded staleness
+ConsistencyLevelEnum.Eventually; // Best performance
 ```
 
 ### ErrorCode
 
 ```typescript
-ErrorCode.SUCCESS             // Operation succeeded
-ErrorCode.UnexpectedError     // Internal error
-ErrorCode.CollectionNotExists // Collection not found
-ErrorCode.IllegalArgument     // Invalid argument
-ErrorCode.RateLimit           // Rate limited
+ErrorCode.SUCCESS; // Operation succeeded
+ErrorCode.UnexpectedError; // Internal error
+ErrorCode.CollectionNotExists; // Collection not found
+ErrorCode.IllegalArgument; // Invalid argument
+ErrorCode.RateLimit; // Rate limited
 ```
 
 ---
@@ -859,7 +872,12 @@ await client.query({
 await client.createCollection({
   collection_name: 'docs',
   fields: [
-    { name: 'id', data_type: DataType.Int64, is_primary_key: true, autoID: true },
+    {
+      name: 'id',
+      data_type: DataType.Int64,
+      is_primary_key: true,
+      autoID: true,
+    },
     { name: 'sparse_vector', data_type: DataType.SparseFloatVector },
   ],
 });
@@ -867,7 +885,7 @@ await client.createCollection({
 await client.insert({
   collection_name: 'docs',
   data: [
-    { sparse_vector: { 0: 0.5, 10: 0.3, 200: 0.8 } },   // dict format
+    { sparse_vector: { 0: 0.5, 10: 0.3, 200: 0.8 } }, // dict format
     { sparse_vector: { 1: 0.1, 50: 0.9 } },
   ],
 });
@@ -886,8 +904,18 @@ await client.search({
 await client.createCollection({
   collection_name: 'multi_tenant',
   fields: [
-    { name: 'id', data_type: DataType.Int64, is_primary_key: true, autoID: true },
-    { name: 'tenant', data_type: DataType.VarChar, max_length: 64, is_partition_key: true },
+    {
+      name: 'id',
+      data_type: DataType.Int64,
+      is_primary_key: true,
+      autoID: true,
+    },
+    {
+      name: 'tenant',
+      data_type: DataType.VarChar,
+      max_length: 64,
+      is_partition_key: true,
+    },
     { name: 'vector', data_type: DataType.FloatVector, dim: 128 },
   ],
   num_partitions: 16,
@@ -897,7 +925,7 @@ await client.createCollection({
 await client.search({
   collection_name: 'multi_tenant',
   data: [queryVector],
-  filter: 'tenant == "user_123"',   // Scoped to partition
+  filter: 'tenant == "user_123"', // Scoped to partition
   limit: 10,
 });
 ```

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -126,6 +126,11 @@ export default defineConfig({
               slug: 'advanced/full-text-search',
               label: 'Full-Text Search',
             },
+            {
+              slug: 'advanced/membership-filters',
+              label: 'Membership Filters',
+            },
+            { slug: 'advanced/client-telemetry', label: 'Client Telemetry' },
             { slug: 'advanced/global-cluster', label: 'Global Cluster' },
             { slug: 'advanced/cloudflare', label: 'Cloudflare Workers' },
             { slug: 'advanced/vercel', label: 'Vercel' },
@@ -174,6 +179,7 @@ export default defineConfig({
           label: 'Resources',
           collapsed: false,
           items: [
+            { slug: 'reference/release-notes', label: 'Release Notes' },
             { slug: 'reference/troubleshooting', label: 'Troubleshooting' },
             {
               slug: 'reference/migration-compatibility',

--- a/docs/src/content/docs/advanced/advanced-features.mdx
+++ b/docs/src/content/docs/advanced/advanced-features.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Advanced Features"
+title: 'Advanced Features'
 ---
 
 This guide covers advanced features including connection pooling, retry mechanisms, error handling, logging, and iterator patterns.
@@ -14,8 +14,8 @@ The SDK uses connection pooling to manage gRPC connections efficiently.
 const client = new MilvusClient({
   address: 'localhost:19530',
   pool: {
-    min: 2,              // Minimum pool size
-    max: 10,             // Maximum pool size
+    min: 2, // Minimum pool size
+    max: 10, // Maximum pool size
     idleTimeoutMillis: 30000, // Idle timeout
   },
 });
@@ -36,14 +36,15 @@ Configure automatic retries for failed operations.
 ```javascript
 const client = new MilvusClient({
   address: 'localhost:19530',
-  maxRetries: 3,        // Maximum retry attempts
-  retryDelay: 1000,     // Delay between retries (ms)
+  maxRetries: 3, // Maximum retry attempts
+  retryDelay: 1000, // Delay between retries (ms)
 });
 ```
 
 ### Retry Behavior
 
 The SDK automatically retries on:
+
 - Network errors
 - Transient server errors
 - Timeout errors
@@ -56,7 +57,9 @@ The SDK automatically retries on:
 import { ErrorCode } from '@zilliz/milvus2-sdk-node';
 
 try {
-  await client.createCollection({ /* ... */ });
+  await client.createCollection({
+    /* ... */
+  });
 } catch (error) {
   switch (error.error_code) {
     case ErrorCode.CollectionNotExists:
@@ -178,9 +181,7 @@ All API methods that extend `GrpcTimeOut` support trace IDs:
 // Insert with trace ID
 await client.insert({
   collection_name: 'my_collection',
-  data: [
-    { id: 1, vector: [0.1, 0.2, 0.3] },
-  ],
+  data: [{ id: 1, vector: [0.1, 0.2, 0.3] }],
   client_request_id: 'insert-trace-123',
 });
 
@@ -240,7 +241,7 @@ const iterator = await client.queryIterator({
 while (true) {
   const batch = await iterator.next();
   if (batch.done) break;
-  
+
   console.log('Batch:', batch.value);
 }
 ```
@@ -260,7 +261,7 @@ const iterator = await client.searchIterator({
 while (true) {
   const batch = await iterator.next();
   if (batch.done) break;
-  
+
   console.log('Batch:', batch.value);
 }
 ```
@@ -274,7 +275,7 @@ Work with sparse vector data:
 const sparseVector = [1.0, undefined, undefined, 2.5, undefined];
 
 // Dictionary format
-const sparseVector = { '0': 1.0, '3': 2.5 };
+const sparseVector = { 0: 1.0, 3: 2.5 };
 
 // CSR format
 const sparseVector = {
@@ -365,9 +366,11 @@ await client.insert({
   collection_name: 'my_collection',
   data: [
     {
-      vector: [/* ... */],
+      vector: [
+        /* ... */
+      ],
       dynamic_field_1: 'value1', // Automatically added
-      dynamic_field_2: 123,      // Automatically added
+      dynamic_field_2: 123, // Automatically added
     },
   ],
 });
@@ -416,4 +419,4 @@ console.log('Replicas:', replicas.replicas);
 
 - Learn about [Best Practices](./best-practices)
 - Explore [HTTP Client](./http-client)
-- Check out [Examples & Tutorials](./examples-tutorials)
+- Check out [Examples & Tutorials](/milvus-sdk-node/getting-started/examples-tutorials)

--- a/docs/src/content/docs/advanced/client-telemetry.mdx
+++ b/docs/src/content/docs/advanced/client-telemetry.mdx
@@ -1,0 +1,57 @@
+---
+title: 'Client Telemetry'
+---
+
+SDK 3.0.5 adds client telemetry to `MilvusClient` (gRPC). It sends operation metrics to the connected Milvus deployment through `ClientHeartbeat`. This is separate from OpenTelemetry tracing configured with `trace`.
+
+## Configuration and defaults
+
+```typescript
+import { MilvusClient } from '@zilliz/milvus2-sdk-node';
+
+const client = new MilvusClient({
+  address: 'localhost:19530',
+  telemetry: {
+    enabled: true,
+    heartbeatIntervalMs: 10_000,
+    samplingRate: 1,
+    errorMaxCount: 100,
+    // clientId: 'recommendation-worker-1',
+  },
+});
+await client.connectPromise;
+console.log(client.getTelemetry().getConfig());
+// Call during application shutdown to stop telemetry and close channels.
+await client.closeConnection();
+```
+
+| Option                | Default        | Meaning                                                                              |
+| --------------------- | -------------- | ------------------------------------------------------------------------------------ |
+| `enabled`             | `true`         | Enable metric collection and start heartbeats                                        |
+| `heartbeatIntervalMs` | `10000`        | Positive finite heartbeat interval, in milliseconds                                  |
+| `samplingRate`        | `1`            | Fraction of logical operations sampled; finite numbers are clamped to 0–1            |
+| `errorMaxCount`       | `100`          | Positive integer cap on retained errors                                              |
+| `clientId`            | Generated UUID | Optional stable identity across process restarts; use a distinct identity per client |
+
+Disable telemetry at construction if you do not want it to start:
+
+```typescript
+const client = new MilvusClient({
+  address: 'localhost:19530',
+  telemetry: { enabled: false },
+});
+```
+
+## Collected information
+
+Telemetry records request, success and error counts, plus average, p99 and maximum latency for supported data operations. High-level operations include their retries in a single logical operation; iterator setup and batches are excluded. Sampling reduces recorded operations rather than extrapolating counts to all requests.
+
+Heartbeats include SDK version, client identity, hostname, user and database context. The server can request collection metrics, recent errors and latency history, inspect configuration, and push changes to enabled state, heartbeat interval or sampling rate. Error details can include operation, collection, request ID and error text.
+
+Server-pushed disabling of collection keeps the heartbeat control channel active, so it differs from `enabled: false` at construction. Metrics arrive in windows and are not an instantaneous view of requests.
+
+## Inspection and server compatibility
+
+`client.getTelemetry()` returns the public `ClientTelemetryManager`. Use `getConfig()` for effective settings and `getMetricsSnapshots()` for retained snapshots. Advanced integrations can register a command handler with `registerCommandHandler(type, handler)`; handlers return a `CommandReply` or a promise of one.
+
+Servers without `ClientHeartbeat` return `UNIMPLEMENTED`. The SDK backs off retries, up to 30 minutes, without blocking ordinary data operations. Transport failures also use heartbeat backoff. Call `closeConnection()` during shutdown to stop timers and release channels.

--- a/docs/src/content/docs/advanced/http-client.mdx
+++ b/docs/src/content/docs/advanced/http-client.mdx
@@ -494,6 +494,6 @@ try {
 
 ## Next Steps
 
-- Learn about [MilvusClient](./getting-started) (gRPC client)
+- Learn about [MilvusClient](/milvus-sdk-node/getting-started/getting-started) (gRPC client)
 - Explore [Best Practices](./best-practices)
-- Check out [Examples & Tutorials](./examples-tutorials)
+- Check out [Examples & Tutorials](/milvus-sdk-node/getting-started/examples-tutorials)

--- a/docs/src/content/docs/advanced/membership-filters.mdx
+++ b/docs/src/content/docs/advanced/membership-filters.mdx
@@ -1,0 +1,86 @@
+---
+title: 'Bloom and Roaring Membership Filters'
+---
+
+SDK 3.0.5 exports helpers that encode large membership sets as binary filter parameters for the gRPC client. Your Milvus deployment must support `bloom_match` or `roaring_match`; upgrading the SDK alone does not add these server expressions.
+
+## Choose a filter
+
+| Helper                            | Members                                              | Semantics                                            |
+| --------------------------------- | ---------------------------------------------------- | ---------------------------------------------------- |
+| `buildBloomFilter(members, fpr?)` | All integers (`number`/`bigint`) or all strings      | Approximate membership; false positives are possible |
+| `buildRoaringBitmap(members)`     | Signed integers (`number`/`bigint`/decimal `string`) | Exact membership; duplicates collapse                |
+
+Both return `Uint8Array`. Build once and reuse the blob in `exprValues` for query or search. Pass the bytes directly, without JSON stringification or base64 encoding. Empty sets match nothing.
+
+## Exact integer membership
+
+Assume `documents` is loaded and contains an integer `user_id` field:
+
+```typescript
+import { buildRoaringBitmap } from '@zilliz/milvus2-sdk-node';
+
+const ids = buildRoaringBitmap([1, 2, '9223372036854775807']);
+const result = await client.query({
+  collection_name: 'documents',
+  filter: 'roaring_match(user_id, {ids})',
+  exprValues: { ids },
+  output_fields: ['user_id'],
+  limit: 100,
+});
+console.log(result.data);
+```
+
+Numbers must be safe integers. Use `bigint` or decimal strings for larger signed int64 values. Roaring does not support VarChar membership: `'123'` here means integer 123. The builder validates signed int64 range and serialized/decoded size limits; compactness depends on the distribution of IDs.
+
+## Approximate integer or string membership
+
+```typescript
+import { buildBloomFilter } from '@zilliz/milvus2-sdk-node';
+
+const members = buildBloomFilter(['alice', 'bob'], 0.005);
+const result = await client.query({
+  collection_name: 'documents',
+  filter: 'bloom_match(owner, {members})',
+  exprValues: { members },
+  output_fields: ['owner'],
+  limit: 100,
+});
+```
+
+The target `owner` field must be VarChar for this string blob. Integer fields require integer members. Use `BigInt('9223372036854775807')` for large Bloom integer members: decimal strings are hashed as UTF-8, not parsed as integers. Mixing strings and integers in `buildBloomFilter` is rejected.
+
+The default false-positive rate is `0.005`; accepted values are `0.0001` through `0.05`. A lower rate generally needs a larger blob. Bloom membership is suitable for candidate filtering; verify candidates against the original set when exact inclusion matters. Do not use approximate membership as an authorization check or negate it for exact exclusion.
+
+## Estimate Bloom payload size
+
+`estimateBloomFilterSize(n, fpr)` returns the serialized byte length, including the envelope, without building the filter. Both arguments are required. Compare the estimate with your deployment's Bloom-filter and overall request limits before allocating a large set.
+
+```typescript
+import {
+  estimateBloomFilterSize,
+  BLOOM_FILTER_DEFAULT_FPR,
+} from '@zilliz/milvus2-sdk-node';
+
+console.log(estimateBloomFilterSize(100_000, BLOOM_FILTER_DEFAULT_FPR));
+```
+
+The package also exports `BLOOM_FILTER_MIN_FPR` and `BLOOM_FILTER_MAX_FPR` for input validation.
+
+## Incremental builders
+
+`BloomFilterBuilder` accepts an expected member count and optional false-positive rate. Add members with `addInt64()` or `addString()`, then call `build()`. Its returned bytes share the builder's buffer; copy them before adding more members if you need an immutable snapshot.
+
+`RoaringBitmapBuilder` accepts `add()` and `addMany()` before `build()`. It retains the members for sorting and deduplication, so incremental input still requires memory proportional to the membership set.
+
+```typescript
+import {
+  BloomFilterBuilder,
+  RoaringBitmapBuilder,
+} from '@zilliz/milvus2-sdk-node';
+
+const bloom = new BloomFilterBuilder(2).addInt64(1).addInt64(2).build();
+const roaring = new RoaringBitmapBuilder().addMany([1, 2]).build();
+```
+
+See [Query & Search](/milvus-sdk-node/operations/data-operations-query) for combining these predicates with other filters.

--- a/docs/src/content/docs/api-reference/client.mdx
+++ b/docs/src/content/docs/api-reference/client.mdx
@@ -71,6 +71,7 @@ interface ClientConfig {
   };
   pool?: Options;
   loaderOptions?: LoaderOption;
+  telemetry?: TelemetryConfig;
   trace?: boolean;
   isGlobal?: boolean;
 }
@@ -266,3 +267,7 @@ const client = new MilvusClient({
 - [API Reference overview](/milvus-sdk-node/api-reference)
 - [Collection Operations](/milvus-sdk-node/api-reference/collections)
 - [Client Configuration](/milvus-sdk-node/core-concepts/client-configuration)
+
+## Client telemetry (SDK 3.0.5)
+
+`telemetry` configures heartbeat reporting and is enabled by default. See [Client Telemetry](/milvus-sdk-node/advanced/client-telemetry) for defaults, collected information, disabling, and `getTelemetry()` inspection. `TelemetryConfig` is exported from the package root.

--- a/docs/src/content/docs/api-reference/collections.mdx
+++ b/docs/src/content/docs/api-reference/collections.mdx
@@ -447,7 +447,6 @@ alterCollectionSchema(
 - `collection_name`: Collection name.
 - `field`: Function output field schema.
 - `function`: Function schema.
-- `do_physical_backfill?`: Backfill existing rows.
 - `index_name?`: Name of the bound index.
 - `extra_params?`: Bound index parameters.
 - `db_name?`: Database name.
@@ -714,3 +713,24 @@ unpinSnapshotData(data: UnpinSnapshotDataReq): Promise<ResStatus>
 - [API Reference overview](/milvus-sdk-node/api-reference)
 - [Collection Management guide](/milvus-sdk-node/management/collection-management)
 - [Data Operations](/milvus-sdk-node/api-reference/data)
+
+## Function-field backfill
+
+In SDK 3.0.4+, `addFunctionField()` returns after the schema change is accepted. Milvus asynchronously backfills existing sealed segments through schema-bump compaction. The wrapper supports BM25 → SparseFloatVector and MINHASH → BinaryVector; provide an explicit bound `index_type` other than `AUTOINDEX`.
+
+`do_physical_backfill` is not an `addFunctionField` / `alterCollectionSchema` option. It remains a separate external-collection creation option.
+
+```typescript
+const stats = await client.getCollectionStatistics({
+  collection_name: 'documents',
+});
+if (stats.status.error_code !== ErrorCode.SUCCESS) {
+  throw new Error(stats.status.reason);
+}
+console.log({
+  consistent: stats.data.schema_version_consistent_segments,
+  total: stats.data.schema_version_total_segments,
+});
+```
+
+For an existing collection with sealed segments, poll these values with a timeout until `total > 0` and `consistent === total` after numeric conversion. Missing counters do not prove completion. Also check `getIndexState({ collection_name, index_name })` reaches `Finished` (stop on `Failed`) before loading and searching the new field. Empty collections need no historical backfill.

--- a/docs/src/content/docs/api-reference/types-and-enums.mdx
+++ b/docs/src/content/docs/api-reference/types-and-enums.mdx
@@ -83,6 +83,7 @@ enum DataType {
   Array = 22,
   JSON = 23,
   Geometry = 24,
+  Text = 25,
   Timestamptz = 26,
   BinaryVector = 100,
   FloatVector = 101,
@@ -367,6 +368,12 @@ enum IndexType {
   BITMAP = 'BITMAP',
   MINHASH_LSH = 'MINHASH_LSH',
   RTREE = 'RTREE',
+  HNSW_SQ = 'HNSW_SQ',
+  HNSW_PQ = 'HNSW_PQ',
+  HNSW_PRQ = 'HNSW_PRQ',
+  AISAQ = 'AISAQ',
+  NGRAM = 'NGRAM',
+  FMINDEX = 'FMINDEX',
 }
 ```
 
@@ -447,3 +454,7 @@ See [User & Role Operations](/milvus-sdk-node/api-reference/users-roles) for RBA
 - [API Reference overview](/milvus-sdk-node/api-reference)
 - [Data Types & Schemas guide](/milvus-sdk-node/core-concepts/data-types-schemas)
 - [Data Operations](/milvus-sdk-node/api-reference/data)
+
+## Membership-filter utilities (SDK 3.0.5)
+
+Package-root exports include `buildBloomFilter`, `BloomFilterBuilder`, `estimateBloomFilterSize`, the three `BLOOM_FILTER_*_FPR` constants, `buildRoaringBitmap`, `RoaringBitmapBuilder`, and the `RoaringBitmapMember` type. See [Membership Filters](../advanced/membership-filters) for signatures, binary `exprValues` examples, integer precision rules and approximate versus exact matching.

--- a/docs/src/content/docs/core-concepts/client-configuration.mdx
+++ b/docs/src/content/docs/core-concepts/client-configuration.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Client Configuration"
+title: 'Client Configuration'
 ---
 
 The Milvus client can be configured with various options to suit your needs. This guide covers all available configuration options.
@@ -40,7 +40,7 @@ const client = new MilvusClient({
 
 ```javascript
 const client = new MilvusClient({
-  address: 'your-endpoint.zillizcloud.com:443',
+  address: 'https://your-endpoint.zillizcloud.com:443',
   token: 'your-api-key', // Can be 'username:password' or API key
 });
 ```
@@ -223,7 +223,7 @@ For Zilliz Cloud, use the endpoint and API key:
 
 ```javascript
 const client = new MilvusClient({
-  address: 'your-endpoint.zillizcloud.com:443',
+  address: 'https://your-endpoint.zillizcloud.com:443',
   token: 'your-api-key',
   ssl: true,
 });
@@ -301,6 +301,7 @@ interface ClientConfig {
   };
   pool?: Options;
   loaderOptions?: LoaderOption;
+  telemetry?: TelemetryConfig;
   trace?: boolean;
 }
 ```
@@ -337,5 +338,9 @@ For more details, see [Request Tracing](../advanced/advanced-features#request-tr
 ## Next Steps
 
 - Learn about [Data Types & Schemas](./data-types-schemas)
-- Explore [Collection Management](./collection-management)
-- Check out [Best Practices](./best-practices) for production configurations
+- Explore [Collection Management](/milvus-sdk-node/management/collection-management)
+- Check out [Best Practices](/milvus-sdk-node/advanced/best-practices) for production configurations
+
+## Client telemetry (SDK 3.0.5)
+
+`telemetry` configures heartbeat reporting and is enabled by default. See [Client Telemetry](/milvus-sdk-node/advanced/client-telemetry) for defaults, collected information, disabling, and `getTelemetry()` inspection. `TelemetryConfig` is exported from the package root.

--- a/docs/src/content/docs/core-concepts/data-types-schemas.mdx
+++ b/docs/src/content/docs/core-concepts/data-types-schemas.mdx
@@ -524,6 +524,23 @@ The SDK validates schemas before creating collections. Common validation errors:
 
 ## Next Steps
 
-- Learn about [Collection Management](./collection-management)
-- Explore [Data Operations](./data-operations-insert)
-- Check out [Best Practices](./best-practices)
+- Learn about [Collection Management](/milvus-sdk-node/management/collection-management)
+- Explore [Data Operations](/milvus-sdk-node/operations/data-operations-insert)
+- Check out [Best Practices](/milvus-sdk-node/advanced/best-practices)
+
+## Text
+
+SDK 3.0.4 adds `DataType.Text` (25) for variable-length text without a `max_length` setting. It requires a Milvus deployment using **StorageV3**. Use VarChar for primary/partition keys and array string elements; Text cannot be used for these roles. Do not set `max_length` on Text fields.
+
+```typescript
+const contentField = {
+  name: 'content',
+  data_type: DataType.Text,
+  nullable: true,
+  enable_analyzer: true,
+  enable_match: true,
+  analyzer_params: { tokenizer: 'standard' },
+};
+```
+
+Add this field alongside a primary key and vector field in `createCollection({ fields })`. Insert and upsert ordinary JavaScript strings (or `null` for nullable fields), and include `content` in `output_fields` to retrieve it. Text supports analyzer-based matching and BM25 input. Request and server resource limits still apply even though the schema has no VarChar length limit.

--- a/docs/src/content/docs/getting-started/getting-started.mdx
+++ b/docs/src/content/docs/getting-started/getting-started.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Getting Started"
+title: 'Getting Started'
 ---
 
 This guide will help you get started with the Milvus Node.js SDK. You'll learn how to install the SDK, connect to Milvus, and perform basic operations.
@@ -51,7 +51,7 @@ For Zilliz Cloud, you can use a token:
 
 ```javascript
 const client = new MilvusClient({
-  address: 'your-endpoint.zillizcloud.com:443',
+  address: 'https://your-endpoint.zillizcloud.com:443',
   token: 'your-api-key',
 });
 
@@ -178,7 +178,7 @@ try {
 
 ## Next Steps
 
-- Learn about [Client Configuration](./client-configuration)
-- Understand [Data Types & Schemas](./data-types-schemas)
-- Explore [Collection Management](./collection-management)
+- Learn about [Client Configuration](/milvus-sdk-node/core-concepts/client-configuration)
+- Understand [Data Types & Schemas](/milvus-sdk-node/core-concepts/data-types-schemas)
+- Explore [Collection Management](/milvus-sdk-node/management/collection-management)
 - Check out [Examples & Tutorials](./examples-tutorials)

--- a/docs/src/content/docs/http-client.mdx
+++ b/docs/src/content/docs/http-client.mdx
@@ -494,6 +494,6 @@ try {
 
 ## Next Steps
 
-- Learn about [MilvusClient](./getting-started) (gRPC client)
-- Explore [Best Practices](./best-practices)
-- Check out [Examples & Tutorials](./examples-tutorials)
+- Learn about [MilvusClient](/milvus-sdk-node/getting-started/getting-started) (gRPC client)
+- Explore [Best Practices](/milvus-sdk-node/advanced/best-practices)
+- Check out [Examples & Tutorials](/milvus-sdk-node/getting-started/examples-tutorials)

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -7,10 +7,17 @@ import { Card, CardGrid, LinkButton } from '@astrojs/starlight/components';
 Build fast vector search applications in TypeScript with the official Milvus Node.js SDK. Connect to Milvus or Zilliz Cloud, manage schemas and indexes, and ship search workflows from one typed client.
 
 <div className="hero-actions not-content">
-  <LinkButton href="./getting-started/getting-started" icon="right-arrow">
+  <LinkButton
+    href="/milvus-sdk-node/getting-started/getting-started"
+    icon="right-arrow"
+  >
     Get started
   </LinkButton>
-  <LinkButton href="./api-reference" variant="secondary" icon="document">
+  <LinkButton
+    href="/milvus-sdk-node/api-reference"
+    variant="secondary"
+    icon="document"
+  >
     API reference
   </LinkButton>
 </div>
@@ -25,6 +32,10 @@ Build fast vector search applications in TypeScript with the official Milvus Nod
     serverless-friendly HTTP integrations.
   </Card>
 </CardGrid>
+
+## Latest documented release
+
+SDK **3.0.5** adds membership-filter builders, client telemetry and six index enum values. See [Release Notes](/milvus-sdk-node/reference/release-notes) for examples and the 3.0.4 additions.
 
 ## What is Milvus?
 
@@ -69,7 +80,7 @@ Features that require a Milvus 3.0 server are marked with the `Milvus 3.0` tag t
 - Element-level result metadata: read `offset` values from query/search results and `group_by_field_values` from grouped search results.
 - Schema and function management: add fields/functions and manage collection functions from the SDK.
 
-See [Migration & Compatibility](./reference/migration-compatibility) for the detailed coverage matrix, including Milvus 3.0 proto additions that are not exposed as public SDK methods.
+See [Migration & Compatibility](/milvus-sdk-node/reference/migration-compatibility) for the detailed coverage matrix, including Milvus 3.0 proto additions that are not exposed as public SDK methods.
 
 ## Prerequisites
 
@@ -95,52 +106,52 @@ console.log('Connected to Milvus!');
 
 ### Getting Started
 
-- **[Getting Started](./getting-started/getting-started)**: Installation and basic usage
-- **[Examples & Tutorials](./getting-started/examples-tutorials)**: Code examples and tutorials
+- **[Getting Started](/milvus-sdk-node/getting-started/getting-started)**: Installation and basic usage
+- **[Examples & Tutorials](/milvus-sdk-node/getting-started/examples-tutorials)**: Code examples and tutorials
 
 ### Core Concepts
 
-- **[Client Configuration](./core-concepts/client-configuration)**: Connection and configuration options
-- **[Data Types & Schemas](./core-concepts/data-types-schemas)**: Understanding data types and schema definition
+- **[Client Configuration](/milvus-sdk-node/core-concepts/client-configuration)**: Connection and configuration options
+- **[Data Types & Schemas](/milvus-sdk-node/core-concepts/data-types-schemas)**: Understanding data types and schema definition
 
 ### Data Operations
 
-- **[Database Operations](./operations/database-operations)**: Database-level operations
-- **[Insert & Update](./operations/data-operations-insert)**: Inserting and updating data
-- **[Query & Search](./operations/data-operations-query)**: Querying and searching vectors
-- **[Delete](./operations/data-operations-delete)**: Deleting data
-- **[Data Management](./operations/data-management)**: Data management operations
+- **[Database Operations](/milvus-sdk-node/operations/database-operations)**: Database-level operations
+- **[Insert & Update](/milvus-sdk-node/operations/data-operations-insert)**: Inserting and updating data
+- **[Query & Search](/milvus-sdk-node/operations/data-operations-query)**: Querying and searching vectors
+- **[Delete](/milvus-sdk-node/operations/data-operations-delete)**: Deleting data
+- **[Data Management](/milvus-sdk-node/operations/data-management)**: Data management operations
 
 ### Management
 
-- **[Collection Management](./management/collection-management)**: Creating and managing collections
-- **[Partition Management](./management/partition-management)**: Managing partitions
-- **[Index Management](./management/index-management)**: Creating and managing indexes
-- **[User & Role Management](./management/user-role-management)**: Managing users and roles
-- **[Resource Management](./management/resource-management)**: Resource management
+- **[Collection Management](/milvus-sdk-node/management/collection-management)**: Creating and managing collections
+- **[Partition Management](/milvus-sdk-node/management/partition-management)**: Managing partitions
+- **[Index Management](/milvus-sdk-node/management/index-management)**: Creating and managing indexes
+- **[User & Role Management](/milvus-sdk-node/management/user-role-management)**: Managing users and roles
+- **[Resource Management](/milvus-sdk-node/management/resource-management)**: Resource management
 
 ### Advanced
 
-- **[Advanced Features](./advanced/advanced-features)**: Connection pooling, retries, and more
-- **[HTTP Client](./advanced/http-client)**: Using HTTP client for serverless environments
-- **[Best Practices](./advanced/best-practices)**: Production-ready patterns and optimizations
+- **[Advanced Features](/milvus-sdk-node/advanced/advanced-features)**: Connection pooling, retries, and more
+- **[HTTP Client](/milvus-sdk-node/advanced/http-client)**: Using HTTP client for serverless environments
+- **[Best Practices](/milvus-sdk-node/advanced/best-practices)**: Production-ready patterns and optimizations
 
 ### API Reference
 
-- **[API Reference](./api-reference)**: Complete method signatures, request types, response types, and enums
+- **[API Reference](/milvus-sdk-node/api-reference)**: Complete method signatures, request types, response types, and enums
 
 ### Resources
 
-- **[Troubleshooting](./reference/troubleshooting)**: Common issues and solutions
-- **[Migration & Compatibility](./reference/migration-compatibility)**: Version migration guides
-- **[Contributing](./reference/contributing)**: How to contribute to the SDK
-- **[Additional Resources](./reference/additional-resources)**: Additional learning resources
+- **[Troubleshooting](/milvus-sdk-node/reference/troubleshooting)**: Common issues and solutions
+- **[Migration & Compatibility](/milvus-sdk-node/reference/migration-compatibility)**: Version migration guides
+- **[Contributing](/milvus-sdk-node/reference/contributing)**: How to contribute to the SDK
+- **[Additional Resources](/milvus-sdk-node/reference/additional-resources)**: Additional learning resources
 
 ## Next Steps
 
-- Read the [Getting Started Guide](./getting-started/getting-started)
-- Explore [Examples & Tutorials](./getting-started/examples-tutorials)
-- Check out the [API Reference](./api-reference)
+- Read the [Getting Started Guide](/milvus-sdk-node/getting-started/getting-started)
+- Explore [Examples & Tutorials](/milvus-sdk-node/getting-started/examples-tutorials)
+- Check out the [API Reference](/milvus-sdk-node/api-reference)
 
 ## Resources
 

--- a/docs/src/content/docs/management/collection-management.mdx
+++ b/docs/src/content/docs/management/collection-management.mdx
@@ -817,4 +817,25 @@ await client.refreshLoad({
 
 - Learn about [Partition Management](./partition-management)
 - Explore [Index Management](./index-management)
-- Check out [Data Operations](./data-operations-insert)
+- Check out [Data Operations](/milvus-sdk-node/operations/data-operations-insert)
+
+## Function-field backfill
+
+In SDK 3.0.4+, `addFunctionField()` returns after the schema change is accepted. Milvus asynchronously backfills existing sealed segments through schema-bump compaction. The wrapper supports BM25 → SparseFloatVector and MINHASH → BinaryVector; provide an explicit bound `index_type` other than `AUTOINDEX`.
+
+`do_physical_backfill` is not an `addFunctionField` / `alterCollectionSchema` option. It remains a separate external-collection creation option.
+
+```typescript
+const stats = await client.getCollectionStatistics({
+  collection_name: 'documents',
+});
+if (stats.status.error_code !== ErrorCode.SUCCESS) {
+  throw new Error(stats.status.reason);
+}
+console.log({
+  consistent: stats.data.schema_version_consistent_segments,
+  total: stats.data.schema_version_total_segments,
+});
+```
+
+For an existing collection with sealed segments, poll these values with a timeout until `total > 0` and `consistent === total` after numeric conversion. Missing counters do not prove completion. Also check `getIndexState({ collection_name, index_name })` reaches `Finished` (stop on `Failed`) before loading and searching the new field. Empty collections need no historical backfill.

--- a/docs/src/content/docs/management/index-management.mdx
+++ b/docs/src/content/docs/management/index-management.mdx
@@ -423,6 +423,19 @@ const results = await client.search({
 
 ## Next Steps
 
-- Learn about [Data Operations](./data-operations-insert)
-- Explore [Search Operations](./data-operations-query)
-- Check out [Best Practices](./best-practices)
+- Learn about [Data Operations](/milvus-sdk-node/operations/data-operations-insert)
+- Explore [Search Operations](/milvus-sdk-node/operations/data-operations-query)
+- Check out [Best Practices](/milvus-sdk-node/advanced/best-practices)
+
+## Additional index enums in SDK 3.0.5
+
+| Enum                 | Purpose                                                         |
+| -------------------- | --------------------------------------------------------------- |
+| `IndexType.HNSW_SQ`  | HNSW with scalar quantization                                   |
+| `IndexType.HNSW_PQ`  | HNSW with product quantization                                  |
+| `IndexType.HNSW_PRQ` | HNSW with product residual quantization                         |
+| `IndexType.AISAQ`    | DiskANN variant with PQ codes stored with the graph             |
+| `IndexType.NGRAM`    | N-gram scalar index for VarChar / JSON paths, accelerating LIKE |
+| `IndexType.FMINDEX`  | FM-index for VarChar pattern matching                           |
+
+Use these constants as `createIndex({ index_type: IndexType.HNSW_SQ, ... })` values. The enum additions do not enable an index on older servers; consult your server's supported index types and parameters. Legacy enum members remain for compatibility and do not guarantee current server support.

--- a/docs/src/content/docs/management/partition-management.mdx
+++ b/docs/src/content/docs/management/partition-management.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Partition Management"
+title: 'Partition Management'
 ---
 
 Partitions allow you to organize data within a collection for better performance and management. This guide covers all partition operations.
@@ -109,7 +109,9 @@ await client.insert({
   partition_name: 'partition_1',
   data: [
     {
-      vector: [/* ... */],
+      vector: [
+        /* ... */
+      ],
       text: 'data for partition 1',
     },
   ],
@@ -136,7 +138,9 @@ Search within specific partitions:
 ```javascript
 const results = await client.search({
   collection_name: 'my_collection',
-  data: [/* vector */],
+  data: [
+    /* vector */
+  ],
   partition_names: ['partition_1', 'partition_2'],
   limit: 10,
 });
@@ -150,14 +154,18 @@ Every collection has a default partition named `_default`. Data inserted without
 // Data goes to _default partition
 await client.insert({
   collection_name: 'my_collection',
-  data: [/* ... */],
+  data: [
+    /* ... */
+  ],
 });
 
 // Explicitly specify partition
 await client.insert({
   collection_name: 'my_collection',
   partition_name: 'partition_1',
-  data: [/* ... */],
+  data: [
+    /* ... */
+  ],
 });
 ```
 
@@ -172,5 +180,5 @@ await client.insert({
 ## Next Steps
 
 - Learn about [Collection Management](./collection-management)
-- Explore [Data Operations](./data-operations-insert)
-- Check out [Best Practices](./best-practices)
+- Explore [Data Operations](/milvus-sdk-node/operations/data-operations-insert)
+- Check out [Best Practices](/milvus-sdk-node/advanced/best-practices)

--- a/docs/src/content/docs/management/resource-management.mdx
+++ b/docs/src/content/docs/management/resource-management.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Resource Management"
+title: 'Resource Management'
 ---
 
 This guide covers resource group management and node/replica operations.
@@ -163,4 +163,4 @@ console.log('Nodes:', info.resource_group.nodes);
 ## Next Steps
 
 - Learn about [Collection Management](./collection-management)
-- Explore [Best Practices](./best-practices)
+- Explore [Best Practices](/milvus-sdk-node/advanced/best-practices)

--- a/docs/src/content/docs/management/user-role-management.mdx
+++ b/docs/src/content/docs/management/user-role-management.mdx
@@ -1,5 +1,5 @@
 ---
-title: "User & Role Management"
+title: 'User & Role Management'
 ---
 
 This guide covers user and role management, including authentication, authorization, and RBAC operations.
@@ -329,6 +329,7 @@ console.log('Dropped roles:', results);
 ## Privilege Objects
 
 Supported privilege objects:
+
 - `Collection`
 - `Partition`
 - `Index`
@@ -338,6 +339,7 @@ Supported privilege objects:
 ## Privilege Names
 
 Common privilege names:
+
 - `Create`
 - `Drop`
 - `Describe`
@@ -362,5 +364,5 @@ Common privilege names:
 
 ## Next Steps
 
-- Learn about [Client Configuration](./client-configuration)
-- Explore [Best Practices](./best-practices)
+- Learn about [Client Configuration](/milvus-sdk-node/core-concepts/client-configuration)
+- Explore [Best Practices](/milvus-sdk-node/advanced/best-practices)

--- a/docs/src/content/docs/operations/data-management.mdx
+++ b/docs/src/content/docs/operations/data-management.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Data Management"
+title: 'Data Management'
 ---
 
 This guide covers data management operations including flushing, compaction, bulk import, and segment management.
@@ -156,7 +156,7 @@ const tasks = await client.listImportTasks({
   collection_name: 'my_collection',
 });
 
-tasks.tasks.forEach(task => {
+tasks.tasks.forEach((task) => {
   console.log('Task ID:', task.taskID);
   console.log('State:', task.state);
   console.log('Progress:', task.progress);
@@ -187,7 +187,7 @@ const info = await client.getQuerySegmentInfo({
   dbName: 'default',
 });
 
-info.infos.forEach(segment => {
+info.infos.forEach((segment) => {
   console.log('Segment ID:', segment.segmentID);
   console.log('State:', segment.state);
   console.log('Level:', segment.level);
@@ -206,7 +206,7 @@ const info = await client.getPersistentSegmentInfo({
   dbName: 'default',
 });
 
-info.infos.forEach(segment => {
+info.infos.forEach((segment) => {
   console.log('Segment ID:', segment.segmentID);
   console.log('State:', segment.state);
   console.log('Level:', segment.level);
@@ -237,5 +237,5 @@ console.log('Metrics:', metrics);
 
 ## Next Steps
 
-- Learn about [Collection Management](./collection-management)
-- Explore [Best Practices](./best-practices)
+- Learn about [Collection Management](/milvus-sdk-node/management/collection-management)
+- Explore [Best Practices](/milvus-sdk-node/advanced/best-practices)

--- a/docs/src/content/docs/operations/data-operations-delete.mdx
+++ b/docs/src/content/docs/operations/data-operations-delete.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Data Operations - Delete"
+title: 'Data Operations - Delete'
 ---
 
 This guide covers deleting data from Milvus collections.
@@ -91,33 +91,33 @@ Use the same filter expression syntax as queries:
 ### Comparison Operators
 
 ```javascript
-'age > 25'
-'age >= 25'
-'age < 25'
-'age <= 25'
-'age == 25'
-'age != 25'
+'age > 25';
+'age >= 25';
+'age < 25';
+'age <= 25';
+'age == 25';
+'age != 25';
 ```
 
 ### Logical Operators
 
 ```javascript
-'age > 25 AND category == "tech"'
-'age > 25 OR age < 18'
-'NOT (age > 25)'
+'age > 25 AND category == "tech"';
+'age > 25 OR age < 18';
+'NOT (age > 25)';
 ```
 
 ### In Operator
 
 ```javascript
-'id in [1, 2, 3, 4, 5]'
-'category in ["old", "deprecated"]'
+'id in [1, 2, 3, 4, 5]';
+'category in ["old", "deprecated"]';
 ```
 
 ### String Operations
 
 ```javascript
-'text like "%deprecated%"'
+'text like "%deprecated%"';
 ```
 
 ## Batch Deletion
@@ -126,7 +126,9 @@ Delete large numbers of entities efficiently:
 
 ```javascript
 // Delete by IDs in batches
-const idsToDelete = [/* large array of IDs */];
+const idsToDelete = [
+  /* large array of IDs */
+];
 const batchSize = 1000;
 
 for (let i = 0; i < idsToDelete.length; i += batchSize) {
@@ -227,4 +229,4 @@ console.log('Remaining entities:', count.data);
 
 - Learn about [Data Management](./data-management)
 - Explore [Query Operations](./data-operations-query)
-- Check out [Best Practices](./best-practices)
+- Check out [Best Practices](/milvus-sdk-node/advanced/best-practices)

--- a/docs/src/content/docs/operations/data-operations-query.mdx
+++ b/docs/src/content/docs/operations/data-operations-query.mdx
@@ -605,4 +605,4 @@ console.log('Search results:', searchResults.results);
 
 - Learn about [Delete Operations](./data-operations-delete)
 - Explore [Data Management](./data-management)
-- Check out [Best Practices](./best-practices)
+- Check out [Best Practices](/milvus-sdk-node/advanced/best-practices)

--- a/docs/src/content/docs/operations/database-operations.mdx
+++ b/docs/src/content/docs/operations/database-operations.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Database Operations"
+title: 'Database Operations'
 ---
 
 Milvus supports multiple databases, allowing you to organize collections into logical groups. This guide covers all database operations.
@@ -140,5 +140,5 @@ Each database is isolated:
 
 ## Next Steps
 
-- Learn about [Collection Management](./collection-management)
-- Explore [User & Role Management](./user-role-management)
+- Learn about [Collection Management](/milvus-sdk-node/management/collection-management)
+- Explore [User & Role Management](/milvus-sdk-node/management/user-role-management)

--- a/docs/src/content/docs/reference/contributing.mdx
+++ b/docs/src/content/docs/reference/contributing.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Contributing"
+title: 'Contributing'
 ---
 
 Thank you for your interest in contributing to the Milvus Node.js SDK!
@@ -59,6 +59,7 @@ yarn coverage
 ### Test Structure
 
 Tests are located in the `test/` directory:
+
 - `test/grpc/`: gRPC client tests
 - `test/http/`: HTTP client tests
 - `test/utils/`: Utility tests
@@ -186,7 +187,7 @@ describe('createCollection', () => {
       collection_name: 'test_collection',
       fields: schema,
     });
-    
+
     expect(result.error_code).toBe('Success');
   });
 });
@@ -197,6 +198,7 @@ describe('createCollection', () => {
 ### Update Documentation
 
 When adding features:
+
 1. Update relevant documentation files
 2. Add code examples
 3. Update API reference if needed
@@ -212,6 +214,7 @@ When adding features:
 ### Bug Reports
 
 Include:
+
 - SDK version
 - Node.js version
 - Steps to reproduce
@@ -221,6 +224,7 @@ Include:
 ### Feature Requests
 
 Include:
+
 - Use case description
 - Proposed solution
 - Benefits
@@ -240,3 +244,17 @@ Please follow the [Code of Conduct](https://github.com/milvus-io/milvus-sdk-node
 - Read [Best Practices](../advanced/best-practices)
 - Check [API Reference](../api-reference)
 - Explore [Examples & Tutorials](../getting-started/examples-tutorials)
+
+## Build and preview the documentation site
+
+Install the documentation dependencies separately from SDK dependencies:
+
+```bash
+yarn --cwd docs install --frozen-lockfile
+npm run doc
+npm run doc:dev
+```
+
+The site uses Astro/Starlight and writes production output to `docs/out/`. Edit MDX under `docs/src/content/docs/`; `npm run doc` preserves these source files. For production preview, run `npm --prefix docs run preview` after building. Use Node.js 22.12.0 or newer, as required by the installed Astro version; the documentation toolchain can require a newer runtime than the SDK.
+
+When releasing, compare the published tag with the last documented version, update guides and API reference, add release notes, and synchronize README compatibility and `llms.txt`. Verify example imports against package exports and check site links after building.

--- a/docs/src/content/docs/reference/migration-compatibility.mdx
+++ b/docs/src/content/docs/reference/migration-compatibility.mdx
@@ -11,7 +11,7 @@ This guide covers version compatibility, migration paths, and breaking changes.
 | Milvus version |   Node SDK version   | Installation                               |
 | :------------: | :------------------: | :----------------------------------------- |
 |    v3.0.0+     | v3.0.0+ / **latest** | `yarn add @zilliz/milvus2-sdk-node@latest` |
-|    v2.6.0+     |        v2.6.x        | `yarn add @zilliz/milvus2-sdk-node@2.6.9`  |
+|    v2.6.0+     |        v2.6.x        | `yarn add @zilliz/milvus2-sdk-node@2.6`    |
 |    v2.5.0+     |        v2.5.x        | `yarn add @zilliz/milvus2-sdk-node@2.5.12` |
 |    v2.4.0+     |        v2.4.9        | `yarn add @zilliz/milvus2-sdk-node@2.4.9`  |
 |    v2.3.0+     |        v2.3.5        | `yarn add @zilliz/milvus2-sdk-node@2.3.5`  |
@@ -20,7 +20,7 @@ This guide covers version compatibility, migration paths, and breaking changes.
 ### Node.js Compatibility
 
 - **Minimum**: Node.js 18+
-- **Recommended**: Node.js 20+ (LTS)
+- **Recommended**: A currently supported Node.js LTS release
 
 ## Checking Versions
 
@@ -57,7 +57,7 @@ const info = await client.getMetric({
 ```bash
 yarn add @zilliz/milvus2-sdk-node@latest
 # or specific version
-yarn add @zilliz/milvus2-sdk-node@2.6.9
+yarn add @zilliz/milvus2-sdk-node@2.6
 ```
 
 3. **Test Thoroughly**:
@@ -94,7 +94,11 @@ The following SDK features require a Milvus 3.0 server. They are marked with the
 | MinHash function and index     | `FunctionType.MINHASH`, `IndexType.MINHASH_LSH`, `MetricType.MHJACCARD`, atomic function-field/index creation                                                                                                                 | [Collection Management](../management/collection-management#add-a-function-output-field-and-index), [Index Management](../management/index-management#minhash_lsh) |
 | Analyzer file resources        | `addFileResource()`, `listFileResources()`, `removeFileResource()`                                                                                                                                                            | [Full-Text Search](../advanced/full-text-search#custom-dictionary-files), [System Operations](../api-reference/system#file-resources)                              |
 
-Not all Milvus 3.0 proto additions are public Node SDK APIs yet. Client telemetry, WAL dump/data-salvage APIs, `ComputePhraseMatchSlop`, `BatchUpdateManifest`, and full molecular data helpers are currently proto-level/internal surfaces unless explicitly exposed in a later SDK release.
+Not all Milvus 3.0 proto additions are public Node SDK APIs yet. WAL dump/data-salvage APIs, `ComputePhraseMatchSlop`, `BatchUpdateManifest`, and full molecular data helpers are currently proto-level/internal surfaces unless explicitly exposed in a later SDK release.
+
+## SDK 3.0.4–3.0.5 additions
+
+See [Release Notes](/milvus-sdk-node/reference/release-notes) for Text fields, asynchronous function-field backfill, membership-filter builders, additional index enums and public client telemetry.
 
 ## Breaking Changes
 
@@ -164,7 +168,7 @@ yarn add @zilliz/milvus2-sdk-node@latest
 1. Update SDK:
 
 ```bash
-yarn add @zilliz/milvus2-sdk-node@latest
+yarn add @zilliz/milvus2-sdk-node@2.6
 ```
 
 2. Update code (if needed):
@@ -177,7 +181,7 @@ yarn add @zilliz/milvus2-sdk-node@latest
 1. Update SDK:
 
 ```bash
-yarn add @zilliz/milvus2-sdk-node@latest
+yarn add @zilliz/milvus2-sdk-node@2.6
 ```
 
 2. Test new features:

--- a/docs/src/content/docs/reference/release-notes.mdx
+++ b/docs/src/content/docs/reference/release-notes.mdx
@@ -1,0 +1,22 @@
+---
+title: 'Release Notes'
+---
+
+These docs cover **SDK 3.0.5**, published on **August 26, 2026**. Both the npm `latest` tag and the [GitHub release](https://github.com/milvus-io/milvus-sdk-node/releases/tag/v3.0.5) pointed to this version when checked on September 8, 2026. Server feature availability is separate from SDK version; see [Migration & Compatibility](/milvus-sdk-node/reference/migration-compatibility).
+
+## 3.0.5
+
+- [Bloom and Roaring filters](/milvus-sdk-node/advanced/membership-filters): build binary membership parameters locally with `buildBloomFilter`, `BloomFilterBuilder`, `buildRoaringBitmap` and `RoaringBitmapBuilder`.
+- [Client telemetry](/milvus-sdk-node/advanced/client-telemetry): configure collection and heartbeat reporting, inspect effective settings, and handle server commands. Telemetry is enabled by default.
+- [Index enums](/milvus-sdk-node/management/index-management#additional-index-enums-in-sdk-305): `HNSW_SQ`, `HNSW_PQ`, `HNSW_PRQ`, `AISAQ`, `NGRAM` and `FMINDEX` now have `IndexType` constants. This exposes names already accepted as strings; availability depends on the server.
+- Dependency updates: Parquet writer dependency updated to 1.8.9; js-yaml updated. Text embedding tests switched provider; this does not change the public SDK API.
+
+[Full 3.0.5 changelog](https://github.com/milvus-io/milvus-sdk-node/compare/v3.0.4...v3.0.5)
+
+## 3.0.4 additions covered here
+
+- [Text fields](/milvus-sdk-node/core-concepts/data-types-schemas#text): `DataType.Text`, without VarChar's `max_length` setting; requires StorageV3.
+- [Function-field backfill](/milvus-sdk-node/management/collection-management#function-field-backfill): adding a BM25 or MinHash output field starts asynchronous server backfill; monitor schema and index readiness.
+- External collection field additions preserve `external_field` mappings.
+
+[Full 3.0.4 changelog](https://github.com/milvus-io/milvus-sdk-node/compare/v3.0.3...v3.0.4)

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # @zilliz/milvus2-sdk-node
 
-> Official Node.js/TypeScript SDK for Milvus and Zilliz Cloud vector databases. Use it for semantic search, RAG retrieval, recommendation, hybrid dense+sparse retrieval, metadata filtering, and collection/index/user/resource management. Package version in this repo: `2.6.14`. Requires Node.js 18+.
+> Official Node.js/TypeScript SDK for Milvus and Zilliz Cloud vector databases. Use it for semantic search, RAG retrieval, recommendation, hybrid dense+sparse retrieval, metadata filtering, and collection/index/user/resource management. Latest documented SDK release: `3.0.5`. Requires Node.js 18+.
 
 ## Install
 
@@ -603,4 +603,15 @@ try {
 
 ## Full API Reference
 
-See `README.md` for current method signatures and examples. Source lives under `milvus/`; generated docs live under `docs/`.
+See `README.md` for current method signatures and examples. Source lives under `milvus/`; handwritten Astro/Starlight documentation lives under `docs/src/content/docs/`.
+
+
+## SDK 3.0.4–3.0.5
+
+- `buildBloomFilter(members, fpr = 0.005)` returns Uint8Array for `filter: 'bloom_match(field, {blob})', exprValues: { blob }`. Members must all be integers (`number`/`bigint`) or strings; decimal strings are UTF-8, not integer IDs. False positives are possible; this is not an authorization filter. FPR range: 0.0001–0.05.
+- `buildRoaringBitmap(members)` returns Uint8Array for `roaring_match(field, {blob})` with the same exprValues shape. Exact integer membership accepts safe numbers, bigint or decimal int64 strings. Reuse blobs; do not JSON/base64 encode them. Server expression support is required. Incremental builders: `BloomFilterBuilder`, `RoaringBitmapBuilder`.
+- `ClientConfig.telemetry` defaults to `{ enabled: true, heartbeatIntervalMs: 10000, samplingRate: 1, errorMaxCount: 100 }`. Set `enabled: false` at construction to prevent startup. `client.getTelemetry().getConfig()` inspects effective settings; `closeConnection()` stops heartbeats. Telemetry is separate from `trace` and sends metrics/client metadata to the connected server.
+- `DataType.Text = 25` requires StorageV3, has no `max_length`, and cannot be a primary/partition key or array element. Values are JavaScript strings.
+- `addFunctionField` backfills existing sealed segments asynchronously. Check `getCollectionStatistics().data.schema_version_consistent_segments` against `schema_version_total_segments`, then bound index readiness. Success of the schema RPC does not mean completion. `do_physical_backfill` is not a function-field option.
+- New index constants: `HNSW_SQ`, `HNSW_PQ`, `HNSW_PRQ`, `AISAQ`, `NGRAM`, `FMINDEX`; server availability varies.
+- Release details: https://milvus-io.github.io/milvus-sdk-node/reference/release-notes

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
     "coverage": "NODE_ENV=dev jest --coverage=true --config jest.config.js --no-cache",
     "build-test": " yarn build && NODE_ENV=dev jest test/build/Collection.spec.ts --testPathIgnorePatterns=none",
     "example": "npx ts-node",
-    "doc": "rm -rf docs && npx typedoc",
+    "doc": "npm --prefix docs run build",
     "doc-json": "npx typedoc milvus --json",
-    "proto:json": "yarn test test/utils/ProtoJson.spec.ts"
+    "proto:json": "yarn test test/utils/ProtoJson.spec.ts",
+    "doc:dev": "npm --prefix docs run dev"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.14.4",


### PR DESCRIPTION
The published SDK is 3.0.5, but the documentation omits its membership-filter helpers, telemetry and new index constants, as well as 3.0.4 Text fields and function-field backfill. This update adds guides and release notes, expands the API reference, and synchronizes README and llms.txt with the released behavior and server requirements.

It also fixes broken internal links, keeps 2.6 upgrade commands on the 2.6 release line, improves TLS and quick-start examples, and replaces the destructive `npm run doc` command with the Astro site build. Contributor instructions now cover previewing and maintaining the documentation.

Validation:
- Documentation build passed: 49 pages.
- Built-site internal page and anchor link checks passed.
- Eight new TypeScript snippets type-checked against SDK source.
- Five relevant unit suites passed: 108 tests covering Bloom/Roaring helpers, collection schema operations and telemetry.
- Prettier and `git diff --check` passed.
- Live Milvus integration tests were not run.
